### PR TITLE
feat: establish bb-mate workspace

### DIFF
--- a/.agents/plans/2026-08-06-bootstrap-bb-mate.md
+++ b/.agents/plans/2026-08-06-bootstrap-bb-mate.md
@@ -12,7 +12,7 @@ Create one Bun monorepo for the browser workbench and independently publishable 
 - `apps/workbench` is a browser-only fake-state studio and does not require a running bb app.
 - `plugins/*` packages each own a bb plugin manifest and release version.
 - Shared packages will be introduced only when real duplication appears.
-- The existing `galligan/bb-plugins` repository remains untouched until explicitly archived or deleted.
+- The empty `galligan/bb-plugins` repository was deleted after explicit approval; its local checkout was moved to the macOS Trash.
 
 ## Acceptance checks
 

--- a/.agents/plans/2026-08-06-bootstrap-bb-mate.md
+++ b/.agents/plans/2026-08-06-bootstrap-bb-mate.md
@@ -1,0 +1,23 @@
+# Bootstrap BB Mate
+
+Status: complete
+
+## Outcome
+
+Create one Bun monorepo for the browser workbench and independently publishable bb plugins while keeping the upstream bb checkout separate.
+
+## Decisions
+
+- The repository and product umbrella are named `bb-mate`; the visible workbench name is “BB Mate.”
+- `apps/workbench` is a browser-only fake-state studio and does not require a running bb app.
+- `plugins/*` packages each own a bb plugin manifest and release version.
+- Shared packages will be introduced only when real duplication appears.
+- The existing `galligan/bb-plugins` repository remains untouched until explicitly archived or deleted.
+
+## Acceptance checks
+
+- `bun install`
+- `bun run check`
+- `bun run test`
+- `bun run build`
+- GitHub repository remains private and resolves as `galligan/bb-mate`.

--- a/.agents/plans/2026-08-06-dispatch-bb-integration.md
+++ b/.agents/plans/2026-08-06-dispatch-bb-integration.md
@@ -1,0 +1,135 @@
+# Dispatch / bb Integration
+
+Status: research — no implementation committed
+
+## Outcome
+
+Decide how bb and [dispatch](https://github.com/outfitter-dev/dispatch) should relate for
+cross-agent communication, given that both already drive the Codex App Server and that
+dispatch's Claude control path is its weakest seam.
+
+This plan records findings and a proposed experiment. It does not commit to building
+anything. Dispatch-side changes are tracked separately; this plan scopes the bb side.
+
+## Findings (verified 2026-08-06)
+
+Verified by process inspection on this machine. Re-check with
+`pgrep -fl "app-server"` and tracing parents with `ps -o pid,ppid,command`.
+
+- **bb spawns `codex app-server` directly.** Two instances (PIDs 33056, 36427) were
+  children of bb's host-daemon (PID 32633). bb is on the app-server protocol, not
+  wrapping the Codex CLI. bb's Codex threads are therefore real app-server threads with
+  thread IDs in the shared `~/.codex` store.
+- **bb spawns per client, not per daemon.** Two concurrent app-servers under one bb
+  daemon. Dispatch ADR-0002 runs exactly one app-server with a router demuxing by
+  `threadId`, and rejects the alternative by name: _"Spawn-per-client (like the SDK) —
+  no shared event bus; can't do cross-lane triggers cleanly."_
+- **Multi-writer over shared `~/.codex` is already the de facto state.** bb's two, plus
+  ChatGPT.app's own two (PIDs 32164, 50968), plus a `codex app-server proxy` over SSH to
+  `mini.local`. Dispatch ADR-0005 left write rungs locked because this case was
+  unverified; reality has outrun the verification, not disproven it.
+- **bb launches Claude Code as a non-interactive Agent SDK session** —
+  `--output-format stream-json --input-format stream-json`, `CLAUDE_CODE_ENTRYPOINT=sdk-cli`,
+  no TTY. bb owns the pipe exclusively.
+- **bb has a first-class mention API**, `bb.ui.registerMentionProvider()`. Prior art:
+  `bb-plugin-linear` registers Linear issue mentions on `#` with a search cache and a
+  usage store for recency ranking.
+
+## Analysis
+
+### The recursion tension mostly dissolves for Codex
+
+Lane 1 (bb as dispatch's backend) makes dispatch depend on bb. Lane 2 (a bb plugin using
+dispatch) makes bb depend on dispatch. Doing both naively yields `bb → dispatch → bb`.
+
+Because bb's Codex threads are app-server threads in the shared store, dispatch does not
+need to reach them _through_ bb. It can discover and attach them the way it attaches
+desktop Codex threads. The topology becomes `dispatch → app-server ← bb`, meeting at the
+store rather than through each other.
+
+### Claude is the case that justifies a backend selector
+
+The two Claude control paths are different capability classes, not competing
+implementations of one thing:
+
+- **bb** gives _exclusive ownership_. ADR-0026 found persistent stream-JSON stays coherent
+  "while it remained the exclusive owner" — which is bb's model by construction. Reliable
+  for owned/headless lanes. Retires the zmx hardening dependency ADR-0026 flagged
+  (raw send unacknowledged, can exit zero after loss).
+- **zmx cockpit / Agent View** gives _human-coexistent_ control — reaching a Claude session
+  a person is also driving. bb cannot do this; its model forbids a second client.
+
+A per-provider backend selector encodes that distinction rather than hedging on it.
+
+### Scoping bb-as-backend to Claude
+
+Extending lane 1 to Codex would make dispatch inherit spawn-per-client, losing the shared
+event bus that cross-lane triggers depend on. Keep Codex native to dispatch.
+
+## Candidate lanes
+
+1. **bb as a per-provider backend in dispatch.** Best fit for _owned_ lanes (ADR-0005's
+   full-read/write tier — no external writer, matching bb's exclusive ownership).
+   Gaps versus dispatch's Codex path: no `rollback`, `compact`, or `inject_items`; goals
+   only partial (`bb thread clear-goal`, Codex-only); bb's CLI is wait/poll-shaped
+   (`bb thread wait --status|--event`) rather than an event stream, though the plugin SDK
+   has realtime and could bridge it. Adds a dependency on the bb server and stacks bb's
+   per-machine `maxPermissionMode` under dispatch's lane authority ladder.
+2. **A bb plugin using dispatch.** Most independent — no dispatch changes; shells out to
+   `dispatch --json` or speaks the control socket. Buys bb what it structurally lacks:
+   discover/attach desktop Codex threads, rollback, goals, inject. Constrained by
+   ADR-0005: attached lanes are read-mostly by default, so realistically observation of
+   external agents plus writes on dispatch-owned lanes.
+3. **`@`-mentioning threads across both namespaces.** Best supported of the three, but a
+   resolver over whatever backends exist — a veneer until something underneath sees both.
+   Dispatch's ref scheme is conveniently ready: ADR-0019's `<source><payload4><mixer>`
+   already varies `source` by provider (`0` = Codex) and separates stable identity from
+   mutable `@handles`. ADR-0013's `@mini:builder` gives the cross-machine form.
+
+Dispatch's inbox/queueing model is dispatch-side and independent of all three.
+
+## Decisions
+
+- Direction for Codex is **attach, not delegate** — but gated on the multi-writer question
+  below, not assumed.
+- bb-as-backend stays **scoped to Claude**, to avoid dispatch inheriting spawn-per-client.
+- A Claude backend selector is warranted on capability grounds (exclusive vs. coexistent),
+  independent of how the Codex question resolves.
+
+## Next action: run the ADR-0005 spike with bb as the second writer
+
+ADR-0005 left write rungs locked partly because the spike could not cleanly distinguish
+"safe" from "racy" (its assumption #3). The second writer was desktop Codex — a GUI that
+cannot be scripted or stepped. bb's second writer is scriptable (`bb thread tell`,
+`bb thread wait --event`, `bb thread show --json`), which makes the experiment tractable.
+
+Run in ADR-0005's ladder order:
+
+1. **Observation only** (tests assumption #2). bb owns a Codex thread and writes turns; a
+   second app-server connection resumes it read-only. Does event fan-out reach the
+   observer live? Does the observer's `thread/items/list` match `bb thread log`?
+   ADR-0005's Phase-1 spike found cross-process observation was _not_ live — re-test now
+   that the writer is instrumentable.
+2. **Interleaved writes** (idle-only-write rung). Alternate turns bb → observer → bb.
+   After each, read full history from both sides and from the persisted rollout in
+   `~/.codex`. Failure signature to watch for is ADR-0026's Claude result: both turns
+   report success but continue from divergent histories, and one side's turn is absent
+   from the other's later reads.
+3. **Concurrent writes** (full-write rung). Both mid-turn simultaneously. Expect breakage;
+   the value is knowing the failure mode.
+
+## Acceptance checks
+
+- Spike step 1 produces a documented yes/no on live cross-process observation.
+- Spike step 2 produces a documented yes/no on history divergence under interleaved writes.
+- Result either clears ADR-0005's locked rungs or documents why they stay locked.
+- No bb or dispatch code changes are made before the spike reports.
+
+## Open questions
+
+- Does bb spawn one app-server per thread, per project, or per environment? Two were
+  observed; the partition was not determined.
+- Can a bb plugin subscribe to app-server events directly, or must it poll bb's CLI
+  surface? Determines whether lane 1 can supply dispatch with a real event stream.
+- How do the two identity models reconcile — dispatch refs/handles versus bb thread
+  IDs/names — and which owns naming when a thread is visible in both?

--- a/.agents/plans/2026-08-06-exact-bb-component-parity-investigation.md
+++ b/.agents/plans/2026-08-06-exact-bb-component-parity-investigation.md
@@ -1,0 +1,56 @@
+# Exact bb component parity investigation
+
+## Goal
+
+Determine the smallest supported way for BB Mate prototypes and future plugins to achieve exact visual parity with bb's production sidebar without coupling the standalone workbench to private application state.
+
+## Success criteria
+
+- Identify which production sidebar components, styles, tokens, and assets are reusable today.
+- Document what `@bb/plugin-sdk/app` and the live plugin runtime expose to frontend plugins.
+- Compare the installed bb 0.35.1 bundle with the canonical source checkout where useful.
+- Recommend one thin, testable integration path before any UI implementation.
+
+## Investigation
+
+- [x] Trace the production sidebar component and style dependency graph.
+- [x] Inspect the public plugin frontend API, UI kit, slots, and host-rendered surfaces.
+- [x] Inspect installed plugin metadata and bundled desktop resources read-only.
+- [x] Evaluate direct reuse, upstream extraction, and host-rendered/plugin-native alternatives.
+- [ ] Verify the preferred path with an exact-component browser fixture before changing BB Mate UI.
+
+## Findings
+
+- bb 0.35.1 exposes `app.slots.experimental_threadList`, an exclusive plugin
+  slot that replaces only the scrolling thread list. The host retains the real
+  New Thread button, search, navigation rows, footer, theme, routing, dialogs,
+  and split behavior.
+- The slot reads the host's live sidebar cache and exposes normalized project,
+  thread, environment, host, activity, indicator, pull-request, and split data
+  plus host-owned actions.
+- `@bb/plugin-sdk/app` is hooks-only. The former host UI kit was removed; normal
+  plugins vendor version-matched components from bb's shadcn registry. The
+  registry includes exact primitives, icons, motion, menus, and coarse-pointer
+  sizing, but not bb's production `ProjectList`, `ProjectRow`, `ThreadRow`, or
+  status glyph component.
+- The bundled `t3sidebar` reference plugin uses the experimental slot and was
+  built with bb 0.35.1 / plugin SDK 0.4.1. Its source demonstrates the intended
+  adapter and styling approach, but it draws its own rows and indicators.
+- The desktop bundle contains the exact compiled app CSS and JavaScript, but
+  these hashed artifacts are not a supported component module boundary. Treat
+  them as a version/parity oracle, not a dependency to scrape or hot-link.
+- Preferred path: share one host-neutral sidebar list view between
+  `apps/workbench` fixtures and a thin BB Mate plugin adapter using
+  `experimental_threadList`. Let the real bb host render all surrounding
+  sidebar chrome, and validate the shared view in both the workbench and the
+  installed app.
+- Browser-oracle validation is pending: the upstream Ladle command currently
+  fails because `/Users/mg/Developer/bb/bb` has no installed `node_modules`.
+  No dependencies were installed and the upstream checkout was not modified.
+
+## Boundaries
+
+- Do not edit `/Users/mg/Developer/bb/bb`.
+- Do not modify the current BB Mate workbench UI during this investigation.
+- Do not install, reload, enable, disable, or publish plugins.
+- Preserve all unrelated worktree changes.

--- a/.agents/plans/2026-08-06-linear-plugin-migration.md
+++ b/.agents/plans/2026-08-06-linear-plugin-migration.md
@@ -1,0 +1,41 @@
+# Linear plugin migration
+
+## Outcome
+
+Move the existing `bb-plugin-linear` working tree from Grid into BB Mate as
+`plugins/linear`, preserving its `bb-plugin-linear` package name, `linear`
+plugin id, saved settings, cache, and mention-usage state.
+
+## Steps
+
+- [x] Confirm BB Mate's plugin workspace and publishing conventions.
+- [x] Move the exact source working tree, including current tracked and
+      untracked changes, into `plugins/linear`.
+- [x] Align package scripts, test imports, and lockfiles with the Bun
+      workspace without changing plugin behavior.
+- [x] Keep the currently installed path functional without removing the
+      plugin, because `bb plugin remove` deletes saved settings and secrets.
+- [x] Run the plugin tests, typecheck, build, live reload, and BB Mate's
+      repository checks.
+- [x] Inspect the final Git state in both repositories and document the
+      compatibility path.
+
+## Verification
+
+- `bun run test`: 23 tests passed across the workbench and Linear plugin.
+- `bun run check`: every workspace typecheck passed.
+- `bun run build`: the workbench and Linear plugin built successfully.
+- Targeted Prettier check: all migration-owned files passed.
+- `bb plugin reload linear`: the installed plugin returned to `running` with
+  its original plugin id and saved configuration.
+
+The repository-wide format check still reports the unrelated, pre-existing
+untracked plan `.agents/plans/2026-08-06-dispatch-bb-integration.md`. This
+migration deliberately leaves that file untouched.
+
+## Safety note
+
+The installed bb version has no public command to retarget an installed path
+plugin. Removing and reinstalling would delete the saved Linear API key. The
+migration therefore keeps a compatibility symlink at the old Grid path while
+the canonical files live in BB Mate.

--- a/.agents/plans/2026-08-06-workbench-overlay-and-runtime-modes.md
+++ b/.agents/plans/2026-08-06-workbench-overlay-and-runtime-modes.md
@@ -1,0 +1,90 @@
+# BB-faithful workbench and Mate overlay
+
+## Goal
+
+Make the workbench feel like bb itself, with BB Mate controls living in a
+small dev-tool overlay instead of a second application shell. Keep the view
+portable between deterministic fixtures and the public bb plugin runtime.
+
+## Success criteria
+
+- The preview occupies the full viewport and uses bb's measured sidebar
+  dimensions, typography, color tokens, icon family, and row rhythm.
+- Workbench-only controls live in a dark rounded overlay that minimizes to one
+  lower-right FAB.
+- Fixture selection remains deterministic and keyboard accessible.
+- The UI names live bb as a separate adapter-backed source; it does not pretend
+  a cross-origin fetch is live plugin state.
+- The implementation has a documented upstream-update path based on public bb
+  packages/registry artifacts and a visual oracle, not imports from `../bb`.
+
+## Design direction
+
+- **Subject:** a visual instrumentation harness for bb plugin authors.
+- **Palette:** bb surface `#fbfbfb`, bb foreground `#525252`; Mate coal
+  `#121418`, raised graphite `#1b1e24`, steel border `#303640`, paper text
+  `#f5f7fa`, signal blue `#8cb4ff`.
+- **Type:** Inter Variable for bb and HUD controls; ui-monospace for adapter and
+  version/status details.
+- **Layout:** bb owns the viewport. Mate floats above it in the lower-right.
+- **Signature:** the compact source light and thin signal-blue edge turn the
+  overlay into a small instrumentation module rather than another settings
+  panel.
+
+```text
++---------------- bb interface -----------------------------+
+| sidebar |                                       composer   |
+|         |                                                  |
+|         |                             +------------------+ |
+|         |                             | MATE  fixture  o | |
+|         |                             | source / state   | |
+|         |                             | scenario         | |
+|         |                             +------------------+ |
++------------------------------------------------------------+
+
+collapsed:                                             ( M )
+```
+
+## Adapter boundary
+
+```text
+deterministic scenarios -> SidebarView <- bb plugin SDK live adapter
+                                ^
+                           Mate overlay
+```
+
+- `apps/workbench` supplies the fixture adapter.
+- A plugin consumer supplies normalized data from
+  `experimental_useSidebarThreads` and related action hooks.
+- The standalone workbench must not fetch or iframe an authenticated Connect
+  client. Those origins and sessions are not a supported data contract.
+
+## Work
+
+- [x] Introduce the full-viewport bb-faithful shell.
+- [x] Add the fixture adapter and scenario switching.
+- [x] Initialize shadcn/Base UI for Mate-only controls and add the smallest
+      required primitives.
+- [x] Add the dark popover/FAB overlay.
+- [x] Verify typecheck, tests, build, and visual behavior through bb Connect.
+- [x] Document the upstream synchronization and live-adapter path.
+- [x] Reconcile composer and sidebar primitives against the current installed
+      bb source and a direct live-render comparison.
+
+## Verification
+
+- `bun --filter @bb-mate/workbench check`
+- `bun --filter @bb-mate/workbench test`
+- `bun --filter @bb-mate/workbench build`
+- Visual inspection at `https://galligan--5173.getbb.app/` at 1170×727
+- Direct geometry and screenshot comparison against `https://galligan.getbb.app/`
+  and the installed `/Applications/bb.app` client.
+- Verified the overlay minimizes to one FAB and the scenario select updates the
+  rendered project/thread fixture.
+
+## Boundaries
+
+- Do not edit `/Users/mg/Developer/bb/bb`.
+- Do not scrape or import hashed desktop application modules.
+- Do not install/reload a plugin or publish packages in this slice.
+- Preserve unrelated GitButler and Linear plugin worktree changes.

--- a/.agents/plans/2026-08-07-native-plugin-preview.md
+++ b/.agents/plans/2026-08-07-native-plugin-preview.md
@@ -16,8 +16,14 @@ dependency.
 - The frontend harness validates registration and hook behavior. It does not
   reproduce bb layout or CSS, so live bb remains the visual authority.
 - `@bb/plugin-sdk@0.4.1` is not currently available from the public npm
-  registry. The harness must therefore be capability-gated; BB Mate will not
-  copy it or import `../bb`.
+  registry. [get-bb/bb#1134](https://github.com/get-bb/bb/issues/1134) now
+  tracks the external publication gap. The harness must therefore be
+  capability-gated; BB Mate will not copy it or import `../bb`.
+- [get-bb/bb#1133](https://github.com/get-bb/bb/issues/1133) tracks the packaged
+  scaffold's missing development dependencies, and draft
+  [PR #1135](https://github.com/get-bb/bb/pull/1135) contains the upstream fix.
+  BB Mate will continue invoking native scaffolding rather than patching the
+  generated package itself.
 - Upstream PR #1107 is the intended declaration-sync path. BB Mate should
   report its availability, not create a competing type-sync mechanism.
 - Upstream PR #1109 is the supported sidebar-replacement reference. BB Mate
@@ -32,9 +38,8 @@ Two independent review passes completed before implementation:
 2. Plugin-author-DX review required an explicit capability matrix, clean-room
    validation, trusted-code disclosure, and native CLI output preservation.
 
-The separate upstream investigation confirmed the two remaining upstream
-gaps—scaffold install under `NODE_ENV=production` and missing SDK publication—
-and is handling their issues/PR independently.
+The separate upstream investigation opened #1133 and #1134 and prepared draft
+PR #1135. Their lifecycle remains upstream-owned and independent of this plan.
 
 ## Walking skeleton
 
@@ -62,7 +67,8 @@ and is handling their issues/PR independently.
 
 ## Follow-on after the walking skeleton
 
-When `@bb/plugin-sdk` is published, add a narrow harness adapter that imports
-the official testing subpaths and runs plugin-owned stories/tests. Expand the
-surface matrix only from the public `CapturedPluginApp` contract, and validate
-every visually exact result in live bb.
+When #1134 establishes a supported `@bb/plugin-sdk` distribution, add a narrow
+harness adapter that imports the official testing subpaths and runs
+plugin-owned stories/tests. Expand the surface matrix only from the public
+`CapturedPluginApp` contract, and validate every visually exact result in live
+bb.

--- a/.agents/plans/2026-08-07-native-plugin-preview.md
+++ b/.agents/plans/2026-08-07-native-plugin-preview.md
@@ -1,0 +1,68 @@
+# Native plugin preview walking skeleton
+
+## Goal
+
+Add the smallest useful plugin-authoring slice to BB Mate without duplicating
+bb's plugin runtime or making the sibling source checkout a workspace
+dependency.
+
+## Verified upstream boundary
+
+- bb owns plugin scaffolding, declarations, build, install, dev/reload, runtime,
+  and live host rendering.
+- `@bb/plugin-sdk/testing` and `@bb/plugin-sdk/testing/app` are the supported
+  behavioral harnesses. BB Mate will consume `createFakePluginHost`,
+  `loadPluginApp`, and `renderSlot` when the package is installable.
+- The frontend harness validates registration and hook behavior. It does not
+  reproduce bb layout or CSS, so live bb remains the visual authority.
+- `@bb/plugin-sdk@0.4.1` is not currently available from the public npm
+  registry. The harness must therefore be capability-gated; BB Mate will not
+  copy it or import `../bb`.
+- Upstream PR #1107 is the intended declaration-sync path. BB Mate should
+  report its availability, not create a competing type-sync mechanism.
+- Upstream PR #1109 is the supported sidebar-replacement reference. BB Mate
+  should link to or inspect the example once it lands, not fork its private UI.
+
+## Review record
+
+Two independent review passes completed before implementation:
+
+1. Upstream-overlap review narrowed BB Mate to discovery, fixtures,
+   inspection, orchestration, and live handoff.
+2. Plugin-author-DX review required an explicit capability matrix, clean-room
+   validation, trusted-code disclosure, and native CLI output preservation.
+
+The separate upstream investigation confirmed the two remaining upstream
+gaps—scaffold install under `NODE_ENV=production` and missing SDK publication—
+and is handling their issues/PR independently.
+
+## Walking skeleton
+
+- [x] Discover an explicit plugin directory from the workbench dev server.
+- [x] Inspect `package.json` plus native `dist/*.meta.json` without loading
+      plugin code.
+- [x] Show one compact Plugin Lab view with Fixture, Harness, and Live modes.
+- [x] Make Harness availability depend on resolving the official testing
+      package, with an actionable unavailable state.
+- [x] Use native `bb plugin list --json` and `bb plugin source --json` for live
+      installation/runtime status.
+- [x] Keep the current deterministic sidebar fixture as the first visual
+      surface and label it honestly as a fixture.
+- [x] Cover discovery and compatibility logic with focused tests.
+- [x] Verify the workbench build and the browser preview through bb Connect.
+
+## Explicit non-goals
+
+- No second plugin manifest, installer, compiler, registry, or fake SDK.
+- No automatic plugin code execution during discovery.
+- No content-script mounting in the workbench.
+- No dependency on `/Users/mg/Developer/bb/bb` or `galligan/bb` at runtime.
+- No SDK publication, plugin publication, upstream edit, or PR status/metadata
+  mutation.
+
+## Follow-on after the walking skeleton
+
+When `@bb/plugin-sdk` is published, add a narrow harness adapter that imports
+the official testing subpaths and runs plugin-owned stories/tests. Expand the
+surface matrix only from the public `CapturedPluginApp` contract, and validate
+every visually exact result in live bb.

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -1,0 +1,7 @@
+# Plans
+
+Use this directory for durable plans that another agent can resume without reconstructing the decision history.
+
+Name plans `YYYY-MM-DD-short-title.md`. Each plan should state the outcome, constraints, acceptance checks, current status, and decisions that changed during implementation.
+
+Completed plans remain useful as lightweight architecture records. Mark them complete rather than deleting them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: bun run format:check
+      - run: bun run check
+      - run: bun run test
+      - run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.DS_Store
+*.log
+.vite/
+coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+bun.lock
+dist/
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 bun.lock
 dist/
 node_modules/
+plugins/*/types/*.d.ts

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ BB Mate is the private workspace for browser-based bb interface experiments and 
 - `../bb` is the canonical upstream source checkout. Read it for contracts and patterns, but do not edit it unless the task explicitly targets upstream bb.
 - Do not import bb application internals into the workbench or plugins. Plugins use the public `@bb/plugin-sdk` contracts.
 - Plugin frontend bundles run inside bb. Keep reusable visual components host-neutral and put bb-specific hooks behind thin adapters.
+- Native bb owns scaffolding, declaration refresh, build, install, dev/reload, and live runtime. BB Mate may orchestrate those commands and explain their output, but must not reimplement them.
+- Use the official `@bb/plugin-sdk/testing` and `@bb/plugin-sdk/testing/app` harnesses for contract tests. If they are unavailable from the selected plugin's installed dependencies, report Harness mode as unavailable; do not copy the harness or import it from `../bb`.
+- Keep preview claims explicit: Fixture is a deterministic approximation, Harness validates public behavior, and Live bb is the visual authority.
 
 ## Working style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+BB Mate is the private workspace for browser-based bb interface experiments and independently shippable bb plugins.
+
+## Boundaries
+
+- `apps/workbench` is a browser-only design studio. It uses deterministic fixtures and must run without a bb server.
+- `plugins/<name>` contains real bb plugins. Every plugin is an independent package with its own `package.json`, `bb` manifest, tests, and version.
+- `../bb` is the canonical upstream source checkout. Read it for contracts and patterns, but do not edit it unless the task explicitly targets upstream bb.
+- Do not import bb application internals into the workbench or plugins. Plugins use the public `@bb/plugin-sdk` contracts.
+- Plugin frontend bundles run inside bb. Keep reusable visual components host-neutral and put bb-specific hooks behind thin adapters.
+
+## Working style
+
+- Start non-trivial work with a plan under `.agents/plans/` and keep it current.
+- Prefer a thin end-to-end slice over speculative infrastructure.
+- Preserve deterministic fake states so visual changes are reproducible.
+- Add shared packages only after two real consumers need the same code.
+- Treat plugins as full-trust local code. Document filesystem, network, secret, and external-service access.
+- Use Bun for workspace management, scripts, tests, and installs.
+
+## Commands
+
+```sh
+bun install
+bun run dev
+bun run check
+bun run test
+bun run build
+bun run format:check
+```
+
+Run the smallest relevant check while iterating and all checks before pushing.
+
+## Plugin development
+
+Create plugins beneath `plugins/` and keep their package names in the `bb-plugin-*` namespace. During development, install a plugin by path:
+
+```sh
+bb plugin install ./plugins/<name> --yes
+cd plugins/<name>
+bb plugin dev
+```
+
+Each plugin must declare honest `engines.bb` and `engines.bbPluginSdk` ranges. Managed npm or Git installs refuse incompatible ranges.
+
+## Documentation
+
+- Architecture and durable decisions belong in `docs/`.
+- Active implementation plans belong in `.agents/plans/`.
+- Keep screenshots and generated design artifacts out of source directories; place durable assets in a purpose-named directory and temporary QA artifacts in thread storage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ JSON output. Discovery never imports or executes plugin code. Harness mode only
 activates when the selected plugin can resolve the officially distributed
 `@bb/plugin-sdk/testing` and `@bb/plugin-sdk/testing/app` packages; BB Mate does
 not copy them or import them from `../bb`.
+
+Current upstream dependencies:
+
+- [get-bb/bb#1134](https://github.com/get-bb/bb/issues/1134) tracks the missing
+  external `@bb/plugin-sdk` distribution required for Harness mode.
+- [get-bb/bb#1133](https://github.com/get-bb/bb/issues/1133) and draft
+  [PR #1135](https://github.com/get-bb/bb/pull/1135) own the native scaffold
+  development-dependency fix. BB Mate does not patch generated scaffolds.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# bb-workbench
-Browser-based design studio and workbench for bb interface experiments.
+# bb-mate
+
+BB Mate is a private Bun monorepo for designing, prototyping, and shipping extensions around [bb](https://github.com/get-bb/bb).
+
+The browser workbench lives in `apps/workbench`. Installable bb plugins live in `plugins/<name>` as independent workspace packages with their own manifests and release versions.
+
+## Commands
+
+```sh
+bun install
+bun run dev
+bun run check
+bun run test
+bun run build
+```
+
+## Layout
+
+```text
+apps/workbench/  Browser-only design studio with deterministic fake bb state
+plugins/         Independently installable and publishable bb plugin packages
+docs/            Architecture, product notes, and release guidance
+.agents/plans/   Durable implementation plans and decision records
+```
+
+The canonical bb source checkout is intentionally separate at `../bb`. It is reference material, not a workspace dependency.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,43 @@ docs/            Architecture, product notes, and release guidance
 ```
 
 The canonical bb source checkout is intentionally separate at `../bb`. It is reference material, not a workspace dependency.
+
+## Relationship to bb
+
+BB Mate is a downstream authoring companion, not an alternate plugin runtime.
+
+| bb owns                                    | BB Mate owns                               |
+| ------------------------------------------ | ------------------------------------------ |
+| Plugin SDK contracts and testing harnesses | Workspace discovery and inspection         |
+| Scaffolding and declaration refresh        | Deterministic fixtures and stories         |
+| Build, install, reload, and runtime        | Thin native-command orchestration          |
+| Host layout, styling, routing, and state   | Compatibility diagnostics and live handoff |
+
+This distinction keeps BB Mate deletable at every seam: when bb improves a
+native workflow, BB Mate should consume it instead of maintaining a competing
+implementation.
+
+## Preview fidelity
+
+BB Mate names three different levels of confidence:
+
+- **Fixture** — deterministic browser state for fast visual iteration. It is an
+  approximation and runs without bb.
+- **Harness** — behavioral validation through the official
+  `@bb/plugin-sdk/testing` packages. It checks public contracts, not host CSS or
+  layout.
+- **Live bb** — the plugin running inside bb. This is the visual and integration
+  authority.
+
+The workbench discovers the only plugin under `plugins/` automatically. When a
+workspace contains more than one plugin, choose one explicitly:
+
+```sh
+BB_MATE_PLUGIN=plugins/<name> bun run dev
+```
+
+The overlay reads `package.json`, native `dist/*.meta.json`, and native bb CLI
+JSON output. Discovery never imports or executes plugin code. Harness mode only
+activates when the selected plugin can resolve the officially distributed
+`@bb/plugin-sdk/testing` and `@bb/plugin-sdk/testing/app` packages; BB Mate does
+not copy them or import them from `../bb`.

--- a/apps/workbench/components.json
+++ b/apps/workbench/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/apps/workbench/index.html
+++ b/apps/workbench/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#111217" />
+    <title>BB Mate</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@bb-mate/workbench",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.4",
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^5.0.2",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.3"
+  }
+}

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -6,17 +6,32 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "bun test src"
   },
   "dependencies": {
+    "@base-ui/react": "^1.7.0",
+    "@fontsource-variable/geist": "^5.3.0",
+    "@fontsource-variable/inter": "^5.3.0",
+    "@hugeicons/core-free-icons": "^4.1.3",
+    "@hugeicons/react": "^1.1.6",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.29.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "shadcn": "^4.16.2",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.3",
     "@types/bun": "^1.3.4",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.2",
+    "tailwindcss": "^4.3.3",
     "typescript": "^5.9.2",
     "vite": "^7.1.3"
   }

--- a/apps/workbench/plugin-inspection-server.ts
+++ b/apps/workbench/plugin-inspection-server.ts
@@ -1,0 +1,436 @@
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { Plugin } from "vite";
+import type {
+  NativeBuildMetadata,
+  PluginInspection,
+  PluginTarget,
+} from "./src/plugin-inspection";
+
+const execFileAsync = promisify(execFile);
+
+interface PluginPackageJson {
+  name?: unknown;
+  version?: unknown;
+  engines?: {
+    bb?: unknown;
+    bbPluginSdk?: unknown;
+  };
+  bb?: {
+    name?: unknown;
+    server?: unknown;
+    app?: unknown;
+  };
+}
+
+interface InstalledPlugin {
+  id?: unknown;
+  rootDir?: unknown;
+  status?: unknown;
+}
+
+interface CommandRunner {
+  (args: string[]): Promise<string>;
+}
+
+export interface InspectPluginOptions {
+  workspaceRoot: string;
+  targetPath?: string;
+  runBb?: CommandRunner;
+  resolveHarness?: (pluginRoot: string) => Promise<string | null>;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+async function readJson(filePath: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+}
+
+async function readPackage(pluginRoot: string): Promise<PluginPackageJson> {
+  return (await readJson(
+    path.join(pluginRoot, "package.json"),
+  )) as PluginPackageJson;
+}
+
+function isPluginPackage(packageJson: PluginPackageJson): boolean {
+  return Boolean(
+    stringOrNull(packageJson.bb?.server) || stringOrNull(packageJson.bb?.app),
+  );
+}
+
+async function discoverPluginRoots(workspaceRoot: string): Promise<string[]> {
+  const pluginsRoot = path.join(workspaceRoot, "plugins");
+  const entries = await fs
+    .readdir(pluginsRoot, { withFileTypes: true })
+    .catch(() => null);
+  if (!entries) return [];
+
+  const roots: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    const candidate = path.join(pluginsRoot, entry.name);
+    try {
+      if (isPluginPackage(await readPackage(candidate))) roots.push(candidate);
+    } catch {
+      // Discovery ignores ordinary directories that are not valid packages.
+    }
+  }
+  return roots.sort();
+}
+
+function displayPath(workspaceRoot: string, pluginRoot: string): string {
+  const relative = path.relative(workspaceRoot, pluginRoot);
+  return relative.startsWith("..") ? pluginRoot : relative || ".";
+}
+
+function parseBuildMetadata(value: unknown): NativeBuildMetadata | null {
+  if (typeof value !== "object" || value === null) return null;
+  const metadata = value as Record<string, unknown>;
+  const builtWith =
+    typeof metadata.builtWith === "object" && metadata.builtWith !== null
+      ? (metadata.builtWith as Record<string, unknown>)
+      : {};
+  return {
+    sdkVersion: stringOrNull(metadata.sdkVersion),
+    pluginId: stringOrNull(metadata.pluginId),
+    pluginVersion: stringOrNull(metadata.pluginVersion),
+    bbVersion: stringOrNull(builtWith.bbVersion),
+  };
+}
+
+async function readBuildMetadata(
+  pluginRoot: string,
+  name: "server" | "app",
+): Promise<NativeBuildMetadata | null> {
+  try {
+    return parseBuildMetadata(
+      await readJson(path.join(pluginRoot, "dist", `${name}.meta.json`)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function defaultRunBb(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("bb", args, {
+    timeout: 5_000,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+async function packageVersionFromResolvedFile(
+  resolvedFile: string,
+): Promise<string | null> {
+  let current = path.dirname(resolvedFile);
+  for (;;) {
+    const packagePath = path.join(current, "package.json");
+    try {
+      const packageJson = (await readJson(packagePath)) as {
+        name?: unknown;
+        version?: unknown;
+      };
+      if (packageJson.name === "@bb/plugin-sdk") {
+        return stringOrNull(packageJson.version);
+      }
+    } catch {
+      // Keep walking until the package root is found.
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+async function defaultResolveHarness(
+  pluginRoot: string,
+): Promise<string | null> {
+  try {
+    const requireFromPlugin = createRequire(
+      path.join(pluginRoot, "package.json"),
+    );
+    const frontendHarness = requireFromPlugin.resolve(
+      "@bb/plugin-sdk/testing/app",
+    );
+    requireFromPlugin.resolve("@bb/plugin-sdk/testing");
+    return packageVersionFromResolvedFile(frontendHarness);
+  } catch {
+    return null;
+  }
+}
+
+async function realPathOrSelf(value: string): Promise<string> {
+  try {
+    return await fs.realpath(value);
+  } catch {
+    return value;
+  }
+}
+
+async function readNativeState(
+  pluginRoot: string,
+  runBb: CommandRunner,
+): Promise<{
+  bbVersion: string | null;
+  connectUrl: string | null;
+  installed: {
+    id: string;
+    status: string | null;
+    sourceKind: string | null;
+  } | null;
+}> {
+  const [versionResult, listResult, connectResult] = await Promise.allSettled([
+    runBb(["--version"]),
+    runBb(["plugin", "list", "--json"]),
+    runBb(["connect", "status", "--json"]),
+  ]);
+
+  let installed: {
+    id: string;
+    status: string | null;
+    sourceKind: string | null;
+  } | null = null;
+  if (listResult.status === "fulfilled") {
+    try {
+      const parsed = JSON.parse(listResult.value) as {
+        plugins?: InstalledPlugin[];
+      };
+      const targetRealPath = await realPathOrSelf(pluginRoot);
+      for (const plugin of parsed.plugins ?? []) {
+        const id = stringOrNull(plugin.id);
+        const rootDir = stringOrNull(plugin.rootDir);
+        if (!id || !rootDir) continue;
+        if ((await realPathOrSelf(rootDir)) === targetRealPath) {
+          installed = {
+            id,
+            status: stringOrNull(plugin.status),
+            sourceKind: null,
+          };
+          break;
+        }
+      }
+    } catch {
+      // A malformed native response is reported as unavailable below.
+    }
+  }
+
+  if (installed) {
+    try {
+      const parsed = JSON.parse(
+        await runBb(["plugin", "source", installed.id, "--json"]),
+      ) as { resolved?: unknown };
+      const resolved = stringOrNull(parsed.resolved);
+      installed.sourceKind = resolved?.split(":", 1)[0] ?? null;
+    } catch {
+      // List status is still useful when detailed source history is unavailable.
+    }
+  }
+
+  let connectUrl: string | null = null;
+  if (connectResult.status === "fulfilled") {
+    try {
+      const parsed = JSON.parse(connectResult.value) as { url?: unknown };
+      connectUrl = stringOrNull(parsed.url);
+    } catch {
+      // Ignore malformed Connect metadata.
+    }
+  }
+
+  return {
+    bbVersion:
+      versionResult.status === "fulfilled" ? versionResult.value : null,
+    connectUrl,
+    installed,
+  };
+}
+
+function emptyInspection(
+  state: PluginInspection["state"],
+  message: string,
+  candidates: string[] = [],
+): PluginInspection {
+  return {
+    state,
+    message,
+    candidates,
+    target: null,
+    modes: {
+      fixture: {
+        available: true,
+        detail: "The deterministic bb sidebar fixture is ready.",
+      },
+      harness: {
+        available: false,
+        sdkVersion: null,
+        detail:
+          "Choose one plugin package before loading the official harness.",
+      },
+      live: {
+        available: false,
+        pluginId: null,
+        status: null,
+        sourceKind: null,
+        url: null,
+        detail: "Choose one installed plugin package before opening live bb.",
+      },
+    },
+    native: { bbVersion: null, connectUrl: null },
+  };
+}
+
+export async function inspectPlugin(
+  options: InspectPluginOptions,
+): Promise<PluginInspection> {
+  const candidates = options.targetPath
+    ? [path.resolve(options.workspaceRoot, options.targetPath)]
+    : await discoverPluginRoots(options.workspaceRoot);
+
+  if (candidates.length === 0) {
+    return emptyInspection(
+      "missing",
+      "No bb plugin packages were found. Set BB_MATE_PLUGIN to a plugin directory.",
+    );
+  }
+  if (candidates.length > 1) {
+    return emptyInspection(
+      "ambiguous",
+      "More than one plugin package was found. Set BB_MATE_PLUGIN to choose one.",
+      candidates.map((candidate) =>
+        displayPath(options.workspaceRoot, candidate),
+      ),
+    );
+  }
+
+  const pluginRoot = candidates[0]!;
+  let packageJson: PluginPackageJson;
+  try {
+    packageJson = await readPackage(pluginRoot);
+    if (!isPluginPackage(packageJson)) {
+      return emptyInspection(
+        "error",
+        `${displayPath(options.workspaceRoot, pluginRoot)} does not declare bb.server or bb.app.`,
+      );
+    }
+  } catch (error) {
+    return emptyInspection(
+      "error",
+      `Could not read ${displayPath(options.workspaceRoot, pluginRoot)}/package.json: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const [serverBuild, appBuild, harnessVersion, native] = await Promise.all([
+    readBuildMetadata(pluginRoot, "server"),
+    readBuildMetadata(pluginRoot, "app"),
+    (options.resolveHarness ?? defaultResolveHarness)(pluginRoot),
+    readNativeState(pluginRoot, options.runBb ?? defaultRunBb),
+  ]);
+
+  const serverEntry = stringOrNull(packageJson.bb?.server);
+  const appEntry = stringOrNull(packageJson.bb?.app);
+  const packageName = stringOrNull(packageJson.name) ?? "unnamed-plugin";
+  const target: PluginTarget = {
+    displayPath: displayPath(options.workspaceRoot, pluginRoot),
+    packageName,
+    displayName: stringOrNull(packageJson.bb?.name) ?? packageName,
+    version: stringOrNull(packageJson.version) ?? "0.0.0",
+    serverEntry,
+    appEntry,
+    engines: {
+      bb: stringOrNull(packageJson.engines?.bb),
+      pluginSdk: stringOrNull(packageJson.engines?.bbPluginSdk),
+    },
+    build: { server: serverBuild, app: appBuild },
+  };
+
+  const installed = native.installed;
+  const liveAvailable = Boolean(appEntry && installed);
+  const liveUrl = liveAvailable ? native.connectUrl : null;
+
+  return {
+    state: "ready",
+    message: null,
+    candidates: [],
+    target,
+    modes: {
+      fixture: {
+        available: true,
+        detail: "Deterministic, browser-only state for visual iteration.",
+      },
+      harness: {
+        available: Boolean(appEntry && harnessVersion),
+        sdkVersion: harnessVersion,
+        detail: !appEntry
+          ? "This plugin is headless; it has no bb.app surface to load."
+          : harnessVersion
+            ? `Official @bb/plugin-sdk ${harnessVersion} testing runtime resolved from the plugin.`
+            : "Official @bb/plugin-sdk testing runtime is not installed for this plugin.",
+      },
+      live: {
+        available: liveAvailable,
+        pluginId: installed?.id ?? null,
+        status: installed?.status ?? null,
+        sourceKind: installed?.sourceKind ?? null,
+        url: liveUrl,
+        detail: !appEntry
+          ? "This plugin is running in bb but does not declare a frontend entry."
+          : installed
+            ? `Plugin ${installed.id} is ${installed.status ?? "installed"} in native bb${installed.sourceKind ? ` from a ${installed.sourceKind} source` : ""}.`
+            : "Install this plugin by path to validate its UI in native bb.",
+      },
+    },
+    native: {
+      bbVersion: native.bbVersion,
+      connectUrl: native.connectUrl,
+    },
+  };
+}
+
+function inspectionMiddleware(options: InspectPluginOptions): (
+  request: { url?: string },
+  response: {
+    statusCode: number;
+    setHeader(name: string, value: string): void;
+    end(body?: string): void;
+  },
+  next: () => void,
+) => void {
+  return (request, response, next) => {
+    if (request.url?.split("?", 1)[0] !== "/bb-mate-plugin.json") {
+      next();
+      return;
+    }
+    void inspectPlugin(options)
+      .then((inspection) => {
+        response.statusCode = 200;
+        response.setHeader("Content-Type", "application/json; charset=utf-8");
+        response.setHeader("Cache-Control", "no-store");
+        response.end(JSON.stringify(inspection));
+      })
+      .catch((error: unknown) => {
+        response.statusCode = 500;
+        response.setHeader("Content-Type", "application/json; charset=utf-8");
+        response.end(
+          JSON.stringify({
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      });
+  };
+}
+
+export function pluginInspectionPlugin(options: InspectPluginOptions): Plugin {
+  return {
+    name: "bb-mate-plugin-inspection",
+    configureServer(server) {
+      server.middlewares.use(inspectionMiddleware(options));
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(inspectionMiddleware(options));
+    },
+  };
+}

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { findScenario, scenarios, type ThreadState } from "./scenarios";
+
+const stateLabels: Record<ThreadState, string> = {
+  idle: "Idle",
+  running: "Running",
+  waiting: "Waiting",
+};
+
+export function App() {
+  const [scenarioId, setScenarioId] = useState(scenarios[0]!.id);
+  const scenario = findScenario(scenarioId);
+
+  return (
+    <main className="studio">
+      <header className="studio-header">
+        <div className="brand">
+          <span className="brand-mark" aria-hidden="true">
+            8
+          </span>
+          <div>
+            <h1>BB Mate</h1>
+            <p>Browser workbench</p>
+          </div>
+        </div>
+        <p className="studio-purpose">Prototype locally. Ship as plugins.</p>
+      </header>
+
+      <section className="workspace" aria-label="Workbench">
+        <aside className="scenario-panel">
+          <div>
+            <p className="section-label">Fake state</p>
+            <h2>Sidebar playground</h2>
+            <p className="scenario-copy">{scenario.description}</p>
+          </div>
+
+          <nav className="scenario-list" aria-label="Preview scenarios">
+            {scenarios.map((item) => (
+              <button
+                className={
+                  item.id === scenario.id ? "scenario active" : "scenario"
+                }
+                key={item.id}
+                onClick={() => setScenarioId(item.id)}
+                type="button"
+              >
+                <span>{item.name}</span>
+                <small>{item.threads.length} rows</small>
+              </button>
+            ))}
+          </nav>
+        </aside>
+
+        <div className="preview-stage">
+          <div className="preview-window">
+            <aside
+              className="bb-sidebar"
+              aria-label={`${scenario.name} preview`}
+            >
+              <div className="bb-sidebar-header">
+                <div className="bb-brand">
+                  <span className="bb-dot" />
+                  <span>bb</span>
+                </div>
+                <button type="button" aria-label="Create thread">
+                  +
+                </button>
+              </div>
+
+              <label className="search">
+                <span aria-hidden="true">⌕</span>
+                <input aria-label="Search threads" placeholder="Search" />
+              </label>
+
+              <div className="thread-section">
+                <p>{scenario.name}</p>
+                <div className="thread-list">
+                  {scenario.threads.map((thread) => (
+                    <button
+                      className="thread-row"
+                      key={thread.id}
+                      type="button"
+                    >
+                      <span className={`state-dot ${thread.state}`} />
+                      <span className="thread-copy">
+                        <strong>{thread.title}</strong>
+                        <small>{thread.detail}</small>
+                      </span>
+                      <span className="sr-only">
+                        {stateLabels[thread.state]}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <footer>
+                <span>Settings</span>
+                <span className="connection">Local</span>
+              </footer>
+            </aside>
+
+            <section className="canvas">
+              <div>
+                <p className="section-label">{scenario.name}</p>
+                <h2>Make the state obvious.</h2>
+                <p>
+                  This shell is intentionally disconnected from bb. Iterate on
+                  the information hierarchy here, then move proven components
+                  behind a plugin adapter.
+                </p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,119 +1,16 @@
 import { useState } from "react";
-import { findScenario, scenarios, type ThreadState } from "./scenarios";
-
-const stateLabels: Record<ThreadState, string> = {
-  idle: "Idle",
-  running: "Running",
-  waiting: "Waiting",
-};
+import { BbShell } from "@/components/BbShell";
+import { MateOverlay } from "@/components/MateOverlay";
+import { findScenario, scenarios } from "@/scenarios";
 
 export function App() {
   const [scenarioId, setScenarioId] = useState(scenarios[0]!.id);
   const scenario = findScenario(scenarioId);
 
   return (
-    <main className="studio">
-      <header className="studio-header">
-        <div className="brand">
-          <span className="brand-mark" aria-hidden="true">
-            8
-          </span>
-          <div>
-            <h1>BB Mate</h1>
-            <p>Browser workbench</p>
-          </div>
-        </div>
-        <p className="studio-purpose">Prototype locally. Ship as plugins.</p>
-      </header>
-
-      <section className="workspace" aria-label="Workbench">
-        <aside className="scenario-panel">
-          <div>
-            <p className="section-label">Fake state</p>
-            <h2>Sidebar playground</h2>
-            <p className="scenario-copy">{scenario.description}</p>
-          </div>
-
-          <nav className="scenario-list" aria-label="Preview scenarios">
-            {scenarios.map((item) => (
-              <button
-                className={
-                  item.id === scenario.id ? "scenario active" : "scenario"
-                }
-                key={item.id}
-                onClick={() => setScenarioId(item.id)}
-                type="button"
-              >
-                <span>{item.name}</span>
-                <small>{item.threads.length} rows</small>
-              </button>
-            ))}
-          </nav>
-        </aside>
-
-        <div className="preview-stage">
-          <div className="preview-window">
-            <aside
-              className="bb-sidebar"
-              aria-label={`${scenario.name} preview`}
-            >
-              <div className="bb-sidebar-header">
-                <div className="bb-brand">
-                  <span className="bb-dot" />
-                  <span>bb</span>
-                </div>
-                <button type="button" aria-label="Create thread">
-                  +
-                </button>
-              </div>
-
-              <label className="search">
-                <span aria-hidden="true">⌕</span>
-                <input aria-label="Search threads" placeholder="Search" />
-              </label>
-
-              <div className="thread-section">
-                <p>{scenario.name}</p>
-                <div className="thread-list">
-                  {scenario.threads.map((thread) => (
-                    <button
-                      className="thread-row"
-                      key={thread.id}
-                      type="button"
-                    >
-                      <span className={`state-dot ${thread.state}`} />
-                      <span className="thread-copy">
-                        <strong>{thread.title}</strong>
-                        <small>{thread.detail}</small>
-                      </span>
-                      <span className="sr-only">
-                        {stateLabels[thread.state]}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <footer>
-                <span>Settings</span>
-                <span className="connection">Local</span>
-              </footer>
-            </aside>
-
-            <section className="canvas">
-              <div>
-                <p className="section-label">{scenario.name}</p>
-                <h2>Make the state obvious.</h2>
-                <p>
-                  This shell is intentionally disconnected from bb. Iterate on
-                  the information hierarchy here, then move proven components
-                  behind a plugin adapter.
-                </p>
-              </div>
-            </section>
-          </div>
-        </div>
-      </section>
-    </main>
+    <>
+      <BbShell scenario={scenario} />
+      <MateOverlay scenarioId={scenario.id} onScenarioChange={setScenarioId} />
+    </>
   );
 }

--- a/apps/workbench/src/components/BbIcon.tsx
+++ b/apps/workbench/src/components/BbIcon.tsx
@@ -1,0 +1,19 @@
+import type { IconSvgElement } from "@hugeicons/react";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+interface BbIconProps {
+  icon: IconSvgElement;
+  size?: number;
+}
+
+export function BbIcon({ icon, size = 16 }: BbIconProps) {
+  return (
+    <HugeiconsIcon
+      aria-hidden="true"
+      color="currentColor"
+      icon={icon}
+      size={size}
+      strokeWidth={1.5}
+    />
+  );
+}

--- a/apps/workbench/src/components/BbShell.tsx
+++ b/apps/workbench/src/components/BbShell.tsx
@@ -1,0 +1,217 @@
+import {
+  ArrowDown01Icon,
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+  ArrowUp02Icon,
+  BubbleChatAddIcon,
+  Bug01Icon,
+  FolderAddIcon,
+  Mic02Icon,
+  PlusSignIcon,
+  Search01Icon,
+  Settings01Icon,
+  SidebarLeftIcon,
+  SidebarRightIcon,
+  SmartPhone01Icon,
+  TimeScheduleIcon,
+  ToolboxIcon,
+} from "@hugeicons/core-free-icons";
+import { useState } from "react";
+import type { Scenario } from "@/scenarios";
+import { BbIcon } from "./BbIcon";
+import { SidebarListView } from "./SidebarListView";
+
+interface BbShellProps {
+  scenario: Scenario;
+}
+
+function OpenAiIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="bb-provider-icon"
+      fill="currentColor"
+      fillRule="evenodd"
+      viewBox="0 0 24 24"
+    >
+      <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.8956zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    </svg>
+  );
+}
+
+function SidebarAction({
+  icon,
+  label,
+  end,
+}: {
+  icon: Parameters<typeof BbIcon>[0]["icon"];
+  label: string;
+  end?: React.ReactNode;
+}) {
+  return (
+    <button className="bb-sidebar-row bb-sidebar-action" type="button">
+      <BbIcon icon={icon} />
+      <span>{label}</span>
+      {end ? <span className="bb-row-end">{end}</span> : null}
+    </button>
+  );
+}
+
+export function BbShell({ scenario }: BbShellProps) {
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
+  return (
+    <main className="bb-app" aria-label="BB Mate workbench">
+      {mobileSidebarOpen ? (
+        <button
+          className="bb-mobile-sidebar-backdrop"
+          type="button"
+          aria-label="Close sidebar"
+          onClick={() => setMobileSidebarOpen(false)}
+        />
+      ) : null}
+      <aside
+        id="bb-workbench-sidebar"
+        className={`bb-sidebar${mobileSidebarOpen ? " mobile-open" : ""}`}
+        aria-label={`${scenario.name} preview`}
+      >
+        <header className="bb-sidebar-chrome">
+          <button
+            className="bb-icon-button"
+            type="button"
+            aria-label="Hide sidebar"
+            onClick={() => setMobileSidebarOpen(false)}
+          >
+            <BbIcon icon={SidebarLeftIcon} />
+          </button>
+          <div className="bb-history-actions">
+            <button
+              className="bb-icon-button"
+              type="button"
+              aria-label="Go back"
+            >
+              <BbIcon icon={ArrowLeft01Icon} />
+            </button>
+            <button
+              className="bb-icon-button"
+              type="button"
+              aria-label="Go forward"
+            >
+              <BbIcon icon={ArrowRight01Icon} />
+            </button>
+          </div>
+        </header>
+
+        <div className="bb-primary-actions">
+          <SidebarAction
+            icon={BubbleChatAddIcon}
+            label="New thread"
+            end={
+              <span className="bb-search-glyph" aria-label="Search threads">
+                <BbIcon icon={Search01Icon} />
+              </span>
+            }
+          />
+          <SidebarAction icon={ToolboxIcon} label="Extensions" />
+          <SidebarAction icon={TimeScheduleIcon} label="Automations" />
+        </div>
+
+        <SidebarListView model={scenario} />
+
+        <footer className="bb-sidebar-footer">
+          <button
+            className="bb-icon-button"
+            type="button"
+            aria-label="Settings"
+          >
+            <BbIcon icon={Settings01Icon} />
+          </button>
+          <button
+            className="bb-icon-button"
+            type="button"
+            aria-label="Remote access"
+          >
+            <BbIcon icon={SmartPhone01Icon} />
+          </button>
+          <button
+            className="bb-icon-button"
+            type="button"
+            aria-label="Report a bug"
+          >
+            <BbIcon icon={Bug01Icon} />
+          </button>
+        </footer>
+      </aside>
+
+      <section className="bb-main" aria-label="New thread">
+        <button
+          className="bb-mobile-sidebar-button"
+          type="button"
+          aria-label="Show sidebar"
+          aria-controls="bb-workbench-sidebar"
+          aria-expanded={mobileSidebarOpen}
+          onClick={() => setMobileSidebarOpen(true)}
+        >
+          <BbIcon icon={SidebarLeftIcon} />
+        </button>
+        <button
+          className="bb-right-panel-button"
+          type="button"
+          aria-label="Show right panel"
+        >
+          <BbIcon icon={SidebarRightIcon} />
+        </button>
+
+        <div className="bb-compose-wrap">
+          <div className="bb-composer">
+            <div className="bb-composer-editor">
+              <p className="bb-placeholder">Ask anything.</p>
+            </div>
+            <div className="bb-composer-toolbar">
+              <button
+                className="bb-compose-icon"
+                type="button"
+                aria-label="Prompt actions"
+              >
+                <BbIcon icon={PlusSignIcon} />
+              </button>
+              <button className="bb-model-button" type="button">
+                <OpenAiIcon />
+                <span>5.5 Medium</span>
+                <BbIcon icon={ArrowDown01Icon} size={14} />
+              </button>
+              <span className="bb-compose-spacer" />
+              <button
+                className="bb-compose-icon"
+                type="button"
+                aria-label="Start voice input"
+              >
+                <BbIcon icon={Mic02Icon} />
+              </button>
+              <button
+                className="bb-submit-button"
+                type="button"
+                aria-label="Submit"
+                disabled
+              >
+                <BbIcon icon={ArrowUp02Icon} />
+              </button>
+            </div>
+          </div>
+
+          <div className="bb-compose-options">
+            <button type="button">
+              <BbIcon icon={FolderAddIcon} size={14} />
+              <span>Work in a project</span>
+              <BbIcon icon={ArrowDown01Icon} size={14} />
+            </button>
+            <button type="button">
+              <span>Approve for me</span>
+              <BbIcon icon={ArrowDown01Icon} size={14} />
+            </button>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/workbench/src/components/MateOverlay.tsx
+++ b/apps/workbench/src/components/MateOverlay.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
-import { Database, Minimize2, Radio, SlidersHorizontal } from "lucide-react";
+import {
+  Database,
+  ExternalLink,
+  FlaskConical,
+  Minimize2,
+  Radio,
+  SlidersHorizontal,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -19,6 +26,7 @@ import {
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { scenarios } from "@/scenarios";
+import { usePluginInspection } from "@/usePluginInspection";
 
 const scenarioItems = scenarios.map((scenario) => ({
   label: scenario.name,
@@ -35,6 +43,11 @@ export function MateOverlay({
   onScenarioChange,
 }: MateOverlayProps) {
   const [open, setOpen] = useState(true);
+  const { inspection, error } = usePluginInspection();
+  const target = inspection?.target;
+  const harness = inspection?.modes.harness;
+  const live = inspection?.modes.live;
+  const build = target?.build.app ?? target?.build.server;
 
   return (
     <div className="dark mate-overlay">
@@ -97,15 +110,68 @@ export function MateOverlay({
                 <Database data-icon="inline-start" />
                 Fixtures
               </ToggleGroupItem>
+              <ToggleGroupItem value="harness" disabled={!harness?.available}>
+                <FlaskConical data-icon="inline-start" />
+                Harness
+              </ToggleGroupItem>
               <ToggleGroupItem value="live" disabled>
                 <Radio data-icon="inline-start" />
                 Live bb
               </ToggleGroupItem>
             </ToggleGroup>
             <p className="mate-help">
-              Live state activates when this view is mounted through the bb
-              plugin adapter.
+              {harness?.detail ??
+                "Inspecting the official SDK harness and native bb runtime…"}
             </p>
+          </div>
+
+          <div className="mate-plugin-card" aria-live="polite">
+            <div className="mate-field-heading">
+              <span>Plugin target</span>
+              <span className="mate-plugin-kind">
+                {target?.appEntry
+                  ? "frontend"
+                  : target
+                    ? "headless"
+                    : "inspect"}
+              </span>
+            </div>
+            {error ? (
+              <p className="mate-plugin-error">{error}</p>
+            ) : target ? (
+              <>
+                <div className="mate-plugin-title-row">
+                  <strong>{target.displayName}</strong>
+                  <span>v{target.version}</span>
+                </div>
+                <code className="mate-plugin-path">{target.displayPath}</code>
+                <div className="mate-plugin-statuses">
+                  <span data-available={Boolean(harness?.available)}>
+                    Harness {harness?.available ? "ready" : "unavailable"}
+                  </span>
+                  <span data-available={Boolean(live?.available)}>
+                    Live {live?.status ?? "not linked"}
+                  </span>
+                </div>
+                {live?.url ? (
+                  <a
+                    className="mate-live-link"
+                    href={live.url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Open native bb
+                    <ExternalLink aria-hidden="true" />
+                  </a>
+                ) : (
+                  <p className="mate-plugin-detail">{live?.detail}</p>
+                )}
+              </>
+            ) : (
+              <p className="mate-plugin-detail">
+                {inspection?.message ?? "Inspecting workspace plugins…"}
+              </p>
+            )}
           </div>
 
           <div className="mate-field">
@@ -139,8 +205,10 @@ export function MateOverlay({
           </div>
 
           <div className="mate-runtime-line">
-            <span>adapter</span>
-            <code>fixture/v1</code>
+            <span>bb {inspection?.native.bbVersion ?? "unavailable"}</span>
+            <code>
+              {build?.sdkVersion ? `sdk ${build.sdkVersion}` : "fixture/v1"}
+            </code>
           </div>
         </PopoverContent>
       </Popover>

--- a/apps/workbench/src/components/MateOverlay.tsx
+++ b/apps/workbench/src/components/MateOverlay.tsx
@@ -33,6 +33,8 @@ const scenarioItems = scenarios.map((scenario) => ({
   value: scenario.id,
 }));
 
+const pluginSdkPublicationIssue = "https://github.com/get-bb/bb/issues/1134";
+
 interface MateOverlayProps {
   scenarioId: string;
   onScenarioChange: (scenarioId: string) => void;
@@ -153,6 +155,17 @@ export function MateOverlay({
                     Live {live?.status ?? "not linked"}
                   </span>
                 </div>
+                {target.appEntry && harness && !harness.available ? (
+                  <a
+                    className="mate-live-link"
+                    href={pluginSdkPublicationIssue}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Track SDK publication
+                    <ExternalLink aria-hidden="true" />
+                  </a>
+                ) : null}
                 {live?.url ? (
                   <a
                     className="mate-live-link"

--- a/apps/workbench/src/components/MateOverlay.tsx
+++ b/apps/workbench/src/components/MateOverlay.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Database, Minimize2, Radio, SlidersHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { scenarios } from "@/scenarios";
+
+const scenarioItems = scenarios.map((scenario) => ({
+  label: scenario.name,
+  value: scenario.id,
+}));
+
+interface MateOverlayProps {
+  scenarioId: string;
+  onScenarioChange: (scenarioId: string) => void;
+}
+
+export function MateOverlay({
+  scenarioId,
+  onScenarioChange,
+}: MateOverlayProps) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="dark mate-overlay">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              className="mate-fab"
+              size="icon-lg"
+              aria-label={
+                open ? "Hide BB Mate controls" : "Show BB Mate controls"
+              }
+            />
+          }
+        >
+          <SlidersHorizontal data-icon="inline-start" />
+        </PopoverTrigger>
+
+        <PopoverContent
+          align="end"
+          side="top"
+          sideOffset={10}
+          className="mate-popover"
+        >
+          <PopoverHeader className="mate-panel-header">
+            <div className="mate-heading-copy">
+              <span className="mate-kicker">BB Mate</span>
+              <PopoverTitle>Workbench controls</PopoverTitle>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Minimize controls"
+              onClick={() => setOpen(false)}
+            >
+              <Minimize2 />
+            </Button>
+          </PopoverHeader>
+          <PopoverDescription className="sr-only">
+            Choose the workbench state source and deterministic preview
+            scenario.
+          </PopoverDescription>
+
+          <div className="mate-divider" />
+
+          <div className="mate-field">
+            <div className="mate-field-heading">
+              <span>Source</span>
+              <span className="mate-source-status">
+                <i aria-hidden="true" /> fixture
+              </span>
+            </div>
+            <ToggleGroup
+              aria-label="State source"
+              className="mate-source-toggle"
+              spacing={0}
+              value={["fixtures"]}
+            >
+              <ToggleGroupItem value="fixtures">
+                <Database data-icon="inline-start" />
+                Fixtures
+              </ToggleGroupItem>
+              <ToggleGroupItem value="live" disabled>
+                <Radio data-icon="inline-start" />
+                Live bb
+              </ToggleGroupItem>
+            </ToggleGroup>
+            <p className="mate-help">
+              Live state activates when this view is mounted through the bb
+              plugin adapter.
+            </p>
+          </div>
+
+          <div className="mate-field">
+            <label className="mate-field-heading" htmlFor="mate-scenario">
+              Scenario
+            </label>
+            <Select
+              items={scenarioItems}
+              value={scenarioId}
+              onValueChange={(value) => {
+                if (value) onScenarioChange(value);
+              }}
+            >
+              <SelectTrigger id="mate-scenario" className="mate-select-trigger">
+                <SelectValue placeholder="Choose a scenario" />
+              </SelectTrigger>
+              <SelectContent
+                align="end"
+                alignItemWithTrigger={false}
+                className="dark mate-select-content"
+              >
+                <SelectGroup>
+                  {scenarioItems.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      {item.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="mate-runtime-line">
+            <span>adapter</span>
+            <code>fixture/v1</code>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/workbench/src/components/SidebarListView.tsx
+++ b/apps/workbench/src/components/SidebarListView.tsx
@@ -1,0 +1,59 @@
+import type { SidebarListModel, ThreadState } from "@/scenarios";
+import { BubbleChatIcon } from "@hugeicons/core-free-icons";
+import { BbIcon } from "./BbIcon";
+
+const stateLabels: Record<ThreadState, string> = {
+  idle: "Idle",
+  running: "Running",
+  waiting: "Waiting",
+};
+
+interface SidebarListViewProps {
+  model: SidebarListModel;
+}
+
+/**
+ * Host-neutral list content. The workbench wraps it in replica bb chrome; a
+ * plugin adapter can mount the same view in `experimental_threadList`, where
+ * bb supplies the real surrounding sidebar.
+ */
+export function SidebarListView({ model }: SidebarListViewProps) {
+  return (
+    <div className="bb-sidebar-scroll">
+      <section className="bb-project-section" aria-labelledby="project-name">
+        <div className="bb-section-heading">
+          <span id="project-name">{model.project}</span>
+        </div>
+        <div className="bb-thread-list">
+          {model.threads.map((thread) => (
+            <button className="bb-thread-row" key={thread.id} type="button">
+              <span
+                className={`bb-state-glyph ${thread.state}`}
+                aria-hidden="true"
+              />
+              <span className="bb-thread-title">{thread.title}</span>
+              <span className="sr-only">
+                {stateLabels[thread.state]}: {thread.detail}
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section
+        className="bb-project-section bb-loose-section"
+        aria-labelledby="threads-name"
+      >
+        <div className="bb-section-heading">
+          <span id="threads-name">Threads</span>
+        </div>
+        <div className="bb-empty-row">
+          <span className="bb-empty-icon">
+            <BbIcon icon={BubbleChatIcon} size={14} />
+          </span>
+          <span>No threads</span>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/workbench/src/components/ui/button.tsx
+++ b/apps/workbench/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/apps/workbench/src/components/ui/popover.tsx
+++ b/apps/workbench/src/components/ui/popover.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
+import { cn } from "@/lib/utils";
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+};

--- a/apps/workbench/src/components/ui/select.tsx
+++ b/apps/workbench/src/components/ui/select.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import * as React from "react";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
+
+const Select = SelectPrimitive.Root;
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/workbench/src/components/ui/toggle-group.tsx
+++ b/apps/workbench/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group";
+import { type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/ui/toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+    orientation?: "horizontal" | "vertical";
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 2,
+  orientation: "horizontal",
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+    orientation?: "horizontal" | "vertical";
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-vertical:flex-col data-vertical:items-stretch",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/apps/workbench/src/components/ui/toggle.tsx
+++ b/apps/workbench/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/apps/workbench/src/lib/utils.ts
+++ b/apps/workbench/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/workbench/src/main.tsx
+++ b/apps/workbench/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+
+if (root === null) {
+  throw new Error("Missing #root element");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/workbench/src/plugin-inspection-server.test.ts
+++ b/apps/workbench/src/plugin-inspection-server.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { inspectPlugin } from "../plugin-inspection-server";
+
+const temporaryRoots: string[] = [];
+
+async function createWorkspace(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-inspection-"));
+  temporaryRoots.push(root);
+  await fs.mkdir(path.join(root, "plugins"), { recursive: true });
+  return root;
+}
+
+async function writePlugin(
+  workspaceRoot: string,
+  name: string,
+  packageJson: Record<string, unknown>,
+): Promise<string> {
+  const pluginRoot = path.join(workspaceRoot, "plugins", name);
+  await fs.mkdir(pluginRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(pluginRoot, "package.json"),
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+  );
+  return pluginRoot;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("plugin inspection", () => {
+  test("discovers one headless workspace plugin without executing it", async () => {
+    const workspaceRoot = await createWorkspace();
+    const pluginRoot = await writePlugin(workspaceRoot, "linear", {
+      name: "bb-plugin-linear",
+      version: "0.1.0",
+      engines: { bb: ">=0.35", bbPluginSdk: "^0.4.1" },
+      bb: { name: "Linear", server: "./server.ts" },
+    });
+    await fs.mkdir(path.join(pluginRoot, "dist"));
+    await fs.writeFile(
+      path.join(pluginRoot, "dist", "server.meta.json"),
+      JSON.stringify({
+        sdkVersion: "0.4.1",
+        pluginId: "linear",
+        pluginVersion: "0.1.0",
+        builtWith: { bbVersion: "0.35.1" },
+      }),
+    );
+
+    const inspection = await inspectPlugin({
+      workspaceRoot,
+      resolveHarness: async () => null,
+      runBb: async (args) => {
+        if (args[0] === "--version") return "0.35.1";
+        if (args[0] === "connect") {
+          return JSON.stringify({ url: "https://example.getbb.app" });
+        }
+        if (args[1] === "source") {
+          return JSON.stringify({ resolved: `path:${pluginRoot}` });
+        }
+        return JSON.stringify({
+          plugins: [{ id: "linear", rootDir: pluginRoot, status: "running" }],
+        });
+      },
+    });
+
+    expect(inspection.state).toBe("ready");
+    expect(inspection.target?.displayPath).toBe("plugins/linear");
+    expect(inspection.target?.build.server?.sdkVersion).toBe("0.4.1");
+    expect(inspection.modes.harness.available).toBe(false);
+    expect(inspection.modes.live.available).toBe(false);
+    expect(inspection.modes.live.status).toBe("running");
+  });
+
+  test("reports official harness and native live availability for an app plugin", async () => {
+    const workspaceRoot = await createWorkspace();
+    const pluginRoot = await writePlugin(workspaceRoot, "notes", {
+      name: "bb-plugin-notes",
+      version: "1.2.3",
+      bb: {
+        name: "Notes",
+        server: "./server.ts",
+        app: "./app.tsx",
+      },
+    });
+
+    const inspection = await inspectPlugin({
+      workspaceRoot,
+      targetPath: pluginRoot,
+      resolveHarness: async () => "0.4.1",
+      runBb: async (args) => {
+        if (args[0] === "--version") return "0.35.1";
+        if (args[0] === "connect") {
+          return JSON.stringify({ url: "https://example.getbb.app" });
+        }
+        if (args[1] === "source") {
+          return JSON.stringify({ resolved: `path:${pluginRoot}` });
+        }
+        return JSON.stringify({
+          plugins: [{ id: "notes", rootDir: pluginRoot, status: "running" }],
+        });
+      },
+    });
+
+    expect(inspection.modes.harness).toMatchObject({
+      available: true,
+      sdkVersion: "0.4.1",
+    });
+    expect(inspection.modes.live).toMatchObject({
+      available: true,
+      pluginId: "notes",
+      status: "running",
+      sourceKind: "path",
+      url: "https://example.getbb.app",
+    });
+  });
+
+  test("requires an explicit target when discovery is ambiguous", async () => {
+    const workspaceRoot = await createWorkspace();
+    await writePlugin(workspaceRoot, "one", {
+      name: "bb-plugin-one",
+      bb: { server: "./server.ts" },
+    });
+    await writePlugin(workspaceRoot, "two", {
+      name: "bb-plugin-two",
+      bb: { app: "./app.tsx" },
+    });
+
+    const inspection = await inspectPlugin({ workspaceRoot });
+
+    expect(inspection.state).toBe("ambiguous");
+    expect(inspection.candidates).toEqual(["plugins/one", "plugins/two"]);
+  });
+});

--- a/apps/workbench/src/plugin-inspection.ts
+++ b/apps/workbench/src/plugin-inspection.ts
@@ -1,0 +1,51 @@
+export type InspectionState = "ready" | "missing" | "ambiguous" | "error";
+
+export interface NativeBuildMetadata {
+  sdkVersion: string | null;
+  pluginId: string | null;
+  pluginVersion: string | null;
+  bbVersion: string | null;
+}
+
+export interface PluginTarget {
+  displayPath: string;
+  packageName: string;
+  displayName: string;
+  version: string;
+  serverEntry: string | null;
+  appEntry: string | null;
+  engines: {
+    bb: string | null;
+    pluginSdk: string | null;
+  };
+  build: {
+    server: NativeBuildMetadata | null;
+    app: NativeBuildMetadata | null;
+  };
+}
+
+export interface PreviewCapability {
+  available: boolean;
+  detail: string;
+}
+
+export interface PluginInspection {
+  state: InspectionState;
+  message: string | null;
+  candidates: string[];
+  target: PluginTarget | null;
+  modes: {
+    fixture: PreviewCapability;
+    harness: PreviewCapability & { sdkVersion: string | null };
+    live: PreviewCapability & {
+      pluginId: string | null;
+      status: string | null;
+      sourceKind: string | null;
+      url: string | null;
+    };
+  };
+  native: {
+    bbVersion: string | null;
+    connectUrl: string | null;
+  };
+}

--- a/apps/workbench/src/scenarios.test.ts
+++ b/apps/workbench/src/scenarios.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { findScenario, scenarios } from "./scenarios";
+
+describe("workbench scenarios", () => {
+  test("provides stable unique fixture ids", () => {
+    expect(new Set(scenarios.map((scenario) => scenario.id)).size).toBe(
+      scenarios.length,
+    );
+  });
+
+  test("falls back to the first scenario", () => {
+    expect(findScenario("missing")).toBe(scenarios[0]);
+  });
+});

--- a/apps/workbench/src/scenarios.ts
+++ b/apps/workbench/src/scenarios.ts
@@ -1,0 +1,79 @@
+export type ThreadState = "idle" | "running" | "waiting";
+
+export interface ThreadFixture {
+  id: string;
+  title: string;
+  detail: string;
+  state: ThreadState;
+}
+
+export interface Scenario {
+  id: string;
+  name: string;
+  description: string;
+  threads: ThreadFixture[];
+}
+
+export const scenarios: Scenario[] = [
+  {
+    id: "agents",
+    name: "Agent focus",
+    description: "A compact view of active, waiting, and quiet agent work.",
+    threads: [
+      {
+        id: "patch",
+        title: "@Patch [primary]",
+        detail: "Coordinating the board",
+        state: "running",
+      },
+      {
+        id: "rez",
+        title: "@Rez [plugin build]",
+        detail: "Waiting for review",
+        state: "waiting",
+      },
+      {
+        id: "index",
+        title: "@Index [research]",
+        detail: "Idle 12m",
+        state: "idle",
+      },
+    ],
+  },
+  {
+    id: "gitbutler",
+    name: "GitButler repo",
+    description: "Repository state without the misleading mega-diff treatment.",
+    threads: [
+      {
+        id: "worktree",
+        title: "bb-mate",
+        detail: "2 branches · 4 changed files",
+        state: "running",
+      },
+      {
+        id: "upstream",
+        title: "get-bb/bb",
+        detail: "main · clean",
+        state: "idle",
+      },
+    ],
+  },
+  {
+    id: "quiet",
+    name: "Quiet workspace",
+    description: "The resting state should feel useful without feeling empty.",
+    threads: [
+      {
+        id: "notes",
+        title: "Sidebar notes",
+        detail: "Idle 1h",
+        state: "idle",
+      },
+    ],
+  },
+];
+
+export function findScenario(id: string): Scenario {
+  return scenarios.find((scenario) => scenario.id === id) ?? scenarios[0]!;
+}

--- a/apps/workbench/src/scenarios.ts
+++ b/apps/workbench/src/scenarios.ts
@@ -1,23 +1,28 @@
 export type ThreadState = "idle" | "running" | "waiting";
 
-export interface ThreadFixture {
+export interface SidebarThreadModel {
   id: string;
   title: string;
   detail: string;
   state: ThreadState;
 }
 
-export interface Scenario {
+export interface SidebarListModel {
+  project: string;
+  threads: readonly SidebarThreadModel[];
+}
+
+export interface Scenario extends SidebarListModel {
   id: string;
   name: string;
   description: string;
-  threads: ThreadFixture[];
 }
 
 export const scenarios: Scenario[] = [
   {
     id: "agents",
     name: "Agent focus",
+    project: "grid",
     description: "A compact view of active, waiting, and quiet agent work.",
     threads: [
       {
@@ -43,6 +48,7 @@ export const scenarios: Scenario[] = [
   {
     id: "gitbutler",
     name: "GitButler repo",
+    project: "bb",
     description: "Repository state without the misleading mega-diff treatment.",
     threads: [
       {
@@ -62,6 +68,7 @@ export const scenarios: Scenario[] = [
   {
     id: "quiet",
     name: "Quiet workspace",
+    project: "bb-mate",
     description: "The resting state should feel useful without feeling empty.",
     threads: [
       {

--- a/apps/workbench/src/styles.css
+++ b/apps/workbench/src/styles.css
@@ -621,6 +621,107 @@ button {
   font-family: "Geist Variable", Geist, sans-serif;
 }
 
+.mate-plugin-card {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: oklch(13% 0.01 260 / 0.58);
+}
+
+.mate-plugin-kind {
+  color: oklch(64% 0.035 255);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.mate-plugin-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.mate-plugin-title-row strong {
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 570;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mate-plugin-title-row span,
+.mate-plugin-path,
+.mate-plugin-statuses,
+.mate-live-link {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+}
+
+.mate-plugin-title-row span,
+.mate-plugin-path {
+  color: oklch(57% 0.018 260);
+}
+
+.mate-plugin-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mate-plugin-statuses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.mate-plugin-statuses span {
+  padding: 3px 6px;
+  border-radius: 999px;
+  color: oklch(61% 0.018 260);
+  background: oklch(24% 0.014 260);
+}
+
+.mate-plugin-statuses span[data-available="true"] {
+  color: oklch(78% 0.09 158);
+  background: oklch(26% 0.04 158 / 0.7);
+}
+
+.mate-plugin-detail,
+.mate-plugin-error {
+  margin: 0;
+  color: oklch(62% 0.015 260);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.mate-plugin-error {
+  color: oklch(74% 0.1 30);
+}
+
+.mate-live-link {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 4px;
+  color: oklch(76% 0.1 255);
+  text-decoration: none;
+}
+
+.mate-live-link:hover {
+  color: oklch(86% 0.08 255);
+}
+
+.mate-live-link svg {
+  width: 11px;
+  height: 11px;
+}
+
 .mate-runtime-line {
   display: flex;
   align-items: center;

--- a/apps/workbench/src/styles.css
+++ b/apps/workbench/src/styles.css
@@ -1,0 +1,439 @@
+:root {
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #17181d;
+  background: #f1f1f4;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+.studio {
+  min-height: 100vh;
+  padding: 28px;
+}
+
+.studio-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1440px;
+  margin: 0 auto 24px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border-radius: 50%;
+  color: white;
+  background: #17181d;
+  font-weight: 750;
+  font-size: 20px;
+}
+
+.brand h1,
+.brand p,
+.scenario-panel h2,
+.scenario-panel p,
+.canvas h2,
+.canvas p {
+  margin: 0;
+}
+
+.brand h1 {
+  font-size: 17px;
+  line-height: 1.2;
+}
+
+.brand p,
+.studio-purpose {
+  margin: 3px 0 0;
+  color: #73747d;
+  font-size: 13px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  max-width: 1440px;
+  min-height: calc(100vh - 118px);
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid #d9d9df;
+  border-radius: 18px;
+  background: #fafafa;
+  box-shadow: 0 18px 60px rgb(25 25 35 / 8%);
+}
+
+.scenario-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 28px 20px;
+  border-right: 1px solid #e2e2e7;
+  background: #fff;
+}
+
+.section-label {
+  color: #8a8b94;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.scenario-panel h2 {
+  margin-top: 8px;
+  font-size: 22px;
+  letter-spacing: -0.03em;
+}
+
+.scenario-panel .scenario-copy {
+  margin-top: 10px;
+  color: #6f7079;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.scenario-list {
+  display: grid;
+  gap: 6px;
+}
+
+.scenario {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 11px 12px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: left;
+}
+
+.scenario small {
+  color: #9a9ba3;
+  font-size: 11px;
+}
+
+.scenario:hover {
+  background: #f5f5f7;
+}
+
+.scenario.active {
+  background: #ececf0;
+  font-weight: 650;
+}
+
+.preview-stage {
+  display: grid;
+  min-width: 0;
+  padding: clamp(22px, 4vw, 56px);
+  place-items: center;
+  background:
+    linear-gradient(rgb(255 255 255 / 56%), rgb(255 255 255 / 56%)),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 23px,
+      #e8e8ed 24px
+    ),
+    repeating-linear-gradient(0deg, transparent, transparent 23px, #e8e8ed 24px);
+}
+
+.preview-window {
+  display: grid;
+  grid-template-columns: 280px minmax(320px, 1fr);
+  width: min(100%, 960px);
+  min-height: 580px;
+  overflow: hidden;
+  border: 1px solid #d5d5dc;
+  border-radius: 14px;
+  background: white;
+  box-shadow: 0 28px 70px rgb(28 29 38 / 14%);
+}
+
+.bb-sidebar {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 12px;
+  border-right: 1px solid #e3e3e8;
+  background: #f8f8fa;
+}
+
+.bb-sidebar-header,
+.bb-brand,
+.bb-sidebar footer {
+  display: flex;
+  align-items: center;
+}
+
+.bb-sidebar-header {
+  justify-content: space-between;
+  padding: 2px 3px 12px;
+}
+
+.bb-brand {
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.bb-dot {
+  width: 15px;
+  height: 15px;
+  border: 4px solid #27282f;
+  border-radius: 50%;
+}
+
+.bb-sidebar-header button {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid #dbdbe1;
+  border-radius: 7px;
+  background: white;
+  cursor: pointer;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 9px;
+  border: 1px solid #dedee4;
+  border-radius: 8px;
+  color: #94959e;
+  background: white;
+}
+
+.search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: #36373d;
+  background: transparent;
+  font-size: 12px;
+}
+
+.thread-section {
+  flex: 1;
+  padding-top: 22px;
+}
+
+.thread-section > p {
+  margin: 0 8px 8px;
+  color: #888992;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.thread-list {
+  display: grid;
+  gap: 3px;
+}
+
+.thread-row {
+  display: grid;
+  grid-template-columns: 9px minmax(0, 1fr);
+  gap: 9px;
+  width: 100%;
+  padding: 9px 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.thread-row:hover {
+  background: #ededf1;
+}
+
+.state-dot {
+  width: 7px;
+  height: 7px;
+  margin-top: 4px;
+  border-radius: 50%;
+  background: #b8b9c0;
+}
+
+.state-dot.running {
+  background: #35a86b;
+  box-shadow: 0 0 0 3px rgb(53 168 107 / 13%);
+}
+
+.state-dot.waiting {
+  background: #d69026;
+}
+
+.thread-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.thread-copy strong,
+.thread-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-copy strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.thread-copy small {
+  color: #8a8b94;
+  font-size: 10px;
+}
+
+.bb-sidebar footer {
+  justify-content: space-between;
+  padding: 10px 5px 2px;
+  border-top: 1px solid #e5e5e9;
+  color: #7d7e87;
+  font-size: 11px;
+}
+
+.connection::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 5px;
+  border-radius: 50%;
+  background: #35a86b;
+  content: "";
+}
+
+.canvas {
+  display: flex;
+  align-items: flex-end;
+  padding: clamp(30px, 6vw, 72px);
+  background: #fff;
+}
+
+.canvas > div {
+  max-width: 430px;
+}
+
+.canvas h2 {
+  margin-top: 10px;
+  font-size: clamp(32px, 5vw, 54px);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.canvas p:last-child {
+  margin-top: 20px;
+  color: #72737c;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 900px) {
+  .studio {
+    padding: 16px;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .scenario-panel {
+    border-right: 0;
+    border-bottom: 1px solid #e2e2e7;
+  }
+
+  .scenario-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .scenario {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
+@media (max-width: 650px) {
+  .studio-purpose {
+    display: none;
+  }
+
+  .scenario-list {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-stage {
+    padding: 14px;
+  }
+
+  .preview-window {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 620px;
+  }
+
+  .bb-sidebar {
+    min-height: 440px;
+    border-right: 0;
+    border-bottom: 1px solid #e3e3e8;
+  }
+
+  .canvas {
+    padding: 30px;
+  }
+}

--- a/apps/workbench/src/styles.css
+++ b/apps/workbench/src/styles.css
@@ -1,26 +1,64 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/geist";
+
+@custom-variant dark (&:is(.dark *));
+
 :root {
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
-  color: #17181d;
-  background: #f1f1f4;
+  color: oklch(32.11% 0 0);
+  background: oklch(100% 0 0);
+  font-family: "Inter Variable", Inter, sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
+
+  --background: oklch(100% 0 0);
+  --foreground: oklch(32.11% 0 0);
+  --card: oklch(100% 0 0);
+  --card-foreground: oklch(32.11% 0 0);
+  --popover: oklch(100% 0 0);
+  --popover-foreground: oklch(32.11% 0 0);
+  --primary: oklch(32.11% 0 0);
+  --primary-foreground: oklch(100% 0 0);
+  --secondary: oklch(96% 0 0);
+  --secondary-foreground: oklch(32.11% 0 0);
+  --muted: oklch(96% 0 0);
+  --muted-foreground: oklch(44% 0 0);
+  --accent: oklch(94% 0 0);
+  --accent-foreground: oklch(32.11% 0 0);
+  --destructive: oklch(57.7% 0.245 27.325);
+  --border: color-mix(in oklch, oklch(32.11% 0 0) 9.5%, white);
+  --input: color-mix(in oklch, oklch(32.11% 0 0) 14%, white);
+  --ring: oklch(70.8% 0 0);
+  --radius: 0.5rem;
+
+  --bb-sidebar-width: 320px;
+  --bb-sidebar-row-height: 1.75rem;
+  --bb-sidebar-row-height-coarse: 2.5rem;
+  --bb-sidebar: color-mix(in oklch, oklch(32.11% 0 0) 2.2%, white);
+  --bb-sidebar-foreground: oklch(32.11% 0 0);
+  --bb-sidebar-accent: color-mix(in oklch, oklch(32.11% 0 0) 8%, white);
+  --bb-sidebar-border: color-mix(in oklch, oklch(32.11% 0 0) 9.5%, white);
+  --bb-subtle-foreground: oklab(0.5 0 0 / 0.75);
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 320px;
+  height: 100%;
+  min-height: 100%;
+  overflow: hidden;
+}
+
 body {
   margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
 }
 
 button,
@@ -30,346 +68,6 @@ input {
 
 button {
   color: inherit;
-}
-
-.studio {
-  min-height: 100vh;
-  padding: 28px;
-}
-
-.studio-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 1440px;
-  margin: 0 auto 24px;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.brand-mark {
-  display: grid;
-  width: 42px;
-  height: 42px;
-  place-items: center;
-  border-radius: 50%;
-  color: white;
-  background: #17181d;
-  font-weight: 750;
-  font-size: 20px;
-}
-
-.brand h1,
-.brand p,
-.scenario-panel h2,
-.scenario-panel p,
-.canvas h2,
-.canvas p {
-  margin: 0;
-}
-
-.brand h1 {
-  font-size: 17px;
-  line-height: 1.2;
-}
-
-.brand p,
-.studio-purpose {
-  margin: 3px 0 0;
-  color: #73747d;
-  font-size: 13px;
-}
-
-.workspace {
-  display: grid;
-  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
-  max-width: 1440px;
-  min-height: calc(100vh - 118px);
-  margin: 0 auto;
-  overflow: hidden;
-  border: 1px solid #d9d9df;
-  border-radius: 18px;
-  background: #fafafa;
-  box-shadow: 0 18px 60px rgb(25 25 35 / 8%);
-}
-
-.scenario-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  padding: 28px 20px;
-  border-right: 1px solid #e2e2e7;
-  background: #fff;
-}
-
-.section-label {
-  color: #8a8b94;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.scenario-panel h2 {
-  margin-top: 8px;
-  font-size: 22px;
-  letter-spacing: -0.03em;
-}
-
-.scenario-panel .scenario-copy {
-  margin-top: 10px;
-  color: #6f7079;
-  font-size: 14px;
-  line-height: 1.5;
-}
-
-.scenario-list {
-  display: grid;
-  gap: 6px;
-}
-
-.scenario {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 11px 12px;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
-  cursor: pointer;
-  font-size: 13px;
-  text-align: left;
-}
-
-.scenario small {
-  color: #9a9ba3;
-  font-size: 11px;
-}
-
-.scenario:hover {
-  background: #f5f5f7;
-}
-
-.scenario.active {
-  background: #ececf0;
-  font-weight: 650;
-}
-
-.preview-stage {
-  display: grid;
-  min-width: 0;
-  padding: clamp(22px, 4vw, 56px);
-  place-items: center;
-  background:
-    linear-gradient(rgb(255 255 255 / 56%), rgb(255 255 255 / 56%)),
-    repeating-linear-gradient(
-      90deg,
-      transparent,
-      transparent 23px,
-      #e8e8ed 24px
-    ),
-    repeating-linear-gradient(0deg, transparent, transparent 23px, #e8e8ed 24px);
-}
-
-.preview-window {
-  display: grid;
-  grid-template-columns: 280px minmax(320px, 1fr);
-  width: min(100%, 960px);
-  min-height: 580px;
-  overflow: hidden;
-  border: 1px solid #d5d5dc;
-  border-radius: 14px;
-  background: white;
-  box-shadow: 0 28px 70px rgb(28 29 38 / 14%);
-}
-
-.bb-sidebar {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  padding: 12px;
-  border-right: 1px solid #e3e3e8;
-  background: #f8f8fa;
-}
-
-.bb-sidebar-header,
-.bb-brand,
-.bb-sidebar footer {
-  display: flex;
-  align-items: center;
-}
-
-.bb-sidebar-header {
-  justify-content: space-between;
-  padding: 2px 3px 12px;
-}
-
-.bb-brand {
-  gap: 7px;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.bb-dot {
-  width: 15px;
-  height: 15px;
-  border: 4px solid #27282f;
-  border-radius: 50%;
-}
-
-.bb-sidebar-header button {
-  display: grid;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  place-items: center;
-  border: 1px solid #dbdbe1;
-  border-radius: 7px;
-  background: white;
-  cursor: pointer;
-}
-
-.search {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 7px 9px;
-  border: 1px solid #dedee4;
-  border-radius: 8px;
-  color: #94959e;
-  background: white;
-}
-
-.search input {
-  width: 100%;
-  min-width: 0;
-  border: 0;
-  outline: 0;
-  color: #36373d;
-  background: transparent;
-  font-size: 12px;
-}
-
-.thread-section {
-  flex: 1;
-  padding-top: 22px;
-}
-
-.thread-section > p {
-  margin: 0 8px 8px;
-  color: #888992;
-  font-size: 11px;
-  font-weight: 650;
-}
-
-.thread-list {
-  display: grid;
-  gap: 3px;
-}
-
-.thread-row {
-  display: grid;
-  grid-template-columns: 9px minmax(0, 1fr);
-  gap: 9px;
-  width: 100%;
-  padding: 9px 8px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-}
-
-.thread-row:hover {
-  background: #ededf1;
-}
-
-.state-dot {
-  width: 7px;
-  height: 7px;
-  margin-top: 4px;
-  border-radius: 50%;
-  background: #b8b9c0;
-}
-
-.state-dot.running {
-  background: #35a86b;
-  box-shadow: 0 0 0 3px rgb(53 168 107 / 13%);
-}
-
-.state-dot.waiting {
-  background: #d69026;
-}
-
-.thread-copy {
-  display: grid;
-  min-width: 0;
-  gap: 3px;
-}
-
-.thread-copy strong,
-.thread-copy small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.thread-copy strong {
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.thread-copy small {
-  color: #8a8b94;
-  font-size: 10px;
-}
-
-.bb-sidebar footer {
-  justify-content: space-between;
-  padding: 10px 5px 2px;
-  border-top: 1px solid #e5e5e9;
-  color: #7d7e87;
-  font-size: 11px;
-}
-
-.connection::before {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  margin-right: 5px;
-  border-radius: 50%;
-  background: #35a86b;
-  content: "";
-}
-
-.canvas {
-  display: flex;
-  align-items: flex-end;
-  padding: clamp(30px, 6vw, 72px);
-  background: #fff;
-}
-
-.canvas > div {
-  max-width: 430px;
-}
-
-.canvas h2 {
-  margin-top: 10px;
-  font-size: clamp(32px, 5vw, 54px);
-  line-height: 0.98;
-  letter-spacing: -0.055em;
-}
-
-.canvas p:last-child {
-  margin-top: 20px;
-  color: #72737c;
-  font-size: 14px;
-  line-height: 1.6;
 }
 
 .sr-only {
@@ -384,56 +82,631 @@ button {
   border: 0;
 }
 
-@media (max-width: 900px) {
-  .studio {
-    padding: 16px;
-  }
+/* The bb surface intentionally mirrors the production client's measured
+   tokens. Mate chrome is scoped separately below. */
+.bb-app {
+  display: flex;
+  width: 100%;
+  height: 100dvh;
+  background: var(--background);
+}
 
-  .workspace {
-    grid-template-columns: 1fr;
-  }
+.bb-sidebar {
+  position: relative;
+  display: flex;
+  flex: 0 0 var(--bb-sidebar-width);
+  flex-direction: column;
+  width: var(--bb-sidebar-width);
+  min-width: 0;
+  height: 100dvh;
+  color: var(--bb-sidebar-foreground);
+  background: var(--bb-sidebar);
+  border-right: 1px solid var(--bb-sidebar-border);
+  font-size: 13px;
+  line-height: 1.4286;
+}
 
-  .scenario-panel {
-    border-right: 0;
-    border-bottom: 1px solid #e2e2e7;
-  }
+.bb-sidebar button,
+.bb-main button {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
 
-  .scenario-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+.bb-sidebar button:focus-visible,
+.bb-main button:focus-visible {
+  outline: 2px solid
+    color-mix(in oklch, var(--bb-sidebar-foreground) 30%, transparent);
+  outline-offset: -2px;
+}
 
-  .scenario {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 4px;
+.bb-sidebar-chrome {
+  display: flex;
+  flex: 0 0 48px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px;
+}
+
+.bb-history-actions,
+.bb-sidebar-footer {
+  display: flex;
+  align-items: center;
+}
+
+.bb-history-actions {
+  gap: 2px;
+  color: oklab(0.5 0 0 / 0.5);
+}
+
+.bb-icon-button,
+.bb-compose-icon {
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+  border-radius: 6px;
+}
+
+.bb-icon-button:hover,
+.bb-compose-icon:hover {
+  background: var(--bb-sidebar-accent);
+}
+
+.bb-primary-actions {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 8px;
+}
+
+.bb-sidebar-row {
+  display: flex;
+  width: 100%;
+  height: var(--bb-sidebar-row-height);
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border-radius: 6px;
+  color: oklab(0.3211 0 0 / 0.85);
+  text-align: left;
+}
+
+.bb-sidebar-row:hover,
+.bb-thread-row:hover {
+  color: var(--bb-sidebar-foreground);
+  background: var(--bb-sidebar-accent);
+}
+
+.bb-row-end {
+  display: inline-flex;
+  margin-left: auto;
+  align-items: center;
+}
+
+.bb-search-glyph {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  margin-right: -8px;
+  place-items: center;
+}
+
+.bb-sidebar-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  scrollbar-width: none;
+}
+
+.bb-project-section {
+  padding: 0 8px 8px;
+}
+
+.bb-section-heading {
+  display: flex;
+  height: 28px;
+  align-items: center;
+  padding: 0 8px;
+  color: var(--bb-subtle-foreground);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.bb-thread-list {
+  display: grid;
+  gap: 2px;
+}
+
+.bb-thread-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  width: 100%;
+  height: var(--bb-sidebar-row-height);
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border-radius: 6px;
+  color: oklab(0.3211 0 0 / 0.85);
+  text-align: left;
+}
+
+.bb-thread-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bb-state-glyph {
+  order: 2;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: oklch(65% 0 0);
+}
+
+.bb-state-glyph.idle {
+  opacity: 0;
+}
+
+.bb-state-glyph.running {
+  background: oklch(66% 0.17 154);
+  box-shadow: 0 0 0 3px oklch(66% 0.17 154 / 0.12);
+}
+
+.bb-state-glyph.waiting {
+  background: oklch(72% 0.15 73);
+}
+
+.bb-loose-section {
+  margin-top: 10px;
+}
+
+.bb-empty-row {
+  display: flex;
+  height: 28px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  color: oklab(0.5 0 0 / 0.6);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.bb-empty-icon {
+  display: grid;
+  width: 14px;
+  height: 14px;
+  place-items: center;
+  opacity: 0.5;
+}
+
+.bb-sidebar-footer {
+  flex: 0 0 44px;
+  gap: 12px;
+  padding: 8px;
+  color: oklab(0.3211 0 0 / 0.65);
+}
+
+.bb-main {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  justify-content: center;
+  background: var(--background);
+}
+
+.bb-right-panel-button {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  place-items: center;
+  border-radius: 6px;
+}
+
+.bb-mobile-sidebar-button {
+  display: none;
+}
+
+.bb-mobile-sidebar-backdrop {
+  display: none;
+}
+
+.bb-compose-wrap {
+  width: min(calc(100% - 80px), 796px);
+  margin-top: 70px;
+}
+
+.bb-composer {
+  display: flex;
+  height: 128px;
+  flex-direction: column;
+  border: 1px solid color-mix(in oklch, var(--foreground) 18%, white);
+  border-radius: 12px;
+  background: var(--background);
+  box-shadow: 0 1px 5px oklch(0% 0 0 / 0.06);
+}
+
+.bb-composer-editor {
+  width: 100%;
+  height: 80px;
+  padding: 12px 56px 4px 16px;
+}
+
+.bb-placeholder {
+  margin: 0;
+  color: oklab(0.5 0 0 / 0.65);
+  font-size: 13px;
+  font-weight: 300;
+  line-height: 1.625;
+}
+
+.bb-composer-toolbar {
+  display: flex;
+  height: 46px;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 8px 8px 14px;
+}
+
+.bb-composer-toolbar .bb-compose-icon {
+  width: 32px;
+  height: 32px;
+}
+
+.bb-composer-toolbar .bb-compose-icon:first-child {
+  margin-left: -6px;
+}
+
+.bb-model-button,
+.bb-compose-options button {
+  display: flex;
+  height: 32px;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px;
+  border-radius: 6px;
+  color: oklab(0.3211 0 0 / 0.82);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.bb-model-button:hover,
+.bb-compose-options button:hover,
+.bb-right-panel-button:hover {
+  background: oklch(96% 0 0);
+}
+
+.bb-provider-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.bb-compose-spacer {
+  flex: 1;
+}
+
+.bb-submit-button {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  place-items: center;
+  border-radius: 8px;
+  color: white;
+  background: oklch(70% 0 0) !important;
+}
+
+.bb-submit-button:disabled {
+  cursor: default;
+}
+
+.bb-compose-options {
+  display: flex;
+  height: 32px;
+  margin-top: 4px;
+  justify-content: space-between;
+  padding: 0 14px;
+}
+
+/* Mate is intentionally a separate, always-dark dev instrument. These
+   semantic overrides keep its shadcn/Base UI primitives independent of bb. */
+.mate-overlay,
+.mate-popover,
+.mate-select-content {
+  --background: oklch(18% 0.012 260);
+  --foreground: oklch(96% 0.006 260);
+  --popover: oklch(18% 0.012 260);
+  --popover-foreground: oklch(96% 0.006 260);
+  --primary: oklch(92% 0.01 260);
+  --primary-foreground: oklch(17% 0.012 260);
+  --secondary: oklch(24% 0.014 260);
+  --secondary-foreground: oklch(94% 0.006 260);
+  --muted: oklch(24% 0.014 260);
+  --muted-foreground: oklch(70% 0.018 260);
+  --accent: oklch(27% 0.018 260);
+  --accent-foreground: oklch(97% 0.006 260);
+  --border: oklch(32% 0.018 260);
+  --input: oklch(32% 0.018 260);
+  --ring: oklch(76% 0.1 255);
+  color-scheme: dark;
+}
+
+.mate-overlay {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  font-family: "Geist Variable", Geist, sans-serif;
+}
+
+.mate-fab {
+  width: 46px;
+  height: 46px;
+  border: 1px solid oklch(38% 0.02 260);
+  border-radius: 15px;
+  color: oklch(96% 0.006 260);
+  background: oklch(18% 0.012 260);
+  box-shadow:
+    0 14px 38px oklch(0% 0 0 / 0.24),
+    inset 0 1px 0 oklch(100% 0 0 / 0.07);
+}
+
+.mate-fab:hover,
+.mate-fab[aria-expanded="true"] {
+  background: oklch(23% 0.017 260);
+}
+
+.mate-fab::after {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: oklch(78% 0.13 255);
+  box-shadow: 0 0 9px oklch(78% 0.13 255 / 0.8);
+  content: "";
+}
+
+.mate-popover {
+  width: min(340px, calc(100vw - 24px));
+  gap: 14px;
+  padding: 15px;
+  overflow: hidden;
+  border: 1px solid oklch(33% 0.018 260);
+  border-radius: 18px;
+  background:
+    linear-gradient(135deg, oklch(24% 0.04 255 / 0.45), transparent 32%),
+    var(--popover);
+  box-shadow:
+    0 24px 70px oklch(0% 0 0 / 0.35),
+    inset 0 1px 0 oklch(100% 0 0 / 0.06);
+}
+
+.mate-popover::before {
+  position: absolute;
+  top: 0;
+  left: 18px;
+  width: 78px;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    oklch(78% 0.13 255),
+    transparent
+  );
+  content: "";
+}
+
+.mate-panel-header {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.mate-heading-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mate-heading-copy [data-slot="popover-title"] {
+  color: var(--foreground);
+  font-size: 15px;
+  font-weight: 570;
+  letter-spacing: -0.015em;
+}
+
+.mate-kicker {
+  color: oklch(76% 0.1 255);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.16em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.mate-divider {
+  height: 1px;
+  background: var(--border);
+}
+
+.mate-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.mate-field-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: oklch(78% 0.012 260);
+  font-size: 11px;
+  font-weight: 520;
+  letter-spacing: 0.01em;
+}
+
+.mate-source-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: oklch(66% 0.018 260);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mate-source-status i {
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: oklch(78% 0.13 255);
+  box-shadow: 0 0 7px oklch(78% 0.13 255 / 0.65);
+}
+
+.mate-source-toggle {
+  width: 100%;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: oklch(13% 0.01 260 / 0.8);
+}
+
+.mate-source-toggle [data-slot="toggle-group-item"] {
+  flex: 1;
+  border-radius: 8px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.mate-source-toggle [aria-pressed="true"] {
+  color: var(--foreground);
+  background: var(--muted);
+  box-shadow: inset 0 1px 0 oklch(100% 0 0 / 0.05);
+}
+
+.mate-source-toggle [disabled] {
+  opacity: 0.36;
+}
+
+.mate-help {
+  margin: 0;
+  color: oklch(62% 0.015 260);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.mate-select-trigger {
+  width: 100%;
+  color: var(--foreground);
+  background: oklch(13% 0.01 260 / 0.72);
+}
+
+.mate-select-content {
+  font-family: "Geist Variable", Geist, sans-serif;
+}
+
+.mate-runtime-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 2px;
+  color: oklch(55% 0.015 260);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  letter-spacing: 0.04em;
+}
+
+.mate-runtime-line code {
+  color: oklch(72% 0.06 255);
+  font: inherit;
+}
+
+@media (pointer: coarse) {
+  .bb-sidebar-row,
+  .bb-thread-row {
+    height: var(--bb-sidebar-row-height-coarse);
   }
 }
 
-@media (max-width: 650px) {
-  .studio-purpose {
-    display: none;
-  }
-
-  .scenario-list {
-    grid-template-columns: 1fr;
-  }
-
-  .preview-stage {
-    padding: 14px;
-  }
-
-  .preview-window {
-    grid-template-columns: minmax(0, 1fr);
-    min-height: 620px;
-  }
-
+@media (max-width: 767px) {
   .bb-sidebar {
-    min-height: 440px;
-    border-right: 0;
-    border-bottom: 1px solid #e3e3e8;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 30;
+    display: flex;
+    transform: translateX(-100%);
+    box-shadow: 16px 0 48px oklch(0% 0 0 / 0.12);
+    transition: transform 180ms ease-out;
   }
 
-  .canvas {
-    padding: 30px;
+  .bb-sidebar.mobile-open {
+    transform: translateX(0);
+  }
+
+  .bb-mobile-sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 20;
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background: oklch(0% 0 0 / 0.12);
+    backdrop-filter: blur(1px);
+  }
+
+  .bb-mobile-sidebar-button {
+    position: absolute;
+    top: 14px;
+    left: 14px;
+    display: grid;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    place-items: center;
+    border-radius: 6px;
+  }
+
+  .bb-mobile-sidebar-button:hover {
+    background: oklch(96% 0 0);
+  }
+
+  .bb-compose-wrap {
+    width: calc(100% - 32px);
+  }
+
+  .mate-overlay {
+    right: 12px;
+    bottom: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/apps/workbench/src/usePluginInspection.ts
+++ b/apps/workbench/src/usePluginInspection.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import type { PluginInspection } from "@/plugin-inspection";
+
+interface InspectionResult {
+  inspection: PluginInspection | null;
+  error: string | null;
+}
+
+export function usePluginInspection(): InspectionResult {
+  const [result, setResult] = useState<InspectionResult>({
+    inspection: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch("/bb-mate-plugin.json", {
+      signal: controller.signal,
+      cache: "no-store",
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Plugin inspection failed with HTTP ${response.status}`,
+          );
+        }
+        return (await response.json()) as PluginInspection;
+      })
+      .then((inspection) => setResult({ inspection, error: null }))
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setResult({
+          inspection: null,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    return () => controller.abort();
+  }, []);
+
+  return result;
+}

--- a/apps/workbench/tsconfig.json
+++ b/apps/workbench/tsconfig.json
@@ -11,6 +11,10 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/apps/workbench/tsconfig.json
+++ b/apps/workbench/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["bun", "vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/workbench/tsconfig.json
+++ b/apps/workbench/tsconfig.json
@@ -21,5 +21,5 @@
     "jsx": "react-jsx",
     "types": ["bun", "vite/client"]
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "plugin-inspection-server.ts", "vite.config.ts"]
 }

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -1,6 +1,13 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
 });

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -2,9 +2,19 @@ import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { pluginInspectionPlugin } from "./plugin-inspection-server";
+
+const workspaceRoot = path.resolve(__dirname, "../..");
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    pluginInspectionPlugin({
+      workspaceRoot,
+      targetPath: process.env.BB_MATE_PLUGIN,
+    }),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/bun.lock
+++ b/bun.lock
@@ -12,16 +12,44 @@
       "name": "@bb-mate/workbench",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "^1.7.0",
+        "@fontsource-variable/geist": "^5.3.0",
+        "@fontsource-variable/inter": "^5.3.0",
+        "@hugeicons/core-free-icons": "^4.1.3",
+        "@hugeicons/react": "^1.1.6",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.29.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "shadcn": "^4.16.2",
+        "tailwind-merge": "^3.6.0",
+        "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.3.3",
         "@types/bun": "^1.3.4",
+        "@types/node": "^26.1.2",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.2",
+        "tailwindcss": "^4.3.3",
         "typescript": "^5.9.2",
         "vite": "^7.1.3",
+      },
+    },
+    "plugins/linear": {
+      "name": "bb-plugin-linear",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "better-sqlite3": "^12.0.0",
+        "hono": "^4.11.9",
+        "typescript": "^5.7.0",
+        "vitest": "^3.2.4",
+        "zod": "^4.3.6",
       },
     },
   },
@@ -34,15 +62,27 @@
 
     "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
 
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" } }, "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw=="],
+
     "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
 
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-member-expression-to-functions": "^7.29.7", "@babel/helper-optimise-call-expression": "^7.29.7", "@babel/helper-replace-supers": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7", "@babel/traverse": "^7.29.7", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg=="],
+
     "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg=="],
 
     "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
 
     "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
 
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" } }, "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong=="],
+
     "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.29.7", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.29.7", "@babel/helper-optimise-call-expression": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
@@ -54,9 +94,21 @@
 
     "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
 
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA=="],
+
+    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.29.7", "", { "dependencies": { "@babel/helper-module-transforms": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ=="],
+
     "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
 
     "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.29.7", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.29.7", "@babel/helper-create-class-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7", "@babel/plugin-syntax-typescript": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw=="],
+
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "@babel/plugin-syntax-jsx": "^7.29.7", "@babel/plugin-transform-modules-commonjs": "^7.29.7", "@babel/plugin-transform-typescript": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
@@ -64,7 +116,15 @@
 
     "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
+    "@base-ui/react": ["@base-ui/react@1.7.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.2", "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
+
     "@bb-mate/workbench": ["@bb-mate/workbench@workspace:apps/workbench"],
+
+    "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
+
+    "@dotenvx/primitives": ["@dotenvx/primitives@0.8.0", "", {}, "sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -118,6 +178,24 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@fontsource-variable/geist": ["@fontsource-variable/geist@5.3.0", "", {}, "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA=="],
+
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+
+    "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
+
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.2.3", "", {}, "sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA=="],
+
+    "@hugeicons/react": ["@hugeicons/react@1.1.9", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -128,7 +206,15 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
+
     "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -182,6 +268,42 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
 
+    "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
+
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
+
+    "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
@@ -190,7 +312,13 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
@@ -200,55 +328,499 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
+    "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.7", "", { "dependencies": { "@vitest/spy": "3.2.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.7", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.7", "", { "dependencies": { "@vitest/utils": "3.2.7", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.7", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
+
+    "atomically": ["atomically@1.7.0", "", {}, "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA=="],
 
+    "bb-plugin-linear": ["bb-plugin-linear@workspace:plugins/linear"],
+
+    "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001807", "", {}, "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "conf": ["conf@10.2.0", "", { "dependencies": { "ajv": "^8.6.3", "ajv-formats": "^2.1.1", "atomically": "^1.7.0", "debounce-fn": "^4.0.0", "dot-prop": "^6.0.1", "env-paths": "^2.2.1", "json-schema-typed": "^7.0.3", "onetime": "^5.1.2", "pkg-up": "^3.1.0", "semver": "^7.3.5" } }, "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debounce-fn": ["debounce-fn@4.0.0", "", { "dependencies": { "mimic-fn": "^3.0.0" } }, "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
+
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.402", "", {}, "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
+
+    "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "fs-extra": ["fs-extra@11.4.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
+
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-own-enumerable-keys": ["get-own-enumerable-keys@1.0.0", "", {}, "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-obj": ["is-obj@3.0.0", "", {}, "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
+
+    "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
+    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+
+    "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "mimic-fn": ["mimic-fn@3.1.0", "", {}, "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
+
     "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
+
+    "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
     "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
@@ -256,24 +828,258 @@
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "recast": ["recast@0.23.19", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-T98lym7kH+pnZmRaD8yDRdaNqyUbwnbEBx0MuchrzMFOEMray4AO3ZJoTUZ5r78Ao78X/OhzW0DL8GB85w/I2w=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
     "rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shadcn": ["shadcn@4.16.2", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "kleur": "^4.1.5", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "undici": "^7.27.2", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-M1AvZKFWcCzWRDoyApIqJMSLIpY8Ev4uBGuiPLSFmiTbixXhPmzotSTvLzFmBrfoIxG9aIg2dZOETblEaXGUnQ=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "stringify-object": ["stringify-object@5.0.0", "", { "dependencies": { "get-own-enumerable-keys": "^1.0.0", "is-obj": "^3.0.0", "is-regexp": "^3.1.0" } }, "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "systeminformation": ["systeminformation@5.33.1", "", { "os": "!aix", "bin": { "systeminformation": "lib/cli.js" } }, "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
+
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
+
+    "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.7", "@vitest/mocker": "3.2.7", "@vitest/pretty-format": "^3.2.7", "@vitest/runner": "3.2.7", "@vitest/snapshot": "3.2.7", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.7", "@vitest/ui": "3.2.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg=="],
+
+    "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yocto-spinner": ["yocto-spinner@1.2.2", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng=="],
+
+    "yoctocolors": ["yoctocolors@2.2.0", "", {}, "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "@dotenvx/dotenvx/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" }, "bundled": true }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "bb-plugin-linear/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "conf/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+
+    "conf/json-schema-typed": ["json-schema-typed@7.0.3", "", {}, "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="],
+
+    "conf/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
+    "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "node-abi/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "@dotenvx/dotenvx/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "@dotenvx/dotenvx/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "@dotenvx/dotenvx/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "@dotenvx/dotenvx/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "@dotenvx/dotenvx/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
+
+    "bb-plugin-linear/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,279 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bb-mate",
+      "devDependencies": {
+        "prettier": "^3.6.2",
+      },
+    },
+    "apps/workbench": {
+      "name": "@bb-mate/workbench",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.4",
+        "@types/react": "^19.1.10",
+        "@types/react-dom": "^19.1.7",
+        "@vitejs/plugin-react": "^5.0.2",
+        "typescript": "^5.9.2",
+        "vite": "^7.1.3",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@bb-mate/workbench": ["@bb-mate/workbench@workspace:apps/workbench"],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.4", "", { "os": "android", "cpu": "arm" }, "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.4", "", { "os": "android", "cpu": "arm64" }, "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.4", "", { "os": "none", "cpu": "arm64" }, "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA=="],
+
+    "browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001807", "", {}, "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.402", "", {}, "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+
+    "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
+
+    "rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
+        "bb-app": "0.35.1",
         "better-sqlite3": "^12.0.0",
         "hono": "^4.11.9",
         "typescript": "^5.7.0",
@@ -216,6 +217,36 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.4", "", { "os": "android", "cpu": "arm" }, "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg=="],
@@ -362,6 +393,8 @@
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "atomically": ["atomically@1.7.0", "", {}, "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -369,6 +402,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA=="],
+
+    "bb-app": ["bb-app@0.35.1", "", { "dependencies": { "@parcel/watcher": "2.5.6", "@tailwindcss/node": "^4.3.0", "@tailwindcss/oxide": "^4.3.0", "better-sqlite3": "12.10.0", "esbuild": "^0.28.0", "hono": "^4.7.0", "jiti": "^2.6.1", "node-pty": "1.1.0", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "pino-roll": "^4.0.0", "tailwindcss": "^4.3.0", "zod": "4.3.6" }, "os": [ "linux", "darwin", ], "bin": { "bb": "dist/bb.js", "bb-app": "dist/bb-app.js", "bb-server": "dist/bb-server.js", "bb-host-daemon": "dist/bb-host-daemon.js" } }, "sha512-gY0REaRmyMMVDsPsY102r18yeYHI9qYFBPxkrh4jkD6/qII77b4ctwWg1OwmeXnAYtkxN6TSYka9IwS6KUq+ZA=="],
 
     "bb-plugin-linear": ["bb-plugin-linear@workspace:plugins/linear"],
 
@@ -422,6 +457,8 @@
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "conf": ["conf@10.2.0", "", { "dependencies": { "ajv": "^8.6.3", "ajv-formats": "^2.1.1", "atomically": "^1.7.0", "debounce-fn": "^4.0.0", "dot-prop": "^6.0.1", "env-paths": "^2.2.1", "json-schema-typed": "^7.0.3", "onetime": "^5.1.2", "pkg-up": "^3.1.0", "semver": "^7.3.5" } }, "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg=="],
@@ -445,6 +482,10 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "debounce-fn": ["debounce-fn@4.0.0", "", { "dependencies": { "mimic-fn": "^3.0.0" } }, "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ=="],
 
@@ -530,9 +571,13 @@
 
     "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
 
+    "fast-copy": ["fast-copy@4.0.4", "", {}, "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
@@ -587,6 +632,8 @@
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
 
@@ -645,6 +692,8 @@
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -740,6 +789,10 @@
 
     "node-abi": ["node-abi@3.94.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g=="],
 
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
     "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
 
     "npm-run-path": ["npm-run-path@6.0.0", "", { "dependencies": { "path-key": "^4.0.0", "unicorn-magic": "^0.3.0" } }, "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA=="],
@@ -749,6 +802,8 @@
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
@@ -790,6 +845,16 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-roll": ["pino-roll@4.0.0", "", { "dependencies": { "date-fns": "^4.1.0", "sonic-boom": "^4.0.1" } }, "sha512-axI1aQaIxXdw1F4OFFli1EDxIrdYNGLowkw/ZoZogX8oCSLHUghzwVVXUS8U+xD/Savwa5IXpiXmsSGKFX/7Sg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
@@ -806,6 +871,8 @@
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
+    "process-warning": ["process-warning@5.1.0", "", {}, "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -815,6 +882,8 @@
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 
@@ -829,6 +898,8 @@
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recast": ["recast@0.23.19", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-T98lym7kH+pnZmRaD8yDRdaNqyUbwnbEBx0MuchrzMFOEMray4AO3ZJoTUZ5r78Ao78X/OhzW0DL8GB85w/I2w=="],
 
@@ -852,9 +923,13 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -888,9 +963,13 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -912,7 +991,7 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
@@ -927,6 +1006,8 @@
     "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -1022,6 +1103,10 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "bb-app/better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+
+    "bb-app/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "bb-plugin-linear/@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
@@ -1050,7 +1135,11 @@
 
     "onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,57 @@ BB Mate is downstream of bb. The sibling `../bb` checkout is the live reference 
 
 Fixtures should describe product state rather than mirror private bb database or React types. Adapters can translate those fixtures into components. This keeps prototypes stable when upstream internals change.
 
+The workbench puts the bb surface directly in the viewport. Workbench controls
+belong in the collapsible Mate overlay, not in a permanent wrapper around the
+prototype. The overlay uses vendored shadcn/Base UI source and has its own dark
+theme; bb-facing views use bb's typography, icon family, and measured semantic
+tokens.
+
+`SidebarListView` is the current host-neutral seam. The workbench supplies its
+model from deterministic scenarios. A future plugin adapter can supply the same
+model from `experimental_useSidebarThreads` and related public action hooks,
+while bb continues to render the actual New Thread, search, navigation, and
+footer chrome around the slot.
+
+## Upstream alignment
+
+Exactness has two levels:
+
+1. In standalone fixture mode, the live bb Connect client is the visual oracle.
+   Measured tokens and screenshot comparisons keep the replica honest, but it is
+   still a replica.
+2. In live plugin mode, bb itself renders the host chrome and provides state
+   through `@bb/plugin-sdk/app`. This is the production-exact surface and should
+   be the final validation environment for plugin UI.
+
+Stay attached to upstream through supported versioned boundaries:
+
+- Every plugin declares honest `engines.bb` and `engines.bbPluginSdk` ranges.
+- Plugin UI primitives are vendored through the bb component registry version
+  that matches the target bb release. Use the shadcn CLI's `--dry-run` and
+  `--diff` flow when updating; do not copy raw application files.
+- Hugeicons and bb-facing type/token choices track the versions used by the
+  target bb release.
+- The sibling `../bb` checkout and installed Connect client are read-only
+  contract/visual references. Hashed desktop assets are never imported.
+
+A follow-up should automate upstream drift detection: record the target bb and
+plugin SDK release, compare the bb registry manifest and the small set of
+measured sidebar tokens, then fail a dedicated parity check when they move.
+
+## Runtime sources
+
+The source control in the Mate overlay represents adapters, not a browser data
+fetch:
+
+- **Fixtures** are always available in `apps/workbench`.
+- **Live bb** becomes available when the view is mounted by a bb plugin and the
+  public SDK adapter is present.
+
+Do not proxy, scrape, or iframe an authenticated bb Connect session to simulate
+live state. Even when a client can be displayed, cross-origin content is not a
+state/action contract and cannot safely drive plugin behavior.
+
 ## Plugins
 
 Each directory under `plugins/` is an independent package. A plugin owns its manifest, backend entry, optional frontend entry, tests, assets, and version. Local development uses path installation so bb loads the package in place.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,33 @@ Do not proxy, scrape, or iframe an authenticated bb Connect session to simulate
 live state. Even when a client can be displayed, cross-origin content is not a
 state/action contract and cannot safely drive plugin behavior.
 
+### Plugin inspection
+
+The workbench dev server may inspect one explicit plugin directory. Inspection
+is data-only: it reads the ordinary package manifest, native
+`dist/server.meta.json` and `dist/app.meta.json`, and the JSON output of native
+bb commands. It must not evaluate the plugin entrypoint, mount a content script,
+or introduce a BB Mate manifest.
+
+The official SDK frontend collector currently exposes these registration
+groups, which define the eventual surface inventory:
+
+- homepage and settings sections
+- navigation panels and thread-panel actions
+- composer customizations and pending interactions
+- sidebar footer actions and thread-list replacements
+- thread-header actions and file openers
+- message directives and message actions
+- trusted content scripts
+
+Component registrations can receive deterministic behavior through
+`loadPluginApp` and `renderSlot`. Content scripts require the explicit
+`mountPluginContentScripts` lifecycle and must never be mounted during ordinary
+discovery. Host-rendered actions still require live bb for their real chrome.
+
+Until `@bb/plugin-sdk` is publicly installable, the workbench exposes Harness as
+an unavailable capability. The sibling checkout is not a fallback dependency.
+
 ## Plugins
 
 Each directory under `plugins/` is an independent package. A plugin owns its manifest, backend entry, optional frontend entry, tests, assets, and version. Local development uses path installation so bb loads the package in place.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,21 @@
+# Architecture
+
+## Repository boundary
+
+BB Mate is downstream of bb. The sibling `../bb` checkout is the live reference for public plugin SDK contracts and host behavior, but it is not part of this Bun workspace.
+
+## Workbench
+
+`apps/workbench` renders deterministic approximations of bb states in an ordinary browser. Its job is fast visual iteration, comparison, and discussion without booting the desktop app or manufacturing real repository state.
+
+Fixtures should describe product state rather than mirror private bb database or React types. Adapters can translate those fixtures into components. This keeps prototypes stable when upstream internals change.
+
+## Plugins
+
+Each directory under `plugins/` is an independent package. A plugin owns its manifest, backend entry, optional frontend entry, tests, assets, and version. Local development uses path installation so bb loads the package in place.
+
+Plugin UI can share host-neutral components with the workbench once a second consumer proves the boundary. Code that imports `@bb/plugin-sdk/app` stays inside the plugin adapter or entrypoint because that runtime only exists inside bb.
+
+## Distribution
+
+bb supports managed npm installation with `bb plugin install npm:<package>@<range>`. The intended release model is independent npm packages published from `plugins/*` by CI. Git monorepo subdirectory installation is proposed upstream in [get-bb/bb#1097](https://github.com/get-bb/bb/issues/1097).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,13 @@ discovery. Host-rendered actions still require live bb for their real chrome.
 
 Until `@bb/plugin-sdk` is publicly installable, the workbench exposes Harness as
 an unavailable capability. The sibling checkout is not a fallback dependency.
+[get-bb/bb#1134](https://github.com/get-bb/bb/issues/1134) is the upstream
+publication tracker.
+
+Scaffold dependency installation remains native bb behavior. BB Mate does not
+repair generated packages after the fact;
+[get-bb/bb#1133](https://github.com/get-bb/bb/issues/1133) and draft
+[PR #1135](https://github.com/get-bb/bb/pull/1135) own that fix.
 
 ## Plugins
 

--- a/docs/plugin-publishing.md
+++ b/docs/plugin-publishing.md
@@ -1,0 +1,13 @@
+# Plugin publishing
+
+BB Mate will publish plugin workspaces independently when the first plugin is ready for external installation.
+
+The expected pipeline is:
+
+1. Validate the selected plugin with type checks, tests, and `bb plugin build`.
+2. Verify the package version and `engines.bb` / `engines.bbPluginSdk` ranges.
+3. Publish the workspace package to npm with provenance from GitHub Actions.
+4. Install the published artifact into a clean bb profile with `bb plugin install npm:<package>@<version>`.
+5. Promote a release only after activation and its primary interaction work.
+
+Do not add release automation until a real plugin establishes package naming, access level, versioning, and release-channel requirements. Changesets is the likely versioning layer if multiple plugins need independent releases.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "bun --filter @bb-mate/workbench dev",
     "build": "bun --filter '*' build",
     "check": "bun --filter '*' check",
-    "test": "bun test",
+    "test": "bun --filter '*' test",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bb-mate",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "bun@1.3.14",
+  "workspaces": [
+    "apps/*",
+    "plugins/*"
+  ],
+  "scripts": {
+    "dev": "bun --filter @bb-mate/workbench dev",
+    "build": "bun --filter '*' build",
+    "check": "bun --filter '*' check",
+    "test": "bun test",
+    "format": "prettier . --write",
+    "format:check": "prettier . --check"
+  },
+  "devDependencies": {
+    "prettier": "^3.6.2"
+  }
+}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,5 @@
+# Plugins
+
+Each child directory is an independently versioned bb plugin package and Bun workspace.
+
+Do not put a plugin manifest at this directory or repository root. Until bb supports repository collections, install local plugins by their package paths and publish remote releases as individual npm packages.

--- a/plugins/linear/.gitignore
+++ b/plugins/linear/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/plugins/linear/README.md
+++ b/plugins/linear/README.md
@@ -1,0 +1,91 @@
+# bb-plugin-linear
+
+Search Linear issues from bb's prompt box and attach fresh issue details as
+agent-only context.
+
+Type `#` followed by an issue identifier or title, then choose a result from
+the **Linear issues** section. Result subtitles use compact status and priority
+symbols for faster scanning while retaining their text labels. At send time
+the plugin fetches the issue again and gives the agent its current status,
+priority, assignee, project, labels, relations, sub-issues, URL, and
+description.
+
+## Install
+
+From this directory:
+
+```sh
+bb plugin install .
+```
+
+The plugin installs from this path, so source edits can be activated with:
+
+```sh
+bb plugin reload linear
+```
+
+## Configure
+
+Create a personal API key under Linear's **Security & access** settings. Open
+the Linear plugin's page in bb Settings and paste it into **Linear personal API
+key**. Keeping the key out of a shell command prevents it from landing in shell
+history.
+
+The optional team filter is safe to set from the CLI:
+
+```sh
+bb plugin config linear set teamKey PAT # optional
+```
+
+`teamKey` restricts results to one Linear team. Leave it unset to search every
+team visible to the API key. With no fixed team, an exact uppercase key such as
+`#PAT`, or a dashed prefix such as `#pat-` and `#PAT-80`, automatically scopes
+that search to the matching team. An ordinary lowercase query such as `#pat`
+remains a workspace-wide text search.
+
+A bare team key such as `#PAT` acts as a compact working queue instead of a
+fuzzy search. It omits completed and canceled issues, then orders results by
+workflow state (In Progress, Todo/Triage, Backlog), priority, recent mention
+use, last update, and identifier. More specific queries retain Linear's search
+relevance ordering.
+
+The API key is declared as a secret bb setting. It is stored outside bb's
+plugin database, is never exposed to the frontend, and is not included in
+errors or logs.
+
+## Develop
+
+```sh
+bun install
+bun run test
+bun run check
+bun run build
+```
+
+The plugin uses Linear's current `searchIssues` GraphQL field with ten bounded
+results. Queries shorter than two characters make no API request, search calls
+time out before bb's two-second mention-provider deadline, and successful
+results are cached for one minute. Identical in-flight searches are coalesced;
+if a refresh times out, results up to ten minutes old can keep the menu useful.
+The cache is limited to 100 queries and clears when credentials or team scope
+change. Cache entries include any team scope inferred from the query. Selected
+issues are always resolved fresh at send time. Descriptions are capped at
+20,000 characters to keep prompt context bounded.
+
+When a message containing a Linear mention is sent, bb resolves that issue once
+to attach fresh context. The plugin stores the issue ID, local send count, and
+last-sent time in its plugin database. Mentions sent within the last 30 days
+receive a tertiary browse-ranking boost; the plugin does not send this usage
+history to Linear. Successfully resolving a mention clears the search cache so
+the next bare-team browse can reflect the signal.
+
+## Files
+
+- `server.ts` registers settings and the `#` mention provider.
+- `linear.ts` owns the GraphQL client, validation, and context formatting.
+- `linear.test.ts` covers search, parsing, safe errors, and context bounds.
+- `mention-usage.ts` persists local sent-mention usage for browse ranking.
+- `mention-usage.test.ts` covers usage aggregation and retrieval.
+- `search-cache.ts` owns bounded search caching and request coalescing.
+- `search-cache.test.ts` covers cache freshness, fallback, and eviction.
+- `types/bb-plugin-sdk.d.ts` is the bb plugin API bundled by the scaffold.

--- a/plugins/linear/linear.test.ts
+++ b/plugins/linear/linear.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  LinearApiError,
+  createLinearClient,
+  formatIssueContext,
+  isBareTeamBrowse,
+  rankTeamBrowseItems,
+  resolveSearchTeamKey,
+  type LinearBrowseItem,
+  type LinearIssue,
+} from "./linear";
+
+const issue: LinearIssue = {
+  id: "issue-80",
+  identifier: "PAT-80",
+  title: "Build bb Linear issue mention plugin",
+  description: "## Goal\n\nPut Linear issues in the prompt box.",
+  url: "https://linear.app/outfitter/issue/PAT-80/example",
+  priorityLabel: "Medium",
+  state: { name: "In Progress", type: "started" },
+  team: { key: "PAT", name: "Patch" },
+  assignee: { name: "Patch" },
+  project: { name: "PatchOS" },
+  labels: { nodes: [{ name: "feature" }, { name: "tooling" }] },
+  parent: { identifier: "PAT-79", title: "Composer integrations" },
+  children: {
+    nodes: [
+      {
+        identifier: "PAT-81",
+        title: "Add OAuth",
+        state: { name: "Backlog" },
+      },
+    ],
+  },
+  relations: {
+    nodes: [
+      {
+        type: "blocks",
+        relatedIssue: { identifier: "PAT-82", title: "Ship plugin" },
+      },
+    ],
+  },
+  inverseRelations: {
+    nodes: [
+      {
+        type: "blocks",
+        issue: { identifier: "PAT-78", title: "Confirm API shape" },
+      },
+    ],
+  },
+};
+
+describe("resolveSearchTeamKey", () => {
+  test("keeps an explicitly configured team authoritative", () => {
+    expect(resolveSearchTeamKey("NUM", "PAT-80")).toBe("NUM");
+  });
+
+  test("infers an exact uppercase team key", () => {
+    expect(resolveSearchTeamKey("", "PAT")).toBe("PAT");
+  });
+
+  test("infers dashed team prefixes case-insensitively", () => {
+    expect(resolveSearchTeamKey("", "pat-")).toBe("PAT");
+    expect(resolveSearchTeamKey("", "Pat-80")).toBe("PAT");
+  });
+
+  test("leaves ordinary lowercase text unscoped", () => {
+    expect(resolveSearchTeamKey("", "pat")).toBe("");
+    expect(resolveSearchTeamKey("", "patch")).toBe("");
+  });
+});
+
+describe("isBareTeamBrowse", () => {
+  test("only browses when the query is the effective team key", () => {
+    expect(isBareTeamBrowse("PAT", "PAT")).toBe(true);
+    expect(isBareTeamBrowse("pat", "PAT")).toBe(true);
+    expect(isBareTeamBrowse("PAT", "pat-")).toBe(false);
+    expect(isBareTeamBrowse("PAT", "PAT-80")).toBe(false);
+    expect(isBareTeamBrowse("NUM", "PAT")).toBe(false);
+  });
+});
+
+describe("rankTeamBrowseItems", () => {
+  test("orders active work by status, priority, recent use, and update time", () => {
+    const now = Date.parse("2026-08-06T18:00:00.000Z");
+    const items: LinearBrowseItem[] = [
+      browseItem("PAT-1", "started", 3, now - 1_000),
+      browseItem("PAT-2", "started", 2, now - 2_000),
+      browseItem("PAT-3", "started", 2, now - 3_000),
+      browseItem("PAT-4", "unstarted", 1, now),
+      browseItem("PAT-5", "triage", 1, now),
+      browseItem("PAT-6", "backlog", 1, now),
+      browseItem("PAT-7", "completed", 1, now),
+    ];
+    const usage = new Map([
+      ["issue-PAT-3", { sentCount: 1, lastSentAtMs: now - 60_000 }],
+    ]);
+
+    expect(
+      rankTeamBrowseItems(items, usage, now).map((item) => item.title),
+    ).toEqual([
+      "PAT-3 Issue PAT-3",
+      "PAT-2 Issue PAT-2",
+      "PAT-1 Issue PAT-1",
+      "PAT-4 Issue PAT-4",
+      "PAT-5 Issue PAT-5",
+      "PAT-6 Issue PAT-6",
+    ]);
+  });
+});
+
+describe("createLinearClient", () => {
+  test("searches current Linear issues with a case-insensitive team filter", async () => {
+    const requests: unknown[] = [];
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "pat",
+      fetch: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return Response.json({
+          data: {
+            searchIssues: {
+              nodes: [
+                {
+                  id: "issue-80",
+                  identifier: "PAT-80",
+                  title: issue.title,
+                  priorityLabel: "Medium",
+                  state: { name: "In Progress", type: "started" },
+                  assignee: { name: "Patch" },
+                  team: { key: "PAT" },
+                },
+              ],
+            },
+          },
+        });
+      },
+    });
+
+    await expect(client.search("linear prompt")).resolves.toEqual([
+      {
+        id: "issue-80",
+        title: "PAT-80 Build bb Linear issue mention plugin",
+        subtitle: "◐ In Progress · ■ Medium · Patch",
+      },
+    ]);
+    expect(requests).toHaveLength(1);
+    const request = expectRecord(requests[0]);
+    expect(typeof request.query).toBe("string");
+    if (typeof request.query !== "string")
+      throw new Error("Expected query text");
+    expect(request.query).toContain("searchIssues");
+    expect(request.query).toContain("eqIgnoreCase: $teamKey");
+    expect(request.variables).toEqual({
+      term: "linear prompt",
+      teamKey: "pat",
+    });
+  });
+
+  test("returns no rows for a too-short mention query without calling Linear", async () => {
+    let called = false;
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "",
+      fetch: async () => {
+        called = true;
+        return Response.json({});
+      },
+    });
+
+    await expect(client.search(" p ")).resolves.toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  test("browses non-terminal team issues ordered from Linear by recent update", async () => {
+    const requests: unknown[] = [];
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "",
+      fetch: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return Response.json({
+          data: {
+            issues: {
+              nodes: [
+                {
+                  id: "issue-80",
+                  identifier: "PAT-80",
+                  title: issue.title,
+                  priority: 3,
+                  priorityLabel: "Medium",
+                  updatedAt: "2026-08-06T18:00:00.000Z",
+                  state: { name: "In Progress", type: "started" },
+                  assignee: null,
+                  team: { key: "PAT" },
+                },
+              ],
+            },
+          },
+        });
+      },
+    });
+
+    await expect(client.browseTeam("PAT")).resolves.toEqual([
+      {
+        id: "issue-80",
+        title: "PAT-80 Build bb Linear issue mention plugin",
+        subtitle: "◐ In Progress · ■ Medium",
+        stateType: "started",
+        priority: 3,
+        updatedAtMs: Date.parse("2026-08-06T18:00:00.000Z"),
+      },
+    ]);
+    const request = expectRecord(requests[0]);
+    expect(request.variables).toEqual({ teamKey: "PAT" });
+    expect(request.query).toContain("issues(");
+    expect(request.query).toContain("orderBy: updatedAt");
+    expect(request.query).toContain('nin: ["completed", "canceled"]');
+  });
+
+  test("formats scannable status and priority glyphs", async () => {
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "",
+      fetch: async () =>
+        Response.json({
+          data: {
+            searchIssues: {
+              nodes: [
+                searchNode("PAT-1", "Triage", "triage", "Urgent"),
+                searchNode("PAT-2", "Backlog", "backlog", "High"),
+                searchNode("PAT-3", "Todo", "unstarted", "Medium"),
+                searchNode("PAT-4", "In Progress", "started", "Low"),
+                searchNode("PAT-5", "Done", "completed", "No priority"),
+                searchNode("PAT-6", "Canceled", "canceled", "No priority"),
+              ],
+            },
+          },
+        }),
+    });
+
+    const results = await client.search("PAT");
+    expect(results.map((result) => result.subtitle)).toEqual([
+      "◇ Triage · ◆ Urgent",
+      "◌ Backlog · ▲ High",
+      "○ Todo · ■ Medium",
+      "◐ In Progress · ▽ Low",
+      "● Done · · No priority",
+      "⊘ Canceled · · No priority",
+    ]);
+  });
+
+  test("fetches and parses fresh issue context by opaque issue id", async () => {
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "",
+      fetch: async (_input, init) => {
+        const body: unknown = JSON.parse(String(init?.body));
+        const request = expectRecord(body);
+        expect(request.variables).toEqual({ id: "issue-80" });
+        return Response.json({ data: { issue } });
+      },
+    });
+
+    await expect(client.getIssue("issue-80")).resolves.toEqual(issue);
+  });
+
+  test("reports safe GraphQL failures without echoing credentials", async () => {
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "",
+      fetch: async () =>
+        Response.json({
+          errors: [{ message: "Not authorized with lin_api_secret" }],
+        }),
+    });
+
+    const error = await client
+      .search("PAT-80")
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(LinearApiError);
+    expect(String(error)).toBe("LinearApiError: Linear API request failed");
+    expect(String(error)).not.toContain("lin_api_secret");
+  });
+
+  test("rejects malformed successful responses", async () => {
+    const client = createLinearClient({
+      apiKey: "lin_api_secret",
+      teamKey: "",
+      fetch: async () =>
+        Response.json({ data: { searchIssues: { nodes: [{}] } } }),
+    });
+
+    await expect(client.search("PAT-80")).rejects.toThrow(
+      "Linear returned an unexpected response",
+    );
+  });
+});
+
+function expectRecord(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  throw new Error("Expected a record");
+}
+
+function searchNode(
+  identifier: string,
+  stateName: string,
+  stateType: string,
+  priorityLabel: string,
+) {
+  return {
+    id: `issue-${identifier}`,
+    identifier,
+    title: `Issue ${identifier}`,
+    priorityLabel,
+    state: { name: stateName, type: stateType },
+    assignee: null,
+    team: { key: "PAT" },
+  };
+}
+
+function browseItem(
+  identifier: string,
+  stateType: string,
+  priority: number,
+  updatedAtMs: number,
+): LinearBrowseItem {
+  return {
+    id: `issue-${identifier}`,
+    title: `${identifier} Issue ${identifier}`,
+    subtitle: "status",
+    stateType,
+    priority,
+    updatedAtMs,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("formatIssueContext", () => {
+  test("produces a bounded agent-ready issue packet", () => {
+    expect(formatIssueContext(issue))
+      .toBe(`# Linear issue PAT-80: Build bb Linear issue mention plugin
+
+- Status: In Progress (started)
+- Priority: Medium
+- Team: Patch (PAT)
+- Assignee: Patch
+- Project: PatchOS
+- Labels: feature, tooling
+- URL: https://linear.app/outfitter/issue/PAT-80/example
+- Parent: PAT-79 Composer integrations
+- Sub-issues: PAT-81 Add OAuth [Backlog]
+- Relations: blocks PAT-82 Ship plugin; blocked by PAT-78 Confirm API shape
+
+## Description
+
+## Goal
+
+Put Linear issues in the prompt box.
+
+Use this issue as project intent and context. Verify live repository state before changing code, and keep the issue current if implementation diverges.`);
+  });
+
+  test("truncates oversized descriptions", () => {
+    const context = formatIssueContext({
+      ...issue,
+      description: "x".repeat(30_000),
+    });
+
+    expect(context.length).toBeLessThan(26_000);
+    expect(context).toContain("[Description truncated by bb-plugin-linear]");
+  });
+});

--- a/plugins/linear/linear.ts
+++ b/plugins/linear/linear.ts
@@ -1,0 +1,591 @@
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+const SEARCH_LIMIT = 10;
+const SEARCH_TIMEOUT_MS = 1_800;
+const DESCRIPTION_LIMIT = 20_000;
+const RECENT_USAGE_MS = 30 * 24 * 60 * 60 * 1_000;
+
+type Fetch = typeof globalThis.fetch;
+
+interface NamedValue {
+  name: string;
+}
+
+interface IssueReference {
+  identifier: string;
+  title: string;
+}
+
+interface IssueRelation {
+  type: string;
+  issue?: IssueReference;
+  relatedIssue?: IssueReference;
+}
+
+export interface LinearIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  priorityLabel: string;
+  state: { name: string; type: string };
+  team: { key: string; name: string };
+  assignee: NamedValue | null;
+  project: NamedValue | null;
+  labels: { nodes: NamedValue[] };
+  parent: IssueReference | null;
+  children: {
+    nodes: Array<IssueReference & { state: NamedValue }>;
+  };
+  relations: { nodes: IssueRelation[] };
+  inverseRelations: { nodes: IssueRelation[] };
+}
+
+export interface LinearMentionItem {
+  id: string;
+  title: string;
+  subtitle: string;
+}
+
+export interface LinearBrowseItem extends LinearMentionItem {
+  stateType: string;
+  priority: number;
+  updatedAtMs: number;
+}
+
+export interface LinearMentionUsage {
+  sentCount: number;
+  lastSentAtMs: number;
+}
+
+interface LinearClientOptions {
+  apiKey: string;
+  teamKey: string;
+  fetch?: Fetch;
+}
+
+export function resolveSearchTeamKey(
+  configuredTeamKey: string,
+  query: string,
+): string {
+  const configured = configuredTeamKey.trim();
+  if (configured) return configured;
+
+  const term = query.trim();
+  const uppercaseKey = /^([A-Z][A-Z0-9]{1,9})$/.exec(term);
+  if (uppercaseKey) return uppercaseKey[1] ?? "";
+
+  const dashedKey = /^([A-Z][A-Z0-9]{1,9})-/i.exec(term);
+  return dashedKey?.[1]?.toUpperCase() ?? "";
+}
+
+export function isBareTeamBrowse(teamKey: string, query: string): boolean {
+  const team = teamKey.trim();
+  return team.length > 0 && query.trim().toUpperCase() === team.toUpperCase();
+}
+
+export function rankTeamBrowseItems(
+  items: LinearBrowseItem[],
+  usageById: ReadonlyMap<string, LinearMentionUsage>,
+  nowMs = Date.now(),
+): LinearMentionItem[] {
+  return [...items]
+    .filter((item) => workflowBucket(item.stateType) < 3)
+    .sort((left, right) => {
+      const workflowDifference =
+        workflowBucket(left.stateType) - workflowBucket(right.stateType);
+      if (workflowDifference !== 0) return workflowDifference;
+
+      const priorityDifference =
+        priorityRank(left.priority) - priorityRank(right.priority);
+      if (priorityDifference !== 0) return priorityDifference;
+
+      const usageDifference =
+        recentUsageAt(right.id, usageById, nowMs) -
+        recentUsageAt(left.id, usageById, nowMs);
+      if (usageDifference !== 0) return usageDifference;
+
+      const updatedDifference = right.updatedAtMs - left.updatedAtMs;
+      if (updatedDifference !== 0) return updatedDifference;
+      return left.title.localeCompare(right.title);
+    })
+    .slice(0, SEARCH_LIMIT)
+    .map(({ id, title, subtitle }) => ({ id, title, subtitle }));
+}
+
+function workflowBucket(stateType: string): number {
+  if (stateType === "started") return 0;
+  if (stateType === "unstarted" || stateType === "triage") return 1;
+  if (stateType === "backlog") return 2;
+  return 3;
+}
+
+function priorityRank(priority: number): number {
+  return priority === 0 ? 5 : priority;
+}
+
+function recentUsageAt(
+  issueId: string,
+  usageById: ReadonlyMap<string, LinearMentionUsage>,
+  nowMs: number,
+): number {
+  const lastSentAtMs = usageById.get(issueId)?.lastSentAtMs ?? 0;
+  return nowMs - lastSentAtMs <= RECENT_USAGE_MS ? lastSentAtMs : 0;
+}
+
+export class LinearApiError extends Error {
+  override readonly name = "LinearApiError";
+}
+
+const SEARCH_FIELDS = `
+  id
+  identifier
+  title
+  priorityLabel
+  state { name type }
+  assignee { name }
+  team { key }
+`;
+
+const SEARCH_QUERY = `
+  query SearchLinearIssues($term: String!) {
+    searchIssues(term: $term, first: ${SEARCH_LIMIT}, includeArchived: false) {
+      nodes { ${SEARCH_FIELDS} }
+    }
+  }
+`;
+
+const SCOPED_SEARCH_QUERY = `
+  query SearchLinearIssues($term: String!, $teamKey: String!) {
+    searchIssues(
+      term: $term
+      first: ${SEARCH_LIMIT}
+      includeArchived: false
+      filter: { team: { key: { eqIgnoreCase: $teamKey } } }
+    ) {
+      nodes { ${SEARCH_FIELDS} }
+    }
+  }
+`;
+
+const TEAM_BROWSE_QUERY = `
+  query BrowseLinearTeamIssues($teamKey: String!) {
+    issues(
+      first: 100
+      includeArchived: false
+      orderBy: updatedAt
+      filter: {
+        team: { key: { eqIgnoreCase: $teamKey } }
+        state: { type: { nin: ["completed", "canceled"] } }
+      }
+    ) {
+      nodes {
+        ${SEARCH_FIELDS}
+        priority
+        updatedAt
+      }
+    }
+  }
+`;
+
+const ISSUE_QUERY = `
+  query LinearIssueContext($id: String!) {
+    issue(id: $id) {
+      id
+      identifier
+      title
+      description
+      url
+      priorityLabel
+      state { name type }
+      team { key name }
+      assignee { name }
+      project { name }
+      labels(first: 50) { nodes { name } }
+      parent { identifier title }
+      children(first: 25) { nodes { identifier title state { name } } }
+      relations(first: 25) {
+        nodes { type relatedIssue { identifier title } }
+      }
+      inverseRelations(first: 25) {
+        nodes { type issue { identifier title } }
+      }
+    }
+  }
+`;
+
+export function createLinearClient(options: LinearClientOptions) {
+  const fetch = options.fetch ?? globalThis.fetch;
+
+  return {
+    async search(query: string): Promise<LinearMentionItem[]> {
+      const term = query.trim();
+      if (term.length < 2) return [];
+
+      const teamKey = options.teamKey.trim();
+      const data = await requestGraphql(
+        fetch,
+        options.apiKey,
+        teamKey ? SCOPED_SEARCH_QUERY : SEARCH_QUERY,
+        teamKey ? { term, teamKey } : { term },
+        SEARCH_TIMEOUT_MS,
+      );
+
+      if (!isRecord(data) || !isRecord(data.searchIssues)) {
+        throw unexpectedResponse();
+      }
+      const nodes = data.searchIssues.nodes;
+      if (!Array.isArray(nodes)) throw unexpectedResponse();
+
+      return nodes.map(parseSearchResult);
+    },
+
+    async browseTeam(teamKey: string): Promise<LinearBrowseItem[]> {
+      const team = teamKey.trim();
+      if (!team) return [];
+
+      const data = await requestGraphql(
+        fetch,
+        options.apiKey,
+        TEAM_BROWSE_QUERY,
+        { teamKey: team },
+        SEARCH_TIMEOUT_MS,
+      );
+      if (!isRecord(data) || !isRecord(data.issues)) {
+        throw unexpectedResponse();
+      }
+      const nodes = data.issues.nodes;
+      if (!Array.isArray(nodes)) throw unexpectedResponse();
+
+      return nodes.map(parseBrowseResult);
+    },
+
+    async getIssue(id: string): Promise<LinearIssue> {
+      const data = await requestGraphql(
+        fetch,
+        options.apiKey,
+        ISSUE_QUERY,
+        { id },
+        10_000,
+      );
+      if (!isRecord(data)) throw unexpectedResponse();
+      return parseIssue(data.issue);
+    },
+  };
+}
+
+function parseBrowseResult(value: unknown): LinearBrowseItem {
+  if (!isRecord(value)) throw unexpectedResponse();
+  const item = parseSearchResult(value);
+  const stateType = requiredNestedString(value.state, "type");
+  const priority = requiredNumber(value.priority);
+  const updatedAtMs = Date.parse(requiredString(value.updatedAt));
+  if (!Number.isFinite(updatedAtMs)) throw unexpectedResponse();
+
+  return { ...item, stateType, priority, updatedAtMs };
+}
+
+async function requestGraphql(
+  fetch: Fetch,
+  apiKey: string,
+  query: string,
+  variables: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(LINEAR_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        authorization: apiKey,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new LinearApiError("Linear API request timed out");
+    }
+    throw new LinearApiError("Could not reach the Linear API");
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new LinearApiError(`Linear API returned HTTP ${response.status}`);
+  }
+
+  if (!response.ok) {
+    throw new LinearApiError(
+      `Linear API request failed (HTTP ${response.status})`,
+    );
+  }
+  if (
+    !isRecord(payload) ||
+    (Array.isArray(payload.errors) && payload.errors.length > 0)
+  ) {
+    throw new LinearApiError("Linear API request failed");
+  }
+
+  return payload.data;
+}
+
+function parseSearchResult(value: unknown): LinearMentionItem {
+  if (!isRecord(value)) throw unexpectedResponse();
+  const id = requiredString(value.id);
+  const identifier = requiredString(value.identifier);
+  const title = requiredString(value.title);
+  const priority = requiredString(value.priorityLabel);
+  const state = requiredNestedString(value.state, "name");
+  const stateType = requiredNestedString(value.state, "type");
+  const assignee = optionalNestedString(value.assignee, "name");
+
+  return {
+    id,
+    title: `${identifier} ${title}`,
+    subtitle: [
+      `${statusGlyph(stateType)} ${state}`,
+      `${priorityGlyph(priority)} ${priority}`,
+      assignee,
+    ]
+      .filter(isPresent)
+      .join(" · "),
+  };
+}
+
+function statusGlyph(type: string): string {
+  if (type === "triage") return "◇";
+  if (type === "backlog") return "◌";
+  if (type === "unstarted") return "○";
+  if (type === "started") return "◐";
+  if (type === "completed") return "●";
+  if (type === "canceled") return "⊘";
+  return "○";
+}
+
+function priorityGlyph(priority: string): string {
+  const normalized = priority.trim().toLowerCase();
+  if (normalized === "urgent") return "◆";
+  if (normalized === "high") return "▲";
+  if (normalized === "medium") return "■";
+  if (normalized === "low") return "▽";
+  return "·";
+}
+
+function parseIssue(value: unknown): LinearIssue {
+  if (!isRecord(value)) throw unexpectedResponse();
+
+  return {
+    id: requiredString(value.id),
+    identifier: requiredString(value.identifier),
+    title: requiredString(value.title),
+    description: optionalString(value.description),
+    url: requiredString(value.url),
+    priorityLabel: requiredString(value.priorityLabel),
+    state: parseState(value.state),
+    team: parseTeam(value.team),
+    assignee: parseOptionalNamedValue(value.assignee),
+    project: parseOptionalNamedValue(value.project),
+    labels: { nodes: parseNamedConnection(value.labels) },
+    parent: parseOptionalReference(value.parent),
+    children: { nodes: parseChildren(value.children) },
+    relations: { nodes: parseRelations(value.relations, "relatedIssue") },
+    inverseRelations: {
+      nodes: parseRelations(value.inverseRelations, "issue"),
+    },
+  };
+}
+
+export function formatIssueContext(issue: LinearIssue): string {
+  const labels =
+    issue.labels.nodes.map((label) => label.name).join(", ") || "None";
+  const lines = [
+    `# Linear issue ${issue.identifier}: ${issue.title}`,
+    "",
+    `- Status: ${issue.state.name} (${issue.state.type})`,
+    `- Priority: ${issue.priorityLabel}`,
+    `- Team: ${issue.team.name} (${issue.team.key})`,
+    `- Assignee: ${issue.assignee?.name ?? "Unassigned"}`,
+    `- Project: ${issue.project?.name ?? "None"}`,
+    `- Labels: ${labels}`,
+    `- URL: ${issue.url}`,
+  ];
+
+  if (issue.parent) {
+    lines.push(`- Parent: ${formatReference(issue.parent)}`);
+  }
+  if (issue.children.nodes.length > 0) {
+    lines.push(
+      `- Sub-issues: ${issue.children.nodes
+        .map((child) => `${formatReference(child)} [${child.state.name}]`)
+        .join("; ")}`,
+    );
+  }
+
+  const relations = formatRelations(issue);
+  if (relations.length > 0) lines.push(`- Relations: ${relations.join("; ")}`);
+
+  const description = truncateDescription(
+    issue.description?.trim() || "No description provided.",
+  );
+  lines.push(
+    "",
+    "## Description",
+    "",
+    description,
+    "",
+    "Use this issue as project intent and context. Verify live repository state before changing code, and keep the issue current if implementation diverges.",
+  );
+
+  return lines.join("\n");
+}
+
+function formatRelations(issue: LinearIssue): string[] {
+  const outgoing = issue.relations.nodes.flatMap((relation) => {
+    if (!relation.relatedIssue) return [];
+    return [
+      `${outgoingRelationLabel(relation.type)} ${formatReference(relation.relatedIssue)}`,
+    ];
+  });
+  const incoming = issue.inverseRelations.nodes.flatMap((relation) => {
+    if (!relation.issue) return [];
+    return [
+      `${incomingRelationLabel(relation.type)} ${formatReference(relation.issue)}`,
+    ];
+  });
+  return [...outgoing, ...incoming];
+}
+
+function outgoingRelationLabel(type: string): string {
+  if (type === "blocks") return "blocks";
+  if (type === "duplicate") return "duplicate of";
+  if (type === "similar") return "similar to";
+  return "related to";
+}
+
+function incomingRelationLabel(type: string): string {
+  if (type === "blocks") return "blocked by";
+  if (type === "duplicate") return "duplicated by";
+  if (type === "similar") return "similar to";
+  return "related to";
+}
+
+function truncateDescription(description: string): string {
+  if (description.length <= DESCRIPTION_LIMIT) return description;
+  return `${description.slice(0, DESCRIPTION_LIMIT)}\n\n[Description truncated by bb-plugin-linear]`;
+}
+
+function formatReference(reference: IssueReference): string {
+  return `${reference.identifier} ${reference.title}`;
+}
+
+function parseState(value: unknown): LinearIssue["state"] {
+  if (!isRecord(value)) throw unexpectedResponse();
+  return { name: requiredString(value.name), type: requiredString(value.type) };
+}
+
+function parseTeam(value: unknown): LinearIssue["team"] {
+  if (!isRecord(value)) throw unexpectedResponse();
+  return { key: requiredString(value.key), name: requiredString(value.name) };
+}
+
+function parseOptionalNamedValue(value: unknown): NamedValue | null {
+  if (value === null) return null;
+  if (!isRecord(value)) throw unexpectedResponse();
+  return { name: requiredString(value.name) };
+}
+
+function parseNamedConnection(value: unknown): NamedValue[] {
+  const nodes = connectionNodes(value);
+  return nodes.map((node) => {
+    if (!isRecord(node)) throw unexpectedResponse();
+    return { name: requiredString(node.name) };
+  });
+}
+
+function parseOptionalReference(value: unknown): IssueReference | null {
+  if (value === null) return null;
+  return parseReference(value);
+}
+
+function parseReference(value: unknown): IssueReference {
+  if (!isRecord(value)) throw unexpectedResponse();
+  return {
+    identifier: requiredString(value.identifier),
+    title: requiredString(value.title),
+  };
+}
+
+function parseChildren(value: unknown): LinearIssue["children"]["nodes"] {
+  return connectionNodes(value).map((node) => {
+    if (!isRecord(node)) throw unexpectedResponse();
+    return {
+      ...parseReference(node),
+      state: { name: requiredNestedString(node.state, "name") },
+    };
+  });
+}
+
+function parseRelations(
+  value: unknown,
+  direction: "issue" | "relatedIssue",
+): IssueRelation[] {
+  return connectionNodes(value).map((node) => {
+    if (!isRecord(node)) throw unexpectedResponse();
+    const reference = parseReference(node[direction]);
+    return direction === "issue"
+      ? { type: requiredString(node.type), issue: reference }
+      : { type: requiredString(node.type), relatedIssue: reference };
+  });
+}
+
+function connectionNodes(value: unknown): unknown[] {
+  if (!isRecord(value) || !Array.isArray(value.nodes))
+    throw unexpectedResponse();
+  return value.nodes;
+}
+
+function requiredNestedString(value: unknown, key: string): string {
+  if (!isRecord(value)) throw unexpectedResponse();
+  return requiredString(value[key]);
+}
+
+function optionalNestedString(value: unknown, key: string): string | null {
+  if (value === null) return null;
+  return requiredNestedString(value, key);
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string") throw unexpectedResponse();
+  return value;
+}
+
+function requiredNumber(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw unexpectedResponse();
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | null {
+  if (value === null) return null;
+  return requiredString(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPresent(value: string | null): value is string {
+  return value !== null && value.length > 0;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
+function unexpectedResponse(): LinearApiError {
+  return new LinearApiError("Linear returned an unexpected response");
+}

--- a/plugins/linear/mention-usage.test.ts
+++ b/plugins/linear/mention-usage.test.ts
@@ -1,0 +1,27 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { MENTION_USAGE_MIGRATIONS, MentionUsageStore } from "./mention-usage";
+
+let database: Database.Database | undefined;
+
+afterEach(() => database?.close());
+
+describe("MentionUsageStore", () => {
+  test("records sent mentions and returns their count and latest use", () => {
+    database = new Database(":memory:");
+    database.exec(MENTION_USAGE_MIGRATIONS[0] ?? "");
+    const usage = new MentionUsageStore(database);
+
+    usage.recordSent("issue-1", 100);
+    usage.recordSent("issue-1", 200);
+    usage.recordSent("issue-2", 150);
+
+    expect(usage.get(["issue-1", "issue-2", "missing"])).toEqual(
+      new Map([
+        ["issue-1", { sentCount: 2, lastSentAtMs: 200 }],
+        ["issue-2", { sentCount: 1, lastSentAtMs: 150 }],
+      ]),
+    );
+  });
+});

--- a/plugins/linear/mention-usage.ts
+++ b/plugins/linear/mention-usage.ts
@@ -1,0 +1,52 @@
+import type Database from "better-sqlite3";
+
+import type { LinearMentionUsage } from "./linear";
+
+export const MENTION_USAGE_MIGRATIONS = [
+  `CREATE TABLE IF NOT EXISTS mention_usage (
+    issue_id TEXT PRIMARY KEY,
+    sent_count INTEGER NOT NULL DEFAULT 0,
+    last_sent_at_ms INTEGER NOT NULL
+  )`,
+];
+
+interface MentionUsageRow {
+  issue_id: string;
+  sent_count: number;
+  last_sent_at_ms: number;
+}
+
+export class MentionUsageStore {
+  constructor(private readonly database: Database.Database) {}
+
+  recordSent(issueId: string, sentAtMs = Date.now()): void {
+    this.database
+      .prepare(
+        `INSERT INTO mention_usage (issue_id, sent_count, last_sent_at_ms)
+         VALUES (?, 1, ?)
+         ON CONFLICT(issue_id) DO UPDATE SET
+           sent_count = mention_usage.sent_count + 1,
+           last_sent_at_ms = excluded.last_sent_at_ms`,
+      )
+      .run(issueId, sentAtMs);
+  }
+
+  get(issueIds: string[]): Map<string, LinearMentionUsage> {
+    if (issueIds.length === 0) return new Map();
+    const placeholders = issueIds.map(() => "?").join(", ");
+    const rows = this.database
+      .prepare<unknown[], MentionUsageRow>(
+        `SELECT issue_id, sent_count, last_sent_at_ms
+         FROM mention_usage
+         WHERE issue_id IN (${placeholders})`,
+      )
+      .all(...issueIds);
+
+    return new Map(
+      rows.map((row) => [
+        row.issue_id,
+        { sentCount: row.sent_count, lastSentAtMs: row.last_sent_at_ms },
+      ]),
+    );
+  }
+}

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -25,6 +25,7 @@
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
+    "bb-app": "0.35.1",
     "better-sqlite3": "^12.0.0",
     "hono": "^4.11.9",
     "typescript": "^5.7.0",

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "bb-plugin-linear",
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "bb": ">=0.35",
+    "bbPluginSdk": "^0.4.1"
+  },
+  "bb": {
+    "name": "Linear",
+    "description": "Search Linear issues from the prompt box and attach fresh, agent-ready context.",
+    "branding": {
+      "icon": "Check"
+    },
+    "server": "./server.ts",
+    "skills": []
+  },
+  "scripts": {
+    "test": "vitest run",
+    "check": "tsc --noEmit",
+    "typecheck": "bun run check",
+    "build": "bb plugin build"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "better-sqlite3": "^12.0.0",
+    "hono": "^4.11.9",
+    "typescript": "^5.7.0",
+    "vitest": "^3.2.4",
+    "zod": "^4.3.6"
+  }
+}

--- a/plugins/linear/search-cache.test.ts
+++ b/plugins/linear/search-cache.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+
+import { SearchCache, searchCacheKey } from "./search-cache";
+
+describe("SearchCache", () => {
+  test("normalizes query and team scope and reuses fresh results", async () => {
+    let loads = 0;
+    const cache = new SearchCache<string[]>({
+      freshForMs: 60_000,
+      staleForMs: 600_000,
+      maxEntries: 100,
+      now: () => 1_000,
+    });
+    const key = searchCacheKey(" PAT ", "  Linear Mentions ");
+    const load = async () => {
+      loads += 1;
+      return ["PAT-80"];
+    };
+
+    await expect(cache.get(key, load)).resolves.toEqual({
+      value: ["PAT-80"],
+      source: "network",
+    });
+    await expect(
+      cache.get(searchCacheKey("pat", "linear mentions"), load),
+    ).resolves.toEqual({ value: ["PAT-80"], source: "fresh-cache" });
+    expect(loads).toBe(1);
+  });
+
+  test("coalesces identical in-flight searches", async () => {
+    let resolveLoad: ((value: string[]) => void) | undefined;
+    let loads = 0;
+    const cache = new SearchCache<string[]>({
+      freshForMs: 60_000,
+      staleForMs: 600_000,
+      maxEntries: 100,
+      now: () => 1_000,
+    });
+    const load = () => {
+      loads += 1;
+      return new Promise<string[]>((resolve) => {
+        resolveLoad = resolve;
+      });
+    };
+
+    const first = cache.get("pat\0memory", load);
+    const second = cache.get("pat\0memory", load);
+    resolveLoad?.(["PAT-72"]);
+
+    await expect(first).resolves.toEqual({
+      value: ["PAT-72"],
+      source: "network",
+    });
+    await expect(second).resolves.toEqual({
+      value: ["PAT-72"],
+      source: "network",
+    });
+    expect(loads).toBe(1);
+  });
+
+  test("falls back to stale results when refresh fails", async () => {
+    let now = 1_000;
+    const cache = new SearchCache<string[]>({
+      freshForMs: 60_000,
+      staleForMs: 600_000,
+      maxEntries: 100,
+      now: () => now,
+    });
+
+    await cache.get("pat\0linear", async () => ["PAT-80"]);
+    now += 60_001;
+
+    const result = await cache.get("pat\0linear", async () => {
+      throw new Error("timed out");
+    });
+
+    expect(result).toMatchObject({
+      value: ["PAT-80"],
+      source: "stale-cache",
+    });
+    if (result.source !== "stale-cache") {
+      throw new Error("Expected a stale cache result");
+    }
+    expect(result.error).toEqual(new Error("timed out"));
+  });
+
+  test("does not hide failures after stale results expire", async () => {
+    let now = 1_000;
+    const cache = new SearchCache<string[]>({
+      freshForMs: 60_000,
+      staleForMs: 600_000,
+      maxEntries: 100,
+      now: () => now,
+    });
+
+    await cache.get("pat\0linear", async () => ["PAT-80"]);
+    now += 600_001;
+
+    await expect(
+      cache.get("pat\0linear", async () => {
+        throw new Error("timed out");
+      }),
+    ).rejects.toThrow("timed out");
+  });
+
+  test("evicts the oldest result when the cache reaches its bound", async () => {
+    let now = 1_000;
+    const cache = new SearchCache<string[]>({
+      freshForMs: 60_000,
+      staleForMs: 600_000,
+      maxEntries: 2,
+      now: () => now,
+    });
+
+    await cache.get("one", async () => ["one"]);
+    now += 1;
+    await cache.get("two", async () => ["two"]);
+    now += 1;
+    await cache.get("three", async () => ["three"]);
+
+    let loads = 0;
+    await cache.get("one", async () => {
+      loads += 1;
+      return ["one-again"];
+    });
+    expect(loads).toBe(1);
+  });
+});

--- a/plugins/linear/search-cache.ts
+++ b/plugins/linear/search-cache.ts
@@ -1,0 +1,88 @@
+export type SearchCacheResult<T> =
+  | { value: T; source: "network" | "fresh-cache" }
+  | { value: T; source: "stale-cache"; error: unknown };
+
+interface SearchCacheEntry<T> {
+  value: T;
+  storedAt: number;
+}
+
+interface SearchCacheOptions {
+  freshForMs: number;
+  staleForMs: number;
+  maxEntries: number;
+  now?: () => number;
+}
+
+export class SearchCache<T> {
+  private readonly entries = new Map<string, SearchCacheEntry<T>>();
+  private readonly inFlight = new Map<string, Promise<SearchCacheResult<T>>>();
+  private readonly now: () => number;
+  private generation = 0;
+
+  constructor(private readonly options: SearchCacheOptions) {
+    this.now = options.now ?? Date.now;
+  }
+
+  async get(
+    key: string,
+    load: () => Promise<T>,
+  ): Promise<SearchCacheResult<T>> {
+    const cached = this.entries.get(key);
+    if (cached && this.now() - cached.storedAt <= this.options.freshForMs) {
+      return { value: cached.value, source: "fresh-cache" };
+    }
+
+    const active = this.inFlight.get(key);
+    if (active) return active;
+
+    const generation = this.generation;
+    const pending = this.load(key, cached, generation, load);
+    this.inFlight.set(key, pending);
+
+    try {
+      return await pending;
+    } finally {
+      if (this.inFlight.get(key) === pending) this.inFlight.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.generation += 1;
+    this.entries.clear();
+    this.inFlight.clear();
+  }
+
+  private async load(
+    key: string,
+    cached: SearchCacheEntry<T> | undefined,
+    generation: number,
+    load: () => Promise<T>,
+  ): Promise<SearchCacheResult<T>> {
+    try {
+      const value = await load();
+      if (generation === this.generation) this.store(key, value);
+      return { value, source: "network" };
+    } catch (error) {
+      if (cached && this.now() - cached.storedAt <= this.options.staleForMs) {
+        return { value: cached.value, source: "stale-cache", error };
+      }
+      throw error;
+    }
+  }
+
+  private store(key: string, value: T): void {
+    if (
+      !this.entries.has(key) &&
+      this.entries.size >= this.options.maxEntries
+    ) {
+      const oldest = this.entries.keys().next();
+      if (!oldest.done) this.entries.delete(oldest.value);
+    }
+    this.entries.set(key, { value, storedAt: this.now() });
+  }
+}
+
+export function searchCacheKey(teamKey: string, query: string): string {
+  return `${teamKey.trim().toLowerCase()}\0${query.trim().toLowerCase()}`;
+}

--- a/plugins/linear/server.ts
+++ b/plugins/linear/server.ts
@@ -1,0 +1,108 @@
+import type { BbPluginApi } from "@bb/plugin-sdk";
+
+import {
+  createLinearClient,
+  formatIssueContext,
+  isBareTeamBrowse,
+  rankTeamBrowseItems,
+  resolveSearchTeamKey,
+  type LinearMentionItem,
+} from "./linear";
+import { MENTION_USAGE_MIGRATIONS, MentionUsageStore } from "./mention-usage";
+import { SearchCache, searchCacheKey } from "./search-cache";
+
+const CONFIGURE_MESSAGE =
+  "Add a Linear personal API key in the plugin's Settings page.";
+const SEARCH_CACHE_FRESH_MS = 60_000;
+const SEARCH_CACHE_STALE_MS = 600_000;
+const SEARCH_CACHE_MAX_ENTRIES = 100;
+
+export default async function plugin(bb: BbPluginApi) {
+  const settings = bb.settings.define({
+    apiKey: {
+      type: "string",
+      label: "Linear personal API key",
+      secret: true,
+    },
+    teamKey: {
+      type: "string",
+      label: "Team key (optional)",
+      description: "Restrict mention search to one Linear team, such as PAT.",
+      default: "",
+    },
+  });
+  const searchCache = new SearchCache<LinearMentionItem[]>({
+    freshForMs: SEARCH_CACHE_FRESH_MS,
+    staleForMs: SEARCH_CACHE_STALE_MS,
+    maxEntries: SEARCH_CACHE_MAX_ENTRIES,
+  });
+  const database = bb.storage.database();
+  bb.storage.migrate(database, MENTION_USAGE_MIGRATIONS);
+  const mentionUsage = new MentionUsageStore(database);
+  settings.onChange((next, previous) => {
+    if (next.apiKey !== previous.apiKey || next.teamKey !== previous.teamKey) {
+      searchCache.clear();
+      bb.log.info("Linear mention search cache cleared after settings change");
+    }
+  });
+
+  const initial = await settings.get();
+  if (!initial.apiKey) bb.status.needsConfiguration(CONFIGURE_MESSAGE);
+
+  bb.ui.registerMentionProvider({
+    id: "linear-issue",
+    label: "Linear issues",
+    triggers: ["#"],
+    async search({ query }) {
+      const { apiKey, teamKey } = await settings.get();
+      if (!apiKey) return [];
+      const searchTeamKey = resolveSearchTeamKey(teamKey, query);
+      const browseTeam = isBareTeamBrowse(searchTeamKey, query);
+
+      try {
+        const result = await searchCache.get(
+          searchCacheKey(searchTeamKey, query),
+          async () => {
+            const client = createLinearClient({
+              apiKey,
+              teamKey: searchTeamKey,
+            });
+            if (!browseTeam) return client.search(query);
+
+            const items = await client.browseTeam(searchTeamKey);
+            const usage = mentionUsage.get(items.map((item) => item.id));
+            return rankTeamBrowseItems(items, usage);
+          },
+        );
+        if (result.source === "stale-cache") {
+          const message =
+            result.error instanceof Error
+              ? result.error.message
+              : "Unknown error";
+          bb.log.warn(
+            `Linear mention search refresh failed; using cached results: ${message}`,
+          );
+        }
+        return result.value;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        bb.log.warn(`Linear mention search failed: ${message}`);
+        return [];
+      }
+    },
+    async resolve(itemId) {
+      const { apiKey, teamKey } = await settings.get();
+      if (!apiKey) throw new Error(CONFIGURE_MESSAGE);
+
+      const issue = await createLinearClient({ apiKey, teamKey }).getIssue(
+        itemId,
+      );
+      mentionUsage.recordSent(issue.id);
+      searchCache.clear();
+      return { context: formatIssueContext(issue) };
+    },
+  });
+
+  bb.log.info("Linear issue mentions registered on #");
+}

--- a/plugins/linear/tsconfig.json
+++ b/plugins/linear/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "paths": {
+      "@bb/plugin-sdk": ["./types/bb-plugin-sdk.d.ts"],
+      "@bb/plugin-sdk/app": ["./types/bb-plugin-sdk-app.d.ts"]
+    },
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "include": ["server.ts", "linear.ts", "linear.test.ts", "types"]
+}

--- a/plugins/linear/types/bb-plugin-sdk.d.ts
+++ b/plugins/linear/types/bb-plugin-sdk.d.ts
@@ -1,0 +1,20050 @@
+// Portable type declarations for `@bb/plugin-sdk`. Unpublished BB
+// workspace contracts are flattened; public subpaths may reuse the
+// package root without requiring any other @bb/* package.
+//
+// Confused by the API, or need a symbol that isn't here? Clone the BB repo
+// and read the real source: https://github.com/ymichael/bb
+
+import Database from "better-sqlite3";
+import { Context } from "hono";
+import * as react from "react";
+import { ComponentType, ReactNode } from "react";
+import * as z from "zod";
+import { z as z$1 } from "zod";
+
+/**
+ * App-wide server-backed preferences.
+ * Client-local settings stay in the frontend localStorage helpers instead.
+ */
+declare const appSettingsSchema: z$1.ZodObject<
+  {
+    caffeinate: z$1.ZodBoolean;
+    showKeyboardHints: z$1.ZodBoolean;
+    steerActiveThreadOnEnter: z$1.ZodBoolean;
+    showUnhandledProviderEvents: z$1.ZodBoolean;
+    codexMemoryEnabled: z$1.ZodBoolean;
+    claudeCodeMemoryEnabled: z$1.ZodBoolean;
+    codexSubagentsDisabled: z$1.ZodBoolean;
+    claudeCodeSubagentsDisabled: z$1.ZodBoolean;
+    claudeCodeWorkflowsDisabled: z$1.ZodBoolean;
+  },
+  z$1.core.$strict
+>;
+type AppSettings = z$1.infer<typeof appSettingsSchema>;
+
+declare const appKeybindingOverridesSchema: z$1.ZodArray<
+  z$1.ZodObject<
+    {
+      command: z$1.ZodEnum<{
+        "thread.jump.1": "thread.jump.1";
+        "thread.jump.2": "thread.jump.2";
+        "thread.jump.3": "thread.jump.3";
+        "thread.jump.4": "thread.jump.4";
+        "thread.jump.5": "thread.jump.5";
+        "thread.jump.6": "thread.jump.6";
+        "thread.jump.7": "thread.jump.7";
+        "thread.jump.8": "thread.jump.8";
+        "thread.jump.9": "thread.jump.9";
+        "question.select.1": "question.select.1";
+        "question.select.2": "question.select.2";
+        "question.select.3": "question.select.3";
+        "question.select.4": "question.select.4";
+        "question.select.5": "question.select.5";
+        "question.select.6": "question.select.6";
+        "question.select.7": "question.select.7";
+        "question.select.8": "question.select.8";
+        "question.select.9": "question.select.9";
+        "pane.focus.1": "pane.focus.1";
+        "pane.focus.2": "pane.focus.2";
+        "pane.focus.3": "pane.focus.3";
+        "pane.focus.4": "pane.focus.4";
+        "pane.focus.5": "pane.focus.5";
+        "pane.focus.6": "pane.focus.6";
+        "pane.focus.7": "pane.focus.7";
+        "pane.focus.8": "pane.focus.8";
+        "thread.new": "thread.new";
+        "thread.search": "thread.search";
+        "thread.previous": "thread.previous";
+        "thread.next": "thread.next";
+        "pane.focus.previous": "pane.focus.previous";
+        "pane.focus.next": "pane.focus.next";
+        "pane.maximize.toggle": "pane.maximize.toggle";
+        "pane.close": "pane.close";
+        "window.new": "window.new";
+        "settings.open": "settings.open";
+        "settings.openServers": "settings.openServers";
+        "sidebar.toggle": "sidebar.toggle";
+        "panel.newTab": "panel.newTab";
+        "panel.close": "panel.close";
+        "panel.toggle": "panel.toggle";
+        "file.quickOpen": "file.quickOpen";
+        "diff.toggle": "diff.toggle";
+        "terminal.open": "terminal.open";
+        "composer.focus": "composer.focus";
+        "modelPicker.toggle": "modelPicker.toggle";
+        "browser.focusLocation": "browser.focusLocation";
+        "browser.reload": "browser.reload";
+        "workspace.openPreferred": "workspace.openPreferred";
+      }>;
+      shortcut: z$1.ZodNullable<
+        z$1.ZodObject<
+          {
+            key: z$1.ZodString;
+            mod: z$1.ZodBoolean;
+            meta: z$1.ZodBoolean;
+            control: z$1.ZodBoolean;
+            alt: z$1.ZodBoolean;
+            shift: z$1.ZodBoolean;
+          },
+          z$1.core.$strict
+        >
+      >;
+    },
+    z$1.core.$strict
+  >
+>;
+type AppKeybindingOverrides = z$1.infer<typeof appKeybindingOverridesSchema>;
+
+declare const appThemeSchema: z$1.ZodObject<
+  {
+    themeId: z$1.ZodString;
+    customCss: z$1.ZodNullable<z$1.ZodString>;
+    faviconColor: z$1.ZodEnum<{
+      default: "default";
+      red: "red";
+      orange: "orange";
+      yellow: "yellow";
+      green: "green";
+      teal: "teal";
+      blue: "blue";
+      purple: "purple";
+      pink: "pink";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type AppTheme = z$1.infer<typeof appThemeSchema>;
+/**
+ * The complete appearance selection a client sends when changing the palette
+ * and/or favicon tint. The server validates `themeId` (built-in id or an
+ * existing custom theme) and resolves the CSS from disk for custom themes.
+ * Callers changing only one facet must carry the other facet forward explicitly.
+ */
+declare const appThemeSelectionSchema: z$1.ZodObject<
+  {
+    themeId: z$1.ZodString;
+    faviconColor: z$1.ZodEnum<{
+      default: "default";
+      red: "red";
+      orange: "orange";
+      yellow: "yellow";
+      green: "green";
+      teal: "teal";
+      blue: "blue";
+      purple: "purple";
+      pink: "pink";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type AppThemeSelection = z$1.infer<typeof appThemeSelectionSchema>;
+
+declare const changedMessageSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"changed">;
+        entity: z$1.ZodLiteral<"thread">;
+        id: z$1.ZodOptional<z$1.ZodString>;
+        metadata: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              backgroundActivityChanged: z$1.ZodOptional<z$1.ZodBoolean>;
+              eventTypes: z$1.ZodOptional<
+                z$1.ZodReadonly<
+                  z$1.ZodArray<
+                    z$1.ZodString &
+                      z$1.ZodType<
+                        | "thread/started"
+                        | "thread/identity"
+                        | "turn/started"
+                        | "turn/completed"
+                        | "turn/input/accepted"
+                        | "thread/name/updated"
+                        | "thread/compacted"
+                        | "thread/goal/updated"
+                        | "thread/goal/cleared"
+                        | "item/started"
+                        | "item/completed"
+                        | "item/agentMessage/delta"
+                        | "item/commandExecution/outputDelta"
+                        | "item/fileChange/outputDelta"
+                        | "item/reasoning/summaryTextDelta"
+                        | "item/reasoning/textDelta"
+                        | "item/plan/delta"
+                        | "item/mcpToolCall/progress"
+                        | "item/toolCall/progress"
+                        | "item/backgroundTask/progress"
+                        | "item/backgroundTask/completed"
+                        | "thread/tokenUsage/updated"
+                        | "thread/contextWindowUsage/updated"
+                        | "turn/plan/updated"
+                        | "turn/diff/updated"
+                        | "provider/error"
+                        | "provider/warning"
+                        | "provider/modelFallback"
+                        | "provider/unhandled"
+                        | "client/thread/start"
+                        | "client/turn/requested"
+                        | "client/turn/start"
+                        | "system/error"
+                        | "system/manager/user_message"
+                        | "system/thread/interrupted"
+                        | "system/operation"
+                        | "system/permissionGrant/lifecycle"
+                        | "system/userQuestion/lifecycle"
+                        | "system/thread-provisioning"
+                        | "system/provider-turn-watchdog",
+                        string,
+                        z$1.core.$ZodTypeInternals<
+                          | "thread/started"
+                          | "thread/identity"
+                          | "turn/started"
+                          | "turn/completed"
+                          | "turn/input/accepted"
+                          | "thread/name/updated"
+                          | "thread/compacted"
+                          | "thread/goal/updated"
+                          | "thread/goal/cleared"
+                          | "item/started"
+                          | "item/completed"
+                          | "item/agentMessage/delta"
+                          | "item/commandExecution/outputDelta"
+                          | "item/fileChange/outputDelta"
+                          | "item/reasoning/summaryTextDelta"
+                          | "item/reasoning/textDelta"
+                          | "item/plan/delta"
+                          | "item/mcpToolCall/progress"
+                          | "item/toolCall/progress"
+                          | "item/backgroundTask/progress"
+                          | "item/backgroundTask/completed"
+                          | "thread/tokenUsage/updated"
+                          | "thread/contextWindowUsage/updated"
+                          | "turn/plan/updated"
+                          | "turn/diff/updated"
+                          | "provider/error"
+                          | "provider/warning"
+                          | "provider/modelFallback"
+                          | "provider/unhandled"
+                          | "client/thread/start"
+                          | "client/turn/requested"
+                          | "client/turn/start"
+                          | "system/error"
+                          | "system/manager/user_message"
+                          | "system/thread/interrupted"
+                          | "system/operation"
+                          | "system/permissionGrant/lifecycle"
+                          | "system/userQuestion/lifecycle"
+                          | "system/thread-provisioning"
+                          | "system/provider-turn-watchdog",
+                          string
+                        >
+                      >
+                  >
+                >
+              >;
+              hasPendingInteraction: z$1.ZodOptional<z$1.ZodBoolean>;
+              projectId: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >
+        >;
+        changes: z$1.ZodReadonly<
+          z$1.ZodArray<
+            z$1.ZodEnum<{
+              "thread-created": "thread-created";
+              "thread-deleted": "thread-deleted";
+              "events-appended": "events-appended";
+              "interactions-changed": "interactions-changed";
+              "status-changed": "status-changed";
+              "title-changed": "title-changed";
+              "queue-changed": "queue-changed";
+              "archived-changed": "archived-changed";
+              "pin-state-changed": "pin-state-changed";
+              "parent-changed": "parent-changed";
+              "environment-changed": "environment-changed";
+              "read-state-changed": "read-state-changed";
+              "order-changed": "order-changed";
+              "tabs-changed": "tabs-changed";
+              "terminals-changed": "terminals-changed";
+            }>
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"changed">;
+        entity: z$1.ZodLiteral<"project">;
+        id: z$1.ZodOptional<z$1.ZodString>;
+        changes: z$1.ZodReadonly<
+          z$1.ZodArray<
+            z$1.ZodEnum<{
+              "project-created": "project-created";
+              "project-updated": "project-updated";
+              "project-deleted": "project-deleted";
+              "project-sources-changed": "project-sources-changed";
+              "threads-changed": "threads-changed";
+              "project-order-changed": "project-order-changed";
+            }>
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"changed">;
+        entity: z$1.ZodLiteral<"environment">;
+        id: z$1.ZodOptional<z$1.ZodString>;
+        changes: z$1.ZodReadonly<
+          z$1.ZodArray<
+            z$1.ZodEnum<{
+              "status-changed": "status-changed";
+              "environment-created": "environment-created";
+              "environment-deleted": "environment-deleted";
+              "metadata-changed": "metadata-changed";
+              "work-status-changed": "work-status-changed";
+              "git-refs-changed": "git-refs-changed";
+              "thread-storage-changed": "thread-storage-changed";
+            }>
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"changed">;
+        entity: z$1.ZodLiteral<"host">;
+        id: z$1.ZodOptional<z$1.ZodString>;
+        changes: z$1.ZodReadonly<
+          z$1.ZodArray<
+            z$1.ZodEnum<{
+              "host-connected": "host-connected";
+              "host-disconnected": "host-disconnected";
+            }>
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"changed">;
+        entity: z$1.ZodLiteral<"system">;
+        changes: z$1.ZodReadonly<
+          z$1.ZodArray<
+            z$1.ZodEnum<{
+              "config-changed": "config-changed";
+              "plugins-changed": "plugins-changed";
+            }>
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "entity"
+>;
+type ChangedMessage = z$1.infer<typeof changedMessageSchema>;
+
+declare const environmentSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    name: z$1.ZodNullable<z$1.ZodString>;
+    projectId: z$1.ZodString;
+    hostId: z$1.ZodString;
+    path: z$1.ZodNullable<z$1.ZodString>;
+    managed: z$1.ZodBoolean;
+    isGitRepo: z$1.ZodBoolean;
+    isWorktree: z$1.ZodBoolean;
+    workspaceProvisionType: z$1.ZodEnum<{
+      unmanaged: "unmanaged";
+      "managed-worktree": "managed-worktree";
+      personal: "personal";
+    }>;
+    branchName: z$1.ZodNullable<z$1.ZodString>;
+    baseBranch: z$1.ZodNullable<z$1.ZodString>;
+    defaultBranch: z$1.ZodNullable<z$1.ZodString>;
+    mergeBaseBranch: z$1.ZodNullable<z$1.ZodString>;
+    status: z$1.ZodEnum<{
+      error: "error";
+      provisioning: "provisioning";
+      ready: "ready";
+      retiring: "retiring";
+      destroying: "destroying";
+      destroyed: "destroyed";
+    }>;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type Environment = z$1.infer<typeof environmentSchema>;
+
+/**
+ * User-opt-in experiments (the Settings → Experiments toggles). Distinct from
+ * `FeatureFlags`: flags are operator-set via env at server start, experiments
+ * are user-toggled at runtime and persisted server-side so server-owned
+ * policy (e.g. skill injection) can honor them.
+ *
+ * Every experiment defaults to off — opting in is the point.
+ */
+declare const experimentsSchema: z$1.ZodObject<
+  {
+    claudeCodeMockCliTraffic: z$1.ZodBoolean;
+    toolsHub: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type Experiments = z$1.infer<typeof experimentsSchema>;
+
+declare const hostSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    name: z$1.ZodString;
+    type: z$1.ZodEnum<{
+      persistent: "persistent";
+    }>;
+    status: z$1.ZodEnum<{
+      connected: "connected";
+      disconnected: "disconnected";
+    }>;
+    maxPermissionMode: z$1.ZodEnum<{
+      full: "full";
+      auto: "auto";
+      "accept-edits": "accept-edits";
+    }>;
+    lastSeenAt: z$1.ZodNullable<z$1.ZodNumber>;
+    lastRejectedProtocolVersion: z$1.ZodNullable<z$1.ZodNumber>;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type Host = z$1.infer<typeof hostSchema>;
+
+interface JsonObject {
+  [key: string]: JsonValue$1;
+}
+type JsonValue$1 =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue$1[]
+  | JsonObject;
+
+declare const pendingInteractionResolutionSchema: z$1.ZodUnion<
+  readonly [
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            decision: z$1.ZodLiteral<"allow_once">;
+            grantedPermissions: z$1.ZodNullable<
+              z$1.ZodObject<
+                {
+                  network: z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                  fileSystem: z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        read: z$1.ZodArray<z$1.ZodString>;
+                        write: z$1.ZodArray<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strict
+              >
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            decision: z$1.ZodLiteral<"allow_for_session">;
+            grantedPermissions: z$1.ZodNullable<
+              z$1.ZodObject<
+                {
+                  network: z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                  fileSystem: z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        read: z$1.ZodArray<z$1.ZodString>;
+                        write: z$1.ZodArray<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strict
+              >
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            decision: z$1.ZodLiteral<"deny">;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "decision"
+    >,
+    z$1.ZodObject<
+      {
+        kind: z$1.ZodLiteral<"user_answer">;
+        answers: z$1.ZodRecord<
+          z$1.ZodString,
+          z$1.ZodObject<
+            {
+              selected: z$1.ZodArray<z$1.ZodString>;
+              freeText: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        kind: z$1.ZodLiteral<"plugin_submitted">;
+      },
+      z$1.core.$strip
+    >,
+  ]
+>;
+type PendingInteractionResolution = z$1.infer<
+  typeof pendingInteractionResolutionSchema
+>;
+declare const providerPendingInteractionSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    status: z$1.ZodEnum<{
+      interrupted: "interrupted";
+      pending: "pending";
+      resolving: "resolving";
+      resolved: "resolved";
+    }>;
+    statusReason: z$1.ZodNullable<z$1.ZodString>;
+    createdAt: z$1.ZodNumber;
+    expiresAt: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodNumber>>;
+    resolvedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    turnId: z$1.ZodString;
+    providerId: z$1.ZodString;
+    providerThreadId: z$1.ZodString;
+    providerRequestId: z$1.ZodString;
+    origin: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          kind: z$1.ZodLiteral<"provider">;
+          providerId: z$1.ZodString;
+          providerThreadId: z$1.ZodString;
+          providerRequestId: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    payload: z$1.ZodUnion<
+      readonly [
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"approval">;
+            subject: z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"command">;
+                    itemId: z$1.ZodString;
+                    command: z$1.ZodString;
+                    cwd: z$1.ZodNullable<z$1.ZodString>;
+                    actions: z$1.ZodArray<
+                      z$1.ZodDiscriminatedUnion<
+                        [
+                          z$1.ZodObject<
+                            {
+                              type: z$1.ZodLiteral<"read">;
+                              command: z$1.ZodString;
+                              name: z$1.ZodString;
+                              path: z$1.ZodString;
+                            },
+                            z$1.core.$strip
+                          >,
+                          z$1.ZodObject<
+                            {
+                              type: z$1.ZodLiteral<"listFiles">;
+                              command: z$1.ZodString;
+                              path: z$1.ZodNullable<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >,
+                          z$1.ZodObject<
+                            {
+                              type: z$1.ZodLiteral<"search">;
+                              command: z$1.ZodString;
+                              query: z$1.ZodNullable<z$1.ZodString>;
+                              path: z$1.ZodNullable<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >,
+                          z$1.ZodObject<
+                            {
+                              type: z$1.ZodLiteral<"unknown">;
+                              command: z$1.ZodString;
+                            },
+                            z$1.core.$strip
+                          >,
+                        ],
+                        "type"
+                      >
+                    >;
+                    sessionGrant: z$1.ZodNullable<
+                      z$1.ZodObject<
+                        {
+                          network: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                          fileSystem: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                read: z$1.ZodArray<z$1.ZodString>;
+                                write: z$1.ZodArray<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                        },
+                        z$1.core.$strict
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"file_change">;
+                    itemId: z$1.ZodString;
+                    writeScope: z$1.ZodNullable<z$1.ZodString>;
+                    sessionGrant: z$1.ZodNullable<
+                      z$1.ZodObject<
+                        {
+                          network: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                          fileSystem: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                read: z$1.ZodArray<z$1.ZodString>;
+                                write: z$1.ZodArray<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                        },
+                        z$1.core.$strict
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"permission_grant">;
+                    itemId: z$1.ZodString;
+                    toolName: z$1.ZodNullable<z$1.ZodString>;
+                    permissions: z$1.ZodObject<
+                      {
+                        network: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        fileSystem: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              read: z$1.ZodArray<z$1.ZodString>;
+                              write: z$1.ZodArray<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                      },
+                      z$1.core.$strict
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "kind"
+            >;
+            reason: z$1.ZodNullable<z$1.ZodString>;
+            availableDecisions: z$1.ZodArray<
+              z$1.ZodEnum<{
+                allow_once: "allow_once";
+                allow_for_session: "allow_for_session";
+                deny: "deny";
+              }>
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"user_question">;
+            questions: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  id: z$1.ZodString;
+                  prompt: z$1.ZodString;
+                  shortLabel: z$1.ZodOptional<z$1.ZodString>;
+                  multiSelect: z$1.ZodBoolean;
+                  options: z$1.ZodOptional<
+                    z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          value: z$1.ZodString;
+                          label: z$1.ZodString;
+                          description: z$1.ZodOptional<z$1.ZodString>;
+                        },
+                        z$1.core.$strip
+                      >
+                    >
+                  >;
+                  allowFreeText: z$1.ZodBoolean;
+                },
+                z$1.core.$strip
+              >
+            >;
+          },
+          z$1.core.$strip
+        >,
+      ]
+    >;
+    resolution: z$1.ZodNullable<
+      z$1.ZodUnion<
+        readonly [
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  decision: z$1.ZodLiteral<"allow_once">;
+                  grantedPermissions: z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        network: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        fileSystem: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              read: z$1.ZodArray<z$1.ZodString>;
+                              write: z$1.ZodArray<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  decision: z$1.ZodLiteral<"allow_for_session">;
+                  grantedPermissions: z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        network: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        fileSystem: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              read: z$1.ZodArray<z$1.ZodString>;
+                              write: z$1.ZodArray<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  decision: z$1.ZodLiteral<"deny">;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "decision"
+          >,
+          z$1.ZodObject<
+            {
+              kind: z$1.ZodLiteral<"user_answer">;
+              answers: z$1.ZodRecord<
+                z$1.ZodString,
+                z$1.ZodObject<
+                  {
+                    selected: z$1.ZodArray<z$1.ZodString>;
+                    freeText: z$1.ZodOptional<z$1.ZodString>;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+        ]
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProviderPendingInteraction = z$1.infer<
+  typeof providerPendingInteractionSchema
+>;
+declare const pluginPendingInteractionSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    status: z$1.ZodEnum<{
+      interrupted: "interrupted";
+      pending: "pending";
+      resolving: "resolving";
+      resolved: "resolved";
+    }>;
+    statusReason: z$1.ZodNullable<z$1.ZodString>;
+    createdAt: z$1.ZodNumber;
+    expiresAt: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodNumber>>;
+    resolvedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    origin: z$1.ZodObject<
+      {
+        kind: z$1.ZodLiteral<"plugin">;
+        pluginId: z$1.ZodString;
+        rendererId: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >;
+    payload: z$1.ZodObject<
+      {
+        kind: z$1.ZodLiteral<"plugin">;
+        title: z$1.ZodString;
+        data: z$1.ZodType<
+          JsonValue$1,
+          unknown,
+          z$1.core.$ZodTypeInternals<JsonValue$1, unknown>
+        >;
+      },
+      z$1.core.$strip
+    >;
+    resolution: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          kind: z$1.ZodLiteral<"plugin_submitted">;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type PluginPendingInteraction = z$1.infer<
+  typeof pluginPendingInteractionSchema
+>;
+type PendingInteraction = ProviderPendingInteraction | PluginPendingInteraction;
+
+declare const projectSourceSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    projectId: z$1.ZodString;
+    isDefault: z$1.ZodBoolean;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    type: z$1.ZodLiteral<"local_path">;
+    hostId: z$1.ZodString;
+    path: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type ProjectSource = z$1.infer<typeof projectSourceSchema>;
+
+declare const reasoningLevelSchema: z$1.ZodEnum<{
+  none: "none";
+  low: "low";
+  medium: "medium";
+  high: "high";
+  xhigh: "xhigh";
+  ultracode: "ultracode";
+  max: "max";
+  ultra: "ultra";
+}>;
+type ReasoningLevel = z$1.infer<typeof reasoningLevelSchema>;
+declare const serviceTierSchema: z$1.ZodEnum<{
+  default: "default";
+  fast: "fast";
+}>;
+type ServiceTier = z$1.infer<typeof serviceTierSchema>;
+declare const permissionModeSchema: z$1.ZodEnum<{
+  full: "full";
+  auto: "auto";
+  "accept-edits": "accept-edits";
+}>;
+type PermissionMode = z$1.infer<typeof permissionModeSchema>;
+declare const promptInputSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        visibility: z$1.ZodOptional<
+          z$1.ZodEnum<{
+            "agent-only": "agent-only";
+          }>
+        >;
+        type: z$1.ZodLiteral<"text">;
+        text: z$1.ZodString;
+        mentions: z$1.ZodDefault<
+          z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                start: z$1.ZodNumber;
+                end: z$1.ZodNumber;
+                resource: z$1.ZodPipe<
+                  z$1.ZodTransform<unknown, unknown>,
+                  z$1.ZodDiscriminatedUnion<
+                    [
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"thread">;
+                          threadId: z$1.ZodString;
+                          projectId: z$1.ZodOptional<z$1.ZodString>;
+                          label: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"project">;
+                          projectId: z$1.ZodString;
+                          label: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"section">;
+                          sectionId: z$1.ZodString;
+                          label: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"path">;
+                          source: z$1.ZodEnum<{
+                            workspace: "workspace";
+                            "thread-storage": "thread-storage";
+                          }>;
+                          entryKind: z$1.ZodEnum<{
+                            file: "file";
+                            directory: "directory";
+                          }>;
+                          path: z$1.ZodString;
+                          label: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"command">;
+                          trigger: z$1.ZodEnum<{
+                            "/": "/";
+                          }>;
+                          name: z$1.ZodString;
+                          source: z$1.ZodEnum<{
+                            command: "command";
+                            skill: "skill";
+                          }>;
+                          origin: z$1.ZodEnum<{
+                            user: "user";
+                            project: "project";
+                            builtin: "builtin";
+                          }>;
+                          label: z$1.ZodString;
+                          argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"plugin">;
+                          pluginId: z$1.ZodString;
+                          icon: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+                          itemId: z$1.ZodString;
+                          label: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                    ],
+                    "kind"
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        visibility: z$1.ZodOptional<
+          z$1.ZodEnum<{
+            "agent-only": "agent-only";
+          }>
+        >;
+        type: z$1.ZodLiteral<"image">;
+        url: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        visibility: z$1.ZodOptional<
+          z$1.ZodEnum<{
+            "agent-only": "agent-only";
+          }>
+        >;
+        type: z$1.ZodLiteral<"localImage">;
+        path: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        visibility: z$1.ZodOptional<
+          z$1.ZodEnum<{
+            "agent-only": "agent-only";
+          }>
+        >;
+        type: z$1.ZodLiteral<"localFile">;
+        path: z$1.ZodString;
+        name: z$1.ZodOptional<z$1.ZodString>;
+        sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+        mimeType: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "type"
+>;
+type PromptInput = z$1.infer<typeof promptInputSchema>;
+declare const resolvedThreadExecutionOptionsSchema: z$1.ZodObject<
+  {
+    seq: z$1.ZodOptional<z$1.ZodNumber>;
+    model: z$1.ZodString;
+    serviceTier: z$1.ZodEnum<{
+      default: "default";
+      fast: "fast";
+    }>;
+    reasoningLevel: z$1.ZodEnum<{
+      none: "none";
+      low: "low";
+      medium: "medium";
+      high: "high";
+      xhigh: "xhigh";
+      ultracode: "ultracode";
+      max: "max";
+      ultra: "ultra";
+    }>;
+    permissionMode: z$1.ZodEnum<{
+      full: "full";
+      auto: "auto";
+      "accept-edits": "accept-edits";
+    }>;
+    source: z$1.ZodEnum<{
+      "client/thread/start": "client/thread/start";
+      "client/turn/requested": "client/turn/requested";
+      "client/turn/start": "client/turn/start";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type ResolvedThreadExecutionOptions = z$1.infer<
+  typeof resolvedThreadExecutionOptionsSchema
+>;
+declare const projectExecutionDefaultsSchema: z$1.ZodObject<
+  {
+    providerId: z$1.ZodString;
+    model: z$1.ZodString;
+    serviceTier: z$1.ZodEnum<{
+      default: "default";
+      fast: "fast";
+    }>;
+    reasoningLevel: z$1.ZodEnum<{
+      none: "none";
+      low: "low";
+      medium: "medium";
+      high: "high";
+      xhigh: "xhigh";
+      ultracode: "ultracode";
+      max: "max";
+      ultra: "ultra";
+    }>;
+    permissionMode: z$1.ZodEnum<{
+      full: "full";
+      auto: "auto";
+      "accept-edits": "accept-edits";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type ProjectExecutionDefaults = z$1.infer<
+  typeof projectExecutionDefaultsSchema
+>;
+
+/** All thread events — provider-originated or system-originated. */
+declare const threadEventSchema: z$1.ZodPipe<
+  z$1.ZodUnknown,
+  z$1.ZodUnion<
+    readonly [
+      z$1.ZodIntersection<
+        z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/started">;
+                threadId: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/identity">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"turn/started">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"turn/completed">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodNullable<z$1.ZodString>;
+                status: z$1.ZodEnum<{
+                  completed: "completed";
+                  failed: "failed";
+                  interrupted: "interrupted";
+                }>;
+                error: z$1.ZodOptional<
+                  z$1.ZodObject<
+                    {
+                      message: z$1.ZodString;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"turn/input/accepted">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                clientRequestId: z$1.ZodString;
+                scope: z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"thread">;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"turn">;
+                        turnId: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "kind"
+                >;
+              },
+              z$1.core.$strict
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/name/updated">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                threadName: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/compacted">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/goal/updated">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                objective: z$1.ZodString;
+                status: z$1.ZodEnum<{
+                  active: "active";
+                  paused: "paused";
+                  budgetLimited: "budgetLimited";
+                  complete: "complete";
+                }>;
+                tokenBudget: z$1.ZodNullable<z$1.ZodNumber>;
+                tokensUsed: z$1.ZodNumber;
+                timeUsedSeconds: z$1.ZodNumber;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/goal/cleared">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/started">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                item: z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"userMessage">;
+                        id: z$1.ZodString;
+                        content: z$1.ZodArray<
+                          z$1.ZodDiscriminatedUnion<
+                            [
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"text">;
+                                  text: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"image">;
+                                  url: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"localImage">;
+                                  path: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"localFile">;
+                                  path: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                            ],
+                            "type"
+                          >
+                        >;
+                        clientRequestId: z$1.ZodOptional<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strict
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"agentMessage">;
+                        id: z$1.ZodString;
+                        text: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"commandExecution">;
+                        id: z$1.ZodString;
+                        command: z$1.ZodString;
+                        cwd: z$1.ZodString;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        approvalStatus: z$1.ZodNullable<
+                          z$1.ZodEnum<{
+                            waiting_for_approval: "waiting_for_approval";
+                            denied: "denied";
+                          }>
+                        >;
+                        aggregatedOutput: z$1.ZodOptional<z$1.ZodString>;
+                        exitCode: z$1.ZodOptional<z$1.ZodNumber>;
+                        durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                        truncation: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              aggregatedOutput: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              result: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              resultText: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"fileChange">;
+                        id: z$1.ZodString;
+                        changes: z$1.ZodArray<
+                          z$1.ZodObject<
+                            {
+                              path: z$1.ZodString;
+                              kind: z$1.ZodEnum<{
+                                add: "add";
+                                delete: "delete";
+                                update: "update";
+                              }>;
+                              movePath: z$1.ZodOptional<z$1.ZodString>;
+                              diff: z$1.ZodOptional<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        approvalStatus: z$1.ZodNullable<
+                          z$1.ZodEnum<{
+                            waiting_for_approval: "waiting_for_approval";
+                            denied: "denied";
+                          }>
+                        >;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"webSearch">;
+                        id: z$1.ZodString;
+                        queries: z$1.ZodArray<z$1.ZodString>;
+                        resultText: z$1.ZodNullable<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"webFetch">;
+                        id: z$1.ZodString;
+                        url: z$1.ZodString;
+                        prompt: z$1.ZodNullable<z$1.ZodString>;
+                        pattern: z$1.ZodNullable<z$1.ZodString>;
+                        resultText: z$1.ZodNullable<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"imageView">;
+                        id: z$1.ZodString;
+                        path: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"toolCall">;
+                        id: z$1.ZodString;
+                        server: z$1.ZodOptional<z$1.ZodString>;
+                        tool: z$1.ZodString;
+                        arguments: z$1.ZodOptional<
+                          z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>
+                        >;
+                        statusLabels: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              pending: z$1.ZodString;
+                              completed: z$1.ZodString;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        result: z$1.ZodOptional<z$1.ZodUnknown>;
+                        error: z$1.ZodOptional<z$1.ZodString>;
+                        durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                        truncation: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              aggregatedOutput: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              result: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              resultText: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"reasoning">;
+                        id: z$1.ZodString;
+                        summary: z$1.ZodArray<z$1.ZodString>;
+                        content: z$1.ZodArray<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"plan">;
+                        id: z$1.ZodString;
+                        text: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"contextCompaction">;
+                        id: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"backgroundTask">;
+                        id: z$1.ZodString;
+                        taskType: z$1.ZodString;
+                        description: z$1.ZodString;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        taskStatus: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          paused: "paused";
+                          pending: "pending";
+                          running: "running";
+                          killed: "killed";
+                          stopped: "stopped";
+                        }>;
+                        skipTranscript: z$1.ZodBoolean;
+                        workflowName: z$1.ZodOptional<z$1.ZodString>;
+                        workflow: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              phases: z$1.ZodArray<
+                                z$1.ZodObject<
+                                  {
+                                    index: z$1.ZodNumber;
+                                    title: z$1.ZodString;
+                                    kind: z$1.ZodOptional<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              agents: z$1.ZodArray<
+                                z$1.ZodObject<
+                                  {
+                                    index: z$1.ZodNumber;
+                                    label: z$1.ZodString;
+                                    state: z$1.ZodEnum<{
+                                      failed: "failed";
+                                      running: "running";
+                                      queued: "queued";
+                                      done: "done";
+                                      skipped: "skipped";
+                                    }>;
+                                    model: z$1.ZodString;
+                                    attempt: z$1.ZodNumber;
+                                    cached: z$1.ZodBoolean;
+                                    lastProgressAt: z$1.ZodNumber;
+                                    phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                                    phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                                    agentType: z$1.ZodOptional<z$1.ZodString>;
+                                    isolation: z$1.ZodOptional<z$1.ZodString>;
+                                    queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                    startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                    lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                                    lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                                    promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                                    resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                                    error: z$1.ZodOptional<z$1.ZodString>;
+                                    tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                                    toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                                    durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        usage: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              totalTokens: z$1.ZodNumber;
+                              toolUses: z$1.ZodNumber;
+                              durationMs: z$1.ZodNumber;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        summary: z$1.ZodOptional<z$1.ZodString>;
+                        error: z$1.ZodOptional<z$1.ZodString>;
+                        outputFile: z$1.ZodOptional<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "type"
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/completed">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                item: z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"userMessage">;
+                        id: z$1.ZodString;
+                        content: z$1.ZodArray<
+                          z$1.ZodDiscriminatedUnion<
+                            [
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"text">;
+                                  text: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"image">;
+                                  url: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"localImage">;
+                                  path: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  type: z$1.ZodLiteral<"localFile">;
+                                  path: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                            ],
+                            "type"
+                          >
+                        >;
+                        clientRequestId: z$1.ZodOptional<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strict
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"agentMessage">;
+                        id: z$1.ZodString;
+                        text: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"commandExecution">;
+                        id: z$1.ZodString;
+                        command: z$1.ZodString;
+                        cwd: z$1.ZodString;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        approvalStatus: z$1.ZodNullable<
+                          z$1.ZodEnum<{
+                            waiting_for_approval: "waiting_for_approval";
+                            denied: "denied";
+                          }>
+                        >;
+                        aggregatedOutput: z$1.ZodOptional<z$1.ZodString>;
+                        exitCode: z$1.ZodOptional<z$1.ZodNumber>;
+                        durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                        truncation: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              aggregatedOutput: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              result: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              resultText: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"fileChange">;
+                        id: z$1.ZodString;
+                        changes: z$1.ZodArray<
+                          z$1.ZodObject<
+                            {
+                              path: z$1.ZodString;
+                              kind: z$1.ZodEnum<{
+                                add: "add";
+                                delete: "delete";
+                                update: "update";
+                              }>;
+                              movePath: z$1.ZodOptional<z$1.ZodString>;
+                              diff: z$1.ZodOptional<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        approvalStatus: z$1.ZodNullable<
+                          z$1.ZodEnum<{
+                            waiting_for_approval: "waiting_for_approval";
+                            denied: "denied";
+                          }>
+                        >;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"webSearch">;
+                        id: z$1.ZodString;
+                        queries: z$1.ZodArray<z$1.ZodString>;
+                        resultText: z$1.ZodNullable<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"webFetch">;
+                        id: z$1.ZodString;
+                        url: z$1.ZodString;
+                        prompt: z$1.ZodNullable<z$1.ZodString>;
+                        pattern: z$1.ZodNullable<z$1.ZodString>;
+                        resultText: z$1.ZodNullable<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"imageView">;
+                        id: z$1.ZodString;
+                        path: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"toolCall">;
+                        id: z$1.ZodString;
+                        server: z$1.ZodOptional<z$1.ZodString>;
+                        tool: z$1.ZodString;
+                        arguments: z$1.ZodOptional<
+                          z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>
+                        >;
+                        statusLabels: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              pending: z$1.ZodString;
+                              completed: z$1.ZodString;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        result: z$1.ZodOptional<z$1.ZodUnknown>;
+                        error: z$1.ZodOptional<z$1.ZodString>;
+                        durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                        truncation: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              aggregatedOutput: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              result: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              resultText: z$1.ZodOptional<
+                                z$1.ZodObject<
+                                  {
+                                    originalLength: z$1.ZodNumber;
+                                    retainedHeadLength: z$1.ZodNumber;
+                                    retainedTailLength: z$1.ZodNumber;
+                                    truncatedAt: z$1.ZodNumber;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"reasoning">;
+                        id: z$1.ZodString;
+                        summary: z$1.ZodArray<z$1.ZodString>;
+                        content: z$1.ZodArray<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"plan">;
+                        id: z$1.ZodString;
+                        text: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"contextCompaction">;
+                        id: z$1.ZodString;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        type: z$1.ZodLiteral<"backgroundTask">;
+                        id: z$1.ZodString;
+                        taskType: z$1.ZodString;
+                        description: z$1.ZodString;
+                        status: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          interrupted: "interrupted";
+                          pending: "pending";
+                        }>;
+                        taskStatus: z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          paused: "paused";
+                          pending: "pending";
+                          running: "running";
+                          killed: "killed";
+                          stopped: "stopped";
+                        }>;
+                        skipTranscript: z$1.ZodBoolean;
+                        workflowName: z$1.ZodOptional<z$1.ZodString>;
+                        workflow: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              phases: z$1.ZodArray<
+                                z$1.ZodObject<
+                                  {
+                                    index: z$1.ZodNumber;
+                                    title: z$1.ZodString;
+                                    kind: z$1.ZodOptional<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              agents: z$1.ZodArray<
+                                z$1.ZodObject<
+                                  {
+                                    index: z$1.ZodNumber;
+                                    label: z$1.ZodString;
+                                    state: z$1.ZodEnum<{
+                                      failed: "failed";
+                                      running: "running";
+                                      queued: "queued";
+                                      done: "done";
+                                      skipped: "skipped";
+                                    }>;
+                                    model: z$1.ZodString;
+                                    attempt: z$1.ZodNumber;
+                                    cached: z$1.ZodBoolean;
+                                    lastProgressAt: z$1.ZodNumber;
+                                    phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                                    phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                                    agentType: z$1.ZodOptional<z$1.ZodString>;
+                                    isolation: z$1.ZodOptional<z$1.ZodString>;
+                                    queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                    startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                    lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                                    lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                                    promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                                    resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                                    error: z$1.ZodOptional<z$1.ZodString>;
+                                    tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                                    toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                                    durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        usage: z$1.ZodOptional<
+                          z$1.ZodObject<
+                            {
+                              totalTokens: z$1.ZodNumber;
+                              toolUses: z$1.ZodNumber;
+                              durationMs: z$1.ZodNumber;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        summary: z$1.ZodOptional<z$1.ZodString>;
+                        error: z$1.ZodOptional<z$1.ZodString>;
+                        outputFile: z$1.ZodOptional<z$1.ZodString>;
+                        parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "type"
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/agentMessage/delta">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                delta: z$1.ZodString;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/commandExecution/outputDelta">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                delta: z$1.ZodString;
+                reset: z$1.ZodOptional<z$1.ZodBoolean>;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/fileChange/outputDelta">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                delta: z$1.ZodString;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/reasoning/summaryTextDelta">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                delta: z$1.ZodString;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/reasoning/textDelta">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                delta: z$1.ZodString;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/plan/delta">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                delta: z$1.ZodString;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/mcpToolCall/progress">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                message: z$1.ZodOptional<z$1.ZodString>;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/toolCall/progress">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                itemId: z$1.ZodString;
+                message: z$1.ZodOptional<z$1.ZodString>;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/backgroundTask/progress">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                item: z$1.ZodObject<
+                  {
+                    type: z$1.ZodLiteral<"backgroundTask">;
+                    id: z$1.ZodString;
+                    taskType: z$1.ZodString;
+                    description: z$1.ZodString;
+                    status: z$1.ZodEnum<{
+                      completed: "completed";
+                      failed: "failed";
+                      interrupted: "interrupted";
+                      pending: "pending";
+                    }>;
+                    taskStatus: z$1.ZodEnum<{
+                      completed: "completed";
+                      failed: "failed";
+                      paused: "paused";
+                      pending: "pending";
+                      running: "running";
+                      killed: "killed";
+                      stopped: "stopped";
+                    }>;
+                    skipTranscript: z$1.ZodBoolean;
+                    workflowName: z$1.ZodOptional<z$1.ZodString>;
+                    workflow: z$1.ZodOptional<
+                      z$1.ZodObject<
+                        {
+                          phases: z$1.ZodArray<
+                            z$1.ZodObject<
+                              {
+                                index: z$1.ZodNumber;
+                                title: z$1.ZodString;
+                                kind: z$1.ZodOptional<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                          agents: z$1.ZodArray<
+                            z$1.ZodObject<
+                              {
+                                index: z$1.ZodNumber;
+                                label: z$1.ZodString;
+                                state: z$1.ZodEnum<{
+                                  failed: "failed";
+                                  running: "running";
+                                  queued: "queued";
+                                  done: "done";
+                                  skipped: "skipped";
+                                }>;
+                                model: z$1.ZodString;
+                                attempt: z$1.ZodNumber;
+                                cached: z$1.ZodBoolean;
+                                lastProgressAt: z$1.ZodNumber;
+                                phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                                phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                                agentType: z$1.ZodOptional<z$1.ZodString>;
+                                isolation: z$1.ZodOptional<z$1.ZodString>;
+                                queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                                lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                                promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                                resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                                error: z$1.ZodOptional<z$1.ZodString>;
+                                tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                                toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                                durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                    usage: z$1.ZodOptional<
+                      z$1.ZodObject<
+                        {
+                          totalTokens: z$1.ZodNumber;
+                          toolUses: z$1.ZodNumber;
+                          durationMs: z$1.ZodNumber;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                    summary: z$1.ZodOptional<z$1.ZodString>;
+                    error: z$1.ZodOptional<z$1.ZodString>;
+                    outputFile: z$1.ZodOptional<z$1.ZodString>;
+                    parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"item/backgroundTask/completed">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                item: z$1.ZodObject<
+                  {
+                    type: z$1.ZodLiteral<"backgroundTask">;
+                    id: z$1.ZodString;
+                    taskType: z$1.ZodString;
+                    description: z$1.ZodString;
+                    status: z$1.ZodEnum<{
+                      completed: "completed";
+                      failed: "failed";
+                      interrupted: "interrupted";
+                      pending: "pending";
+                    }>;
+                    taskStatus: z$1.ZodEnum<{
+                      completed: "completed";
+                      failed: "failed";
+                      paused: "paused";
+                      pending: "pending";
+                      running: "running";
+                      killed: "killed";
+                      stopped: "stopped";
+                    }>;
+                    skipTranscript: z$1.ZodBoolean;
+                    workflowName: z$1.ZodOptional<z$1.ZodString>;
+                    workflow: z$1.ZodOptional<
+                      z$1.ZodObject<
+                        {
+                          phases: z$1.ZodArray<
+                            z$1.ZodObject<
+                              {
+                                index: z$1.ZodNumber;
+                                title: z$1.ZodString;
+                                kind: z$1.ZodOptional<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                          agents: z$1.ZodArray<
+                            z$1.ZodObject<
+                              {
+                                index: z$1.ZodNumber;
+                                label: z$1.ZodString;
+                                state: z$1.ZodEnum<{
+                                  failed: "failed";
+                                  running: "running";
+                                  queued: "queued";
+                                  done: "done";
+                                  skipped: "skipped";
+                                }>;
+                                model: z$1.ZodString;
+                                attempt: z$1.ZodNumber;
+                                cached: z$1.ZodBoolean;
+                                lastProgressAt: z$1.ZodNumber;
+                                phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                                phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                                agentType: z$1.ZodOptional<z$1.ZodString>;
+                                isolation: z$1.ZodOptional<z$1.ZodString>;
+                                queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                                lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                                lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                                promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                                resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                                error: z$1.ZodOptional<z$1.ZodString>;
+                                tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                                toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                                durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                    usage: z$1.ZodOptional<
+                      z$1.ZodObject<
+                        {
+                          totalTokens: z$1.ZodNumber;
+                          toolUses: z$1.ZodNumber;
+                          durationMs: z$1.ZodNumber;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                    summary: z$1.ZodOptional<z$1.ZodString>;
+                    error: z$1.ZodOptional<z$1.ZodString>;
+                    outputFile: z$1.ZodOptional<z$1.ZodString>;
+                    parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/tokenUsage/updated">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                tokenUsage: z$1.ZodObject<
+                  {
+                    total: z$1.ZodObject<
+                      {
+                        totalTokens: z$1.ZodNumber;
+                        inputTokens: z$1.ZodNumber;
+                        cachedInputTokens: z$1.ZodNumber;
+                        outputTokens: z$1.ZodNumber;
+                        reasoningOutputTokens: z$1.ZodNumber;
+                      },
+                      z$1.core.$strip
+                    >;
+                    last: z$1.ZodObject<
+                      {
+                        totalTokens: z$1.ZodNumber;
+                        inputTokens: z$1.ZodNumber;
+                        cachedInputTokens: z$1.ZodNumber;
+                        outputTokens: z$1.ZodNumber;
+                        reasoningOutputTokens: z$1.ZodNumber;
+                      },
+                      z$1.core.$strip
+                    >;
+                    modelContextWindow: z$1.ZodNullable<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"thread/contextWindowUsage/updated">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                contextWindowUsage: z$1.ZodObject<
+                  {
+                    usedTokens: z$1.ZodNullable<z$1.ZodNumber>;
+                    modelContextWindow: z$1.ZodNullable<z$1.ZodNumber>;
+                    estimated: z$1.ZodBoolean;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"turn/plan/updated">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                plan: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      step: z$1.ZodString;
+                      status: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          active: "active";
+                          pending: "pending";
+                        }>
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+                explanation: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"turn/diff/updated">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                diff: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"provider/error">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                message: z$1.ZodString;
+                detail: z$1.ZodOptional<z$1.ZodString>;
+                willRetry: z$1.ZodOptional<z$1.ZodBoolean>;
+                errorInfo: z$1.ZodOptional<
+                  z$1.ZodObject<
+                    {
+                      category: z$1.ZodEnum<{
+                        unknown: "unknown";
+                        "active-turn-not-steerable": "active-turn-not-steerable";
+                        "bad-request": "bad-request";
+                        "connection-failed": "connection-failed";
+                        "context-window-exceeded": "context-window-exceeded";
+                        billing: "billing";
+                        "budget-exceeded": "budget-exceeded";
+                        internal: "internal";
+                        "max-output-tokens": "max-output-tokens";
+                        "max-turns": "max-turns";
+                        overloaded: "overloaded";
+                        policy: "policy";
+                        "rate-limit": "rate-limit";
+                        sandbox: "sandbox";
+                        "stream-disconnected": "stream-disconnected";
+                        "structured-output-retries": "structured-output-retries";
+                        "thread-rollback-failed": "thread-rollback-failed";
+                        "too-many-failed-attempts": "too-many-failed-attempts";
+                        unauthorized: "unauthorized";
+                      }>;
+                      providerCode: z$1.ZodNullable<z$1.ZodString>;
+                      httpStatusCode: z$1.ZodNullable<z$1.ZodNumber>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"provider/warning">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                category: z$1.ZodEnum<{
+                  deprecation: "deprecation";
+                  config: "config";
+                  general: "general";
+                }>;
+                summary: z$1.ZodOptional<z$1.ZodString>;
+                details: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"provider/modelFallback">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                originalModel: z$1.ZodString;
+                fallbackModel: z$1.ZodString;
+                reason: z$1.ZodEnum<{
+                  refusal: "refusal";
+                  provider: "provider";
+                }>;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"provider/unhandled">;
+                threadId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                providerId: z$1.ZodString;
+                rawType: z$1.ZodString;
+                rawEvent: z$1.ZodObject<
+                  {
+                    jsonrpc: z$1.ZodLiteral<"2.0">;
+                    id: z$1.ZodOptional<
+                      z$1.ZodUnion<readonly [z$1.ZodString, z$1.ZodNumber]>
+                    >;
+                    method: z$1.ZodString;
+                    params: z$1.ZodOptional<
+                      z$1.ZodType<
+                        JsonValue$1,
+                        unknown,
+                        z$1.core.$ZodTypeInternals<JsonValue$1, unknown>
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >;
+                parentToolCallId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >,
+        z$1.ZodObject<
+          {
+            scope: z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"thread">;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"turn">;
+                    turnId: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "kind"
+            >;
+          },
+          z$1.core.$strip
+        >
+      >,
+      z$1.ZodIntersection<
+        z$1.ZodUnion<
+          readonly [
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"client/thread/start">;
+                threadId: z$1.ZodString;
+                direction: z$1.ZodLiteral<"outbound">;
+                source: z$1.ZodEnum<{
+                  spawn: "spawn";
+                  tell: "tell";
+                }>;
+                initiator: z$1.ZodEnum<{
+                  system: "system";
+                  user: "user";
+                  agent: "agent";
+                }>;
+                request: z$1.ZodObject<
+                  {
+                    method: z$1.ZodEnum<{
+                      "thread/start": "thread/start";
+                      "turn/start": "turn/start";
+                    }>;
+                    params: z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"client/turn/requested">;
+                threadId: z$1.ZodString;
+                direction: z$1.ZodLiteral<"outbound">;
+                requestId: z$1.ZodString;
+                source: z$1.ZodEnum<{
+                  spawn: "spawn";
+                  tell: "tell";
+                }>;
+                initiator: z$1.ZodEnum<{
+                  system: "system";
+                  user: "user";
+                  agent: "agent";
+                }>;
+                senderThreadId: z$1.ZodNullable<z$1.ZodString>;
+                systemMessageKind: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "ownership-assigned": "ownership-assigned";
+                    "ownership-removed": "ownership-removed";
+                    "child-needs-attention": "child-needs-attention";
+                    "child-completed": "child-completed";
+                    "child-failed": "child-failed";
+                    "child-interrupted": "child-interrupted";
+                    "child-outcome-batch": "child-outcome-batch";
+                    unlabeled: "unlabeled";
+                  }>
+                >;
+                systemMessageSubject: z$1.ZodOptional<
+                  z$1.ZodNullable<
+                    z$1.ZodDiscriminatedUnion<
+                      [
+                        z$1.ZodObject<
+                          {
+                            kind: z$1.ZodLiteral<"thread">;
+                            threadId: z$1.ZodString;
+                            threadName: z$1.ZodString;
+                          },
+                          z$1.core.$strip
+                        >,
+                        z$1.ZodObject<
+                          {
+                            kind: z$1.ZodLiteral<"thread-batch">;
+                            count: z$1.ZodNumber;
+                          },
+                          z$1.core.$strip
+                        >,
+                      ],
+                      "kind"
+                    >
+                  >
+                >;
+                input: z$1.ZodArray<
+                  z$1.ZodDiscriminatedUnion<
+                    [
+                      z$1.ZodObject<
+                        {
+                          visibility: z$1.ZodOptional<
+                            z$1.ZodEnum<{
+                              "agent-only": "agent-only";
+                            }>
+                          >;
+                          type: z$1.ZodLiteral<"text">;
+                          text: z$1.ZodString;
+                          mentions: z$1.ZodDefault<
+                            z$1.ZodArray<
+                              z$1.ZodObject<
+                                {
+                                  start: z$1.ZodNumber;
+                                  end: z$1.ZodNumber;
+                                  resource: z$1.ZodPipe<
+                                    z$1.ZodTransform<unknown, unknown>,
+                                    z$1.ZodDiscriminatedUnion<
+                                      [
+                                        z$1.ZodObject<
+                                          {
+                                            kind: z$1.ZodLiteral<"thread">;
+                                            threadId: z$1.ZodString;
+                                            projectId: z$1.ZodOptional<z$1.ZodString>;
+                                            label: z$1.ZodString;
+                                          },
+                                          z$1.core.$strip
+                                        >,
+                                        z$1.ZodObject<
+                                          {
+                                            kind: z$1.ZodLiteral<"project">;
+                                            projectId: z$1.ZodString;
+                                            label: z$1.ZodString;
+                                          },
+                                          z$1.core.$strip
+                                        >,
+                                        z$1.ZodObject<
+                                          {
+                                            kind: z$1.ZodLiteral<"section">;
+                                            sectionId: z$1.ZodString;
+                                            label: z$1.ZodString;
+                                          },
+                                          z$1.core.$strip
+                                        >,
+                                        z$1.ZodObject<
+                                          {
+                                            kind: z$1.ZodLiteral<"path">;
+                                            source: z$1.ZodEnum<{
+                                              workspace: "workspace";
+                                              "thread-storage": "thread-storage";
+                                            }>;
+                                            entryKind: z$1.ZodEnum<{
+                                              file: "file";
+                                              directory: "directory";
+                                            }>;
+                                            path: z$1.ZodString;
+                                            label: z$1.ZodString;
+                                          },
+                                          z$1.core.$strip
+                                        >,
+                                        z$1.ZodObject<
+                                          {
+                                            kind: z$1.ZodLiteral<"command">;
+                                            trigger: z$1.ZodEnum<{
+                                              "/": "/";
+                                            }>;
+                                            name: z$1.ZodString;
+                                            source: z$1.ZodEnum<{
+                                              command: "command";
+                                              skill: "skill";
+                                            }>;
+                                            origin: z$1.ZodEnum<{
+                                              user: "user";
+                                              project: "project";
+                                              builtin: "builtin";
+                                            }>;
+                                            label: z$1.ZodString;
+                                            argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                          },
+                                          z$1.core.$strip
+                                        >,
+                                        z$1.ZodObject<
+                                          {
+                                            kind: z$1.ZodLiteral<"plugin">;
+                                            pluginId: z$1.ZodString;
+                                            icon: z$1.ZodOptional<
+                                              z$1.ZodNullable<z$1.ZodString>
+                                            >;
+                                            itemId: z$1.ZodString;
+                                            label: z$1.ZodString;
+                                          },
+                                          z$1.core.$strip
+                                        >,
+                                      ],
+                                      "kind"
+                                    >
+                                  >;
+                                },
+                                z$1.core.$strip
+                              >
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          visibility: z$1.ZodOptional<
+                            z$1.ZodEnum<{
+                              "agent-only": "agent-only";
+                            }>
+                          >;
+                          type: z$1.ZodLiteral<"image">;
+                          url: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          visibility: z$1.ZodOptional<
+                            z$1.ZodEnum<{
+                              "agent-only": "agent-only";
+                            }>
+                          >;
+                          type: z$1.ZodLiteral<"localImage">;
+                          path: z$1.ZodString;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          visibility: z$1.ZodOptional<
+                            z$1.ZodEnum<{
+                              "agent-only": "agent-only";
+                            }>
+                          >;
+                          type: z$1.ZodLiteral<"localFile">;
+                          path: z$1.ZodString;
+                          name: z$1.ZodOptional<z$1.ZodString>;
+                          sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                          mimeType: z$1.ZodOptional<z$1.ZodString>;
+                        },
+                        z$1.core.$strip
+                      >,
+                    ],
+                    "type"
+                  >
+                >;
+                inputGroups: z$1.ZodOptional<
+                  z$1.ZodArray<
+                    z$1.ZodArray<
+                      z$1.ZodDiscriminatedUnion<
+                        [
+                          z$1.ZodObject<
+                            {
+                              visibility: z$1.ZodOptional<
+                                z$1.ZodEnum<{
+                                  "agent-only": "agent-only";
+                                }>
+                              >;
+                              type: z$1.ZodLiteral<"text">;
+                              text: z$1.ZodString;
+                              mentions: z$1.ZodDefault<
+                                z$1.ZodArray<
+                                  z$1.ZodObject<
+                                    {
+                                      start: z$1.ZodNumber;
+                                      end: z$1.ZodNumber;
+                                      resource: z$1.ZodPipe<
+                                        z$1.ZodTransform<unknown, unknown>,
+                                        z$1.ZodDiscriminatedUnion<
+                                          [
+                                            z$1.ZodObject<
+                                              {
+                                                kind: z$1.ZodLiteral<"thread">;
+                                                threadId: z$1.ZodString;
+                                                projectId: z$1.ZodOptional<z$1.ZodString>;
+                                                label: z$1.ZodString;
+                                              },
+                                              z$1.core.$strip
+                                            >,
+                                            z$1.ZodObject<
+                                              {
+                                                kind: z$1.ZodLiteral<"project">;
+                                                projectId: z$1.ZodString;
+                                                label: z$1.ZodString;
+                                              },
+                                              z$1.core.$strip
+                                            >,
+                                            z$1.ZodObject<
+                                              {
+                                                kind: z$1.ZodLiteral<"section">;
+                                                sectionId: z$1.ZodString;
+                                                label: z$1.ZodString;
+                                              },
+                                              z$1.core.$strip
+                                            >,
+                                            z$1.ZodObject<
+                                              {
+                                                kind: z$1.ZodLiteral<"path">;
+                                                source: z$1.ZodEnum<{
+                                                  workspace: "workspace";
+                                                  "thread-storage": "thread-storage";
+                                                }>;
+                                                entryKind: z$1.ZodEnum<{
+                                                  file: "file";
+                                                  directory: "directory";
+                                                }>;
+                                                path: z$1.ZodString;
+                                                label: z$1.ZodString;
+                                              },
+                                              z$1.core.$strip
+                                            >,
+                                            z$1.ZodObject<
+                                              {
+                                                kind: z$1.ZodLiteral<"command">;
+                                                trigger: z$1.ZodEnum<{
+                                                  "/": "/";
+                                                }>;
+                                                name: z$1.ZodString;
+                                                source: z$1.ZodEnum<{
+                                                  command: "command";
+                                                  skill: "skill";
+                                                }>;
+                                                origin: z$1.ZodEnum<{
+                                                  user: "user";
+                                                  project: "project";
+                                                  builtin: "builtin";
+                                                }>;
+                                                label: z$1.ZodString;
+                                                argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                              },
+                                              z$1.core.$strip
+                                            >,
+                                            z$1.ZodObject<
+                                              {
+                                                kind: z$1.ZodLiteral<"plugin">;
+                                                pluginId: z$1.ZodString;
+                                                icon: z$1.ZodOptional<
+                                                  z$1.ZodNullable<z$1.ZodString>
+                                                >;
+                                                itemId: z$1.ZodString;
+                                                label: z$1.ZodString;
+                                              },
+                                              z$1.core.$strip
+                                            >,
+                                          ],
+                                          "kind"
+                                        >
+                                      >;
+                                    },
+                                    z$1.core.$strip
+                                  >
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >,
+                          z$1.ZodObject<
+                            {
+                              visibility: z$1.ZodOptional<
+                                z$1.ZodEnum<{
+                                  "agent-only": "agent-only";
+                                }>
+                              >;
+                              type: z$1.ZodLiteral<"image">;
+                              url: z$1.ZodString;
+                            },
+                            z$1.core.$strip
+                          >,
+                          z$1.ZodObject<
+                            {
+                              visibility: z$1.ZodOptional<
+                                z$1.ZodEnum<{
+                                  "agent-only": "agent-only";
+                                }>
+                              >;
+                              type: z$1.ZodLiteral<"localImage">;
+                              path: z$1.ZodString;
+                            },
+                            z$1.core.$strip
+                          >,
+                          z$1.ZodObject<
+                            {
+                              visibility: z$1.ZodOptional<
+                                z$1.ZodEnum<{
+                                  "agent-only": "agent-only";
+                                }>
+                              >;
+                              type: z$1.ZodLiteral<"localFile">;
+                              path: z$1.ZodString;
+                              name: z$1.ZodOptional<z$1.ZodString>;
+                              sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                              mimeType: z$1.ZodOptional<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >,
+                        ],
+                        "type"
+                      >
+                    >
+                  >
+                >;
+                target: z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"thread-start">;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"new-turn">;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"auto">;
+                        expectedTurnId: z$1.ZodNullable<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"steer">;
+                        expectedTurnId: z$1.ZodNullable<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "kind"
+                >;
+                request: z$1.ZodObject<
+                  {
+                    method: z$1.ZodEnum<{
+                      "thread/start": "thread/start";
+                      "turn/start": "turn/start";
+                    }>;
+                    params: z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>;
+                  },
+                  z$1.core.$strip
+                >;
+                execution: z$1.ZodObject<
+                  {
+                    seq: z$1.ZodOptional<z$1.ZodNumber>;
+                    model: z$1.ZodString;
+                    serviceTier: z$1.ZodEnum<{
+                      default: "default";
+                      fast: "fast";
+                    }>;
+                    reasoningLevel: z$1.ZodEnum<{
+                      none: "none";
+                      low: "low";
+                      medium: "medium";
+                      high: "high";
+                      xhigh: "xhigh";
+                      ultracode: "ultracode";
+                      max: "max";
+                      ultra: "ultra";
+                    }>;
+                    source: z$1.ZodEnum<{
+                      "client/thread/start": "client/thread/start";
+                      "client/turn/requested": "client/turn/requested";
+                      "client/turn/start": "client/turn/start";
+                    }>;
+                    permissionMode: z$1.ZodEnum<{
+                      readonly: "readonly";
+                      full: "full";
+                      auto: "auto";
+                      "accept-edits": "accept-edits";
+                      "workspace-write": "workspace-write";
+                    }>;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"client/turn/start">;
+                threadId: z$1.ZodString;
+                direction: z$1.ZodLiteral<"outbound">;
+                source: z$1.ZodEnum<{
+                  spawn: "spawn";
+                  tell: "tell";
+                }>;
+                initiator: z$1.ZodEnum<{
+                  system: "system";
+                  user: "user";
+                  agent: "agent";
+                }>;
+                request: z$1.ZodObject<
+                  {
+                    method: z$1.ZodEnum<{
+                      "thread/start": "thread/start";
+                      "turn/start": "turn/start";
+                    }>;
+                    params: z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/error">;
+                threadId: z$1.ZodString;
+                code: z$1.ZodOptional<z$1.ZodString>;
+                message: z$1.ZodString;
+                detail: z$1.ZodOptional<z$1.ZodString>;
+                reconnectAttempt: z$1.ZodOptional<z$1.ZodNumber>;
+                reconnectTotal: z$1.ZodOptional<z$1.ZodNumber>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/manager/user_message">;
+                threadId: z$1.ZodString;
+                text: z$1.ZodString;
+                toolCallId: z$1.ZodOptional<z$1.ZodString>;
+                turnId: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/thread/interrupted">;
+                threadId: z$1.ZodString;
+                reason: z$1.ZodEnum<{
+                  "manual-stop": "manual-stop";
+                  "host-daemon-restarted": "host-daemon-restarted";
+                  "provider-turn-idle": "provider-turn-idle";
+                }>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/operation">;
+                threadId: z$1.ZodString;
+                operation: z$1.ZodString;
+                status: z$1.ZodString;
+                message: z$1.ZodString;
+                operationId: z$1.ZodString;
+                metadata: z$1.ZodOptional<
+                  z$1.ZodRecord<
+                    z$1.ZodString,
+                    z$1.ZodType<
+                      JsonValue$1,
+                      unknown,
+                      z$1.core.$ZodTypeInternals<JsonValue$1, unknown>
+                    >
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/permissionGrant/lifecycle">;
+                threadId: z$1.ZodString;
+                interactionId: z$1.ZodString;
+                providerId: z$1.ZodString;
+                providerRequestId: z$1.ZodString;
+                status: z$1.ZodEnum<{
+                  interrupted: "interrupted";
+                  pending: "pending";
+                  resolving: "resolving";
+                  resolved: "resolved";
+                }>;
+                resolution: z$1.ZodDefault<
+                  z$1.ZodNullable<
+                    z$1.ZodDiscriminatedUnion<
+                      [
+                        z$1.ZodObject<
+                          {
+                            decision: z$1.ZodLiteral<"allow_once">;
+                            grantedPermissions: z$1.ZodNullable<
+                              z$1.ZodObject<
+                                {
+                                  network: z$1.ZodNullable<
+                                    z$1.ZodObject<
+                                      {
+                                        enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                      },
+                                      z$1.core.$strip
+                                    >
+                                  >;
+                                  fileSystem: z$1.ZodNullable<
+                                    z$1.ZodObject<
+                                      {
+                                        read: z$1.ZodArray<z$1.ZodString>;
+                                        write: z$1.ZodArray<z$1.ZodString>;
+                                      },
+                                      z$1.core.$strip
+                                    >
+                                  >;
+                                },
+                                z$1.core.$strict
+                              >
+                            >;
+                          },
+                          z$1.core.$strip
+                        >,
+                        z$1.ZodObject<
+                          {
+                            decision: z$1.ZodLiteral<"allow_for_session">;
+                            grantedPermissions: z$1.ZodNullable<
+                              z$1.ZodObject<
+                                {
+                                  network: z$1.ZodNullable<
+                                    z$1.ZodObject<
+                                      {
+                                        enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                      },
+                                      z$1.core.$strip
+                                    >
+                                  >;
+                                  fileSystem: z$1.ZodNullable<
+                                    z$1.ZodObject<
+                                      {
+                                        read: z$1.ZodArray<z$1.ZodString>;
+                                        write: z$1.ZodArray<z$1.ZodString>;
+                                      },
+                                      z$1.core.$strip
+                                    >
+                                  >;
+                                },
+                                z$1.core.$strict
+                              >
+                            >;
+                          },
+                          z$1.core.$strip
+                        >,
+                        z$1.ZodObject<
+                          {
+                            decision: z$1.ZodLiteral<"deny">;
+                          },
+                          z$1.core.$strip
+                        >,
+                      ],
+                      "decision"
+                    >
+                  >
+                >;
+                statusReason: z$1.ZodDefault<z$1.ZodNullable<z$1.ZodString>>;
+                subject: z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"permission_grant">;
+                    itemId: z$1.ZodString;
+                    toolName: z$1.ZodNullable<z$1.ZodString>;
+                    permissions: z$1.ZodObject<
+                      {
+                        network: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                        fileSystem: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              read: z$1.ZodArray<z$1.ZodString>;
+                              write: z$1.ZodArray<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                      },
+                      z$1.core.$strict
+                    >;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/userQuestion/lifecycle">;
+                threadId: z$1.ZodString;
+                interactionId: z$1.ZodString;
+                providerId: z$1.ZodString;
+                providerRequestId: z$1.ZodString;
+                status: z$1.ZodEnum<{
+                  interrupted: "interrupted";
+                  pending: "pending";
+                  resolving: "resolving";
+                  resolved: "resolved";
+                }>;
+                resolution: z$1.ZodDefault<
+                  z$1.ZodNullable<
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"user_answer">;
+                        answers: z$1.ZodRecord<
+                          z$1.ZodString,
+                          z$1.ZodObject<
+                            {
+                              selected: z$1.ZodArray<z$1.ZodString>;
+                              freeText: z$1.ZodOptional<z$1.ZodString>;
+                            },
+                            z$1.core.$strip
+                          >
+                        >;
+                      },
+                      z$1.core.$strip
+                    >
+                  >
+                >;
+                statusReason: z$1.ZodDefault<z$1.ZodNullable<z$1.ZodString>>;
+                payload: z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"user_question">;
+                    questions: z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          id: z$1.ZodString;
+                          prompt: z$1.ZodString;
+                          shortLabel: z$1.ZodOptional<z$1.ZodString>;
+                          multiSelect: z$1.ZodBoolean;
+                          options: z$1.ZodOptional<
+                            z$1.ZodArray<
+                              z$1.ZodObject<
+                                {
+                                  value: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                  description: z$1.ZodOptional<z$1.ZodString>;
+                                },
+                                z$1.core.$strip
+                              >
+                            >
+                          >;
+                          allowFreeText: z$1.ZodBoolean;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/thread-provisioning">;
+                threadId: z$1.ZodString;
+                provisioningId: z$1.ZodString;
+                status: z$1.ZodEnum<{
+                  completed: "completed";
+                  failed: "failed";
+                  active: "active";
+                  cancelled: "cancelled";
+                }>;
+                environmentId: z$1.ZodString;
+                entries: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      type: z$1.ZodEnum<{
+                        output: "output";
+                        step: "step";
+                      }>;
+                      key: z$1.ZodString;
+                      text: z$1.ZodString;
+                      startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                      status: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          completed: "completed";
+                          failed: "failed";
+                          started: "started";
+                        }>
+                      >;
+                      metadata: z$1.ZodOptional<
+                        z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"system/provider-turn-watchdog">;
+                threadId: z$1.ZodString;
+                reason: z$1.ZodLiteral<"provider-turn-idle">;
+                thresholdMs: z$1.ZodNumber;
+                elapsedMs: z$1.ZodNumber;
+                activeTurnId: z$1.ZodString;
+                activeTurnStartedAt: z$1.ZodNumber;
+                lastActivityEventSequence: z$1.ZodNumber;
+                lastActivityEventType: z$1.ZodString;
+                lastActivityEventAt: z$1.ZodNumber;
+                providerId: z$1.ZodString;
+                providerThreadId: z$1.ZodNullable<z$1.ZodString>;
+                firedAt: z$1.ZodNumber;
+              },
+              z$1.core.$strip
+            >,
+          ]
+        >,
+        z$1.ZodObject<
+          {
+            scope: z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"thread">;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"turn">;
+                    turnId: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "kind"
+            >;
+          },
+          z$1.core.$strip
+        >
+      >,
+    ]
+  >
+>;
+type ThreadEvent = z$1.infer<typeof threadEventSchema>;
+type ThreadEventType = ThreadEvent["type"];
+
+declare const providerInfoSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    displayName: z$1.ZodString;
+    logoUrl: z$1.ZodNullable<z$1.ZodString>;
+    capabilities: z$1.ZodObject<
+      {
+        supportsArchive: z$1.ZodBoolean;
+        supportsRename: z$1.ZodBoolean;
+        supportsServiceTier: z$1.ZodBoolean;
+        supportsUserQuestion: z$1.ZodBoolean;
+        supportsFork: z$1.ZodBoolean;
+        supportedPermissionModes: z$1.ZodArray<
+          z$1.ZodEnum<{
+            full: "full";
+            auto: "auto";
+            "accept-edits": "accept-edits";
+          }>
+        >;
+      },
+      z$1.core.$strip
+    >;
+    composerActions: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              kind: z$1.ZodLiteral<"skills">;
+              trigger: z$1.ZodEnum<{
+                "/": "/";
+              }>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              kind: z$1.ZodLiteral<"plan">;
+              command: z$1.ZodObject<
+                {
+                  trigger: z$1.ZodEnum<{
+                    "/": "/";
+                  }>;
+                  name: z$1.ZodString;
+                  trailingText: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              kind: z$1.ZodLiteral<"goal">;
+              command: z$1.ZodObject<
+                {
+                  trigger: z$1.ZodEnum<{
+                    "/": "/";
+                  }>;
+                  name: z$1.ZodString;
+                  trailingText: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "kind"
+      >
+    >;
+    available: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type ProviderInfo = z$1.infer<typeof providerInfoSchema>;
+
+declare const threadEventScopeSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        kind: z$1.ZodLiteral<"thread">;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        kind: z$1.ZodLiteral<"turn">;
+        turnId: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "kind"
+>;
+type ThreadEventScope = z$1.infer<typeof threadEventScopeSchema>;
+
+type ThreadEventByType = {
+  [TType in ThreadEventType]: Extract<
+    ThreadEvent,
+    {
+      type: TType;
+    }
+  >;
+};
+type ThreadEventForType<TType extends ThreadEventType> =
+  ThreadEventByType[TType];
+type StoredThreadEventDataFromEvent<TEvent extends ThreadEvent> = Omit<
+  TEvent,
+  "threadId" | "type" | "scope"
+>;
+interface ThreadEventRowBase {
+  id: string;
+  scope: ThreadEventScope;
+  threadId: string;
+  seq: number;
+  createdAt: number;
+}
+type ThreadEventRowFromEvent<TEvent extends ThreadEvent> =
+  ThreadEventRowBase & {
+    type: TEvent["type"];
+    data: StoredThreadEventDataFromEvent<TEvent>;
+  };
+type ThreadEventRowOfType<TType extends ThreadEventType> =
+  ThreadEventRowFromEvent<ThreadEventForType<TType>>;
+type ThreadEventRow = {
+  [TType in ThreadEventType]: ThreadEventRowOfType<TType>;
+}[ThreadEventType];
+
+declare const threadStatusSchema: z$1.ZodEnum<{
+  error: "error";
+  active: "active";
+  starting: "starting";
+  idle: "idle";
+  stopping: "stopping";
+}>;
+type ThreadStatus = z$1.infer<typeof threadStatusSchema>;
+
+declare const threadTimelinePendingTodosSchema: z$1.ZodObject<
+  {
+    sourceSeq: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    items: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          text: z$1.ZodString;
+          status: z$1.ZodEnum<{
+            completed: "completed";
+            pending: "pending";
+            in_progress: "in_progress";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ThreadTimelinePendingTodos = z$1.infer<
+  typeof threadTimelinePendingTodosSchema
+>;
+
+declare const threadQueuedMessageSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    content: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"text">;
+              text: z$1.ZodString;
+              mentions: z$1.ZodDefault<
+                z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      start: z$1.ZodNumber;
+                      end: z$1.ZodNumber;
+                      resource: z$1.ZodPipe<
+                        z$1.ZodTransform<unknown, unknown>,
+                        z$1.ZodDiscriminatedUnion<
+                          [
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"thread">;
+                                threadId: z$1.ZodString;
+                                projectId: z$1.ZodOptional<z$1.ZodString>;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"project">;
+                                projectId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"section">;
+                                sectionId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"path">;
+                                source: z$1.ZodEnum<{
+                                  workspace: "workspace";
+                                  "thread-storage": "thread-storage";
+                                }>;
+                                entryKind: z$1.ZodEnum<{
+                                  file: "file";
+                                  directory: "directory";
+                                }>;
+                                path: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"command">;
+                                trigger: z$1.ZodEnum<{
+                                  "/": "/";
+                                }>;
+                                name: z$1.ZodString;
+                                source: z$1.ZodEnum<{
+                                  command: "command";
+                                  skill: "skill";
+                                }>;
+                                origin: z$1.ZodEnum<{
+                                  user: "user";
+                                  project: "project";
+                                  builtin: "builtin";
+                                }>;
+                                label: z$1.ZodString;
+                                argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"plugin">;
+                                pluginId: z$1.ZodString;
+                                icon: z$1.ZodOptional<
+                                  z$1.ZodNullable<z$1.ZodString>
+                                >;
+                                itemId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                          ],
+                          "kind"
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"image">;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localImage">;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localFile">;
+              path: z$1.ZodString;
+              name: z$1.ZodOptional<z$1.ZodString>;
+              sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+              mimeType: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+    model: z$1.ZodString;
+    reasoningLevel: z$1.ZodEnum<{
+      none: "none";
+      low: "low";
+      medium: "medium";
+      high: "high";
+      xhigh: "xhigh";
+      ultracode: "ultracode";
+      max: "max";
+      ultra: "ultra";
+    }>;
+    permissionMode: z$1.ZodEnum<{
+      full: "full";
+      auto: "auto";
+      "accept-edits": "accept-edits";
+    }>;
+    serviceTier: z$1.ZodEnum<{
+      default: "default";
+      fast: "fast";
+    }>;
+    groupWithNext: z$1.ZodBoolean;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type ThreadQueuedMessage = z$1.infer<typeof threadQueuedMessageSchema>;
+
+declare const createThreadEnvironmentArgsSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"reuse">;
+        environmentId: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host">;
+        hostId: z$1.ZodOptional<z$1.ZodString>;
+        workspace: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"unmanaged">;
+                path: z$1.ZodNullable<z$1.ZodString>;
+                branch: z$1.ZodOptional<
+                  z$1.ZodDiscriminatedUnion<
+                    [
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"existing">;
+                          name: z$1.ZodString;
+                        },
+                        z$1.core.$strict
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"new">;
+                          baseBranch: z$1.ZodString;
+                        },
+                        z$1.core.$strict
+                      >,
+                    ],
+                    "kind"
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"managed-worktree">;
+                baseBranch: z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"named">;
+                        name: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"default">;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "kind"
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"personal">;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"project-default">;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "type"
+>;
+type CreateThreadEnvironmentArgs = z$1.infer<
+  typeof createThreadEnvironmentArgsSchema
+>;
+declare const workspaceFileListResponseSchema: z$1.ZodObject<
+  {
+    files: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          path: z$1.ZodString;
+          name: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    truncated: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type WorkspaceFileListResponse = z$1.infer<
+  typeof workspaceFileListResponseSchema
+>;
+declare const workspacePathListResponseSchema: z$1.ZodObject<
+  {
+    paths: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          kind: z$1.ZodEnum<{
+            file: "file";
+            directory: "directory";
+          }>;
+          path: z$1.ZodString;
+          name: z$1.ZodString;
+          score: z$1.ZodNumber;
+          positions: z$1.ZodArray<z$1.ZodNumber>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    truncated: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type WorkspacePathListResponse = z$1.infer<
+  typeof workspacePathListResponseSchema
+>;
+
+declare const createProjectSourceRequestSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        hostId: z$1.ZodString;
+        type: z$1.ZodLiteral<"local_path">;
+        path: z$1.ZodPipe<z$1.ZodString, z$1.ZodTransform<string, string>>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        hostId: z$1.ZodString;
+        type: z$1.ZodLiteral<"clone">;
+        targetPath: z$1.ZodOptional<
+          z$1.ZodPipe<z$1.ZodString, z$1.ZodTransform<string, string>>
+        >;
+        remoteUrl: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "type"
+>;
+type CreateProjectSourceRequest = z$1.infer<
+  typeof createProjectSourceRequestSchema
+>;
+declare const createProjectRequestSchema: z$1.ZodObject<
+  {
+    name: z$1.ZodString;
+    source: z$1.ZodObject<
+      {
+        hostId: z$1.ZodString;
+        type: z$1.ZodLiteral<"local_path">;
+        path: z$1.ZodPipe<z$1.ZodString, z$1.ZodTransform<string, string>>;
+      },
+      z$1.core.$strict
+    >;
+  },
+  z$1.core.$strip
+>;
+type CreateProjectRequest = z$1.infer<typeof createProjectRequestSchema>;
+declare const threadSectionSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    name: z$1.ZodString;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+  },
+  z$1.core.$strict
+>;
+type ThreadSectionResponse = z$1.infer<typeof threadSectionSchema>;
+declare const createThreadSectionRequestSchema: z$1.ZodObject<
+  {
+    name: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type CreateThreadSectionRequest = z$1.infer<
+  typeof createThreadSectionRequestSchema
+>;
+declare const updateThreadSectionRequestSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    name: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type UpdateThreadSectionRequest = z$1.infer<
+  typeof updateThreadSectionRequestSchema
+>;
+declare const deleteThreadSectionRequestSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type DeleteThreadSectionRequest = z$1.infer<
+  typeof deleteThreadSectionRequestSchema
+>;
+declare const threadSectionMutationResponseSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    name: z$1.ZodString;
+    updatedThreadCount: z$1.ZodNumber;
+  },
+  z$1.core.$strict
+>;
+type ThreadSectionMutationResponse = z$1.infer<
+  typeof threadSectionMutationResponseSchema
+>;
+declare const reorderProjectRequestSchema: z$1.ZodObject<
+  {
+    previousProjectId: z$1.ZodNullable<z$1.ZodString>;
+    nextProjectId: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ReorderProjectRequest = z$1.infer<typeof reorderProjectRequestSchema>;
+declare const projectListQuerySchema: z$1.ZodObject<
+  {
+    include: z$1.ZodOptional<z$1.ZodString>;
+    includePersonal: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProjectListQuery = z$1.infer<typeof projectListQuerySchema>;
+declare const projectFilesQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodOptional<z$1.ZodString>>;
+    limit: z$1.ZodOptional<z$1.ZodOptional<z$1.ZodString>>;
+    hostId: z$1.ZodOptional<z$1.ZodString>;
+    environmentId: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodTransform<unknown, unknown>,
+        z$1.ZodOptional<z$1.ZodString>
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProjectFilesQuery = z$1.infer<typeof projectFilesQuerySchema>;
+declare const projectPathsQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodOptional<z$1.ZodString>>;
+    limit: z$1.ZodOptional<z$1.ZodOptional<z$1.ZodString>>;
+    includeFiles: z$1.ZodEnum<{
+      true: "true";
+      false: "false";
+    }>;
+    includeDirectories: z$1.ZodEnum<{
+      true: "true";
+      false: "false";
+    }>;
+    hostId: z$1.ZodOptional<z$1.ZodString>;
+    environmentId: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodTransform<unknown, unknown>,
+        z$1.ZodOptional<z$1.ZodString>
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProjectPathsQuery = z$1.infer<typeof projectPathsQuerySchema>;
+declare const projectFileContentQuerySchema: z$1.ZodObject<
+  {
+    path: z$1.ZodString;
+    hostId: z$1.ZodOptional<z$1.ZodString>;
+    environmentId: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodTransform<unknown, unknown>,
+        z$1.ZodOptional<z$1.ZodString>
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProjectFileContentQuery = z$1.infer<typeof projectFileContentQuerySchema>;
+declare const projectBranchesQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodString>;
+    limit: z$1.ZodOptional<z$1.ZodString>;
+    hostId: z$1.ZodString;
+    selectedBranch: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ProjectBranchesQuery = z$1.infer<typeof projectBranchesQuerySchema>;
+declare const projectBranchesResponseSchema: z$1.ZodObject<
+  {
+    branches: z$1.ZodArray<z$1.ZodString>;
+    branchesTruncated: z$1.ZodBoolean;
+    checkout: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"branch">;
+            branchName: z$1.ZodString;
+            headSha: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"detached">;
+            headSha: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"unborn">;
+            branchName: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"unknown">;
+            reason: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "kind"
+    >;
+    defaultBranch: z$1.ZodNullable<z$1.ZodString>;
+    defaultBranchRelation: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        unknown: "unknown";
+        equal: "equal";
+        "local-behind": "local-behind";
+        "local-ahead": "local-ahead";
+        diverged: "diverged";
+      }>
+    >;
+    hasUncommittedChanges: z$1.ZodBoolean;
+    operation: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"none">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"merge">;
+            hasConflicts: z$1.ZodBoolean;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"rebase">;
+            hasConflicts: z$1.ZodBoolean;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"cherry-pick">;
+            hasConflicts: z$1.ZodBoolean;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"revert">;
+            hasConflicts: z$1.ZodBoolean;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"unknown">;
+            reason: z$1.ZodString;
+            hasConflicts: z$1.ZodBoolean;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "kind"
+    >;
+    originDefaultBranch: z$1.ZodNullable<z$1.ZodString>;
+    remoteBranches: z$1.ZodArray<z$1.ZodString>;
+    remoteBranchesTruncated: z$1.ZodBoolean;
+    selectedBranch: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          name: z$1.ZodString;
+          kind: z$1.ZodEnum<{
+            local: "local";
+            remote: "remote";
+            missing: "missing";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    defaultWorktreeBaseBranch: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ProjectBranchesResponse = z$1.infer<typeof projectBranchesResponseSchema>;
+declare const promptHistoryQuerySchema: z$1.ZodObject<
+  {
+    limit: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type PromptHistoryQuery = z$1.infer<typeof promptHistoryQuerySchema>;
+declare const promptHistoryResponseSchema: z$1.ZodArray<
+  z$1.ZodObject<
+    {
+      id: z$1.ZodString;
+      createdAt: z$1.ZodNumber;
+      input: z$1.ZodArray<
+        z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"text">;
+                text: z$1.ZodString;
+                mentions: z$1.ZodDefault<
+                  z$1.ZodArray<
+                    z$1.ZodObject<
+                      {
+                        start: z$1.ZodNumber;
+                        end: z$1.ZodNumber;
+                        resource: z$1.ZodPipe<
+                          z$1.ZodTransform<unknown, unknown>,
+                          z$1.ZodDiscriminatedUnion<
+                            [
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"thread">;
+                                  threadId: z$1.ZodString;
+                                  projectId: z$1.ZodOptional<z$1.ZodString>;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"project">;
+                                  projectId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"section">;
+                                  sectionId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"path">;
+                                  source: z$1.ZodEnum<{
+                                    workspace: "workspace";
+                                    "thread-storage": "thread-storage";
+                                  }>;
+                                  entryKind: z$1.ZodEnum<{
+                                    file: "file";
+                                    directory: "directory";
+                                  }>;
+                                  path: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"command">;
+                                  trigger: z$1.ZodEnum<{
+                                    "/": "/";
+                                  }>;
+                                  name: z$1.ZodString;
+                                  source: z$1.ZodEnum<{
+                                    command: "command";
+                                    skill: "skill";
+                                  }>;
+                                  origin: z$1.ZodEnum<{
+                                    user: "user";
+                                    project: "project";
+                                    builtin: "builtin";
+                                  }>;
+                                  label: z$1.ZodString;
+                                  argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"plugin">;
+                                  pluginId: z$1.ZodString;
+                                  icon: z$1.ZodOptional<
+                                    z$1.ZodNullable<z$1.ZodString>
+                                  >;
+                                  itemId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                            ],
+                            "kind"
+                          >
+                        >;
+                      },
+                      z$1.core.$strip
+                    >
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"image">;
+                url: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"localImage">;
+                path: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"localFile">;
+                path: z$1.ZodString;
+                name: z$1.ZodOptional<z$1.ZodString>;
+                sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                mimeType: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >
+      >;
+    },
+    z$1.core.$strip
+  >
+>;
+type PromptHistoryResponse = z$1.infer<typeof promptHistoryResponseSchema>;
+declare const updateProjectRequestSchema: z$1.ZodObject<
+  {
+    name: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type UpdateProjectRequest = z$1.infer<typeof updateProjectRequestSchema>;
+declare const updateProjectSourceRequestSchema: z$1.ZodObject<
+  {
+    type: z$1.ZodLiteral<"local_path">;
+    path: z$1.ZodOptional<
+      z$1.ZodPipe<z$1.ZodString, z$1.ZodTransform<string, string>>
+    >;
+    isDefault: z$1.ZodOptional<z$1.ZodLiteral<true>>;
+  },
+  z$1.core.$strict
+>;
+type UpdateProjectSourceRequest = z$1.infer<
+  typeof updateProjectSourceRequestSchema
+>;
+declare const commandListResponseSchema: z$1.ZodObject<
+  {
+    commands: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          name: z$1.ZodString;
+          source: z$1.ZodEnum<{
+            command: "command";
+            skill: "skill";
+          }>;
+          origin: z$1.ZodEnum<{
+            user: "user";
+            project: "project";
+            builtin: "builtin";
+          }>;
+          description: z$1.ZodNullable<z$1.ZodString>;
+          argumentHint: z$1.ZodNullable<z$1.ZodString>;
+          pluginId: z$1.ZodOptional<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type CommandListResponse = z$1.infer<typeof commandListResponseSchema>;
+/** Query for the complete command catalog available to a project and provider. */
+declare const projectCommandsQuerySchema: z$1.ZodObject<
+  {
+    provider: z$1.ZodString;
+    hostId: z$1.ZodOptional<z$1.ZodString>;
+    environmentId: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodTransform<unknown, unknown>,
+        z$1.ZodOptional<z$1.ZodString>
+      >
+    >;
+  },
+  z$1.core.$strict
+>;
+type ProjectCommandsQuery = z$1.infer<typeof projectCommandsQuerySchema>;
+declare const skillListResponseSchema: z$1.ZodObject<
+  {
+    skills: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          name: z$1.ZodString;
+          description: z$1.ZodNullable<z$1.ZodString>;
+          provider: z$1.ZodNullable<
+            z$1.ZodEnum<{
+              "claude-code": "claude-code";
+              codex: "codex";
+            }>
+          >;
+          scope: z$1.ZodEnum<{
+            plugin: "plugin";
+            "bb-builtin": "bb-builtin";
+            "bb-user": "bb-user";
+            "bb-project": "bb-project";
+            "claude-user": "claude-user";
+            "claude-project": "claude-project";
+            "codex-user": "codex-user";
+            "codex-project": "codex-project";
+          }>;
+          pluginId: z$1.ZodNullable<z$1.ZodString>;
+          filePath: z$1.ZodString;
+          manageable: z$1.ZodBoolean;
+          registrySkillId: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type SkillListResponse = z$1.infer<typeof skillListResponseSchema>;
+declare const skillContentResponseSchema: z$1.ZodObject<
+  {
+    content: z$1.ZodString;
+    revision: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type SkillContentResponse = z$1.infer<typeof skillContentResponseSchema>;
+declare const skillFilesResponseSchema: z$1.ZodObject<
+  {
+    files: z$1.ZodArray<z$1.ZodString>;
+    truncated: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type SkillFilesResponse = z$1.infer<typeof skillFilesResponseSchema>;
+declare const projectResponseSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    kind: z$1.ZodEnum<{
+      personal: "personal";
+      standard: "standard";
+    }>;
+    name: z$1.ZodString;
+    gitRemoteUrl: z$1.ZodNullable<z$1.ZodString>;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    sources: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          projectId: z$1.ZodString;
+          isDefault: z$1.ZodBoolean;
+          createdAt: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+          type: z$1.ZodLiteral<"local_path">;
+          hostId: z$1.ZodString;
+          path: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProjectResponse = z$1.infer<typeof projectResponseSchema>;
+declare const projectWithThreadsResponseSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    kind: z$1.ZodEnum<{
+      personal: "personal";
+      standard: "standard";
+    }>;
+    name: z$1.ZodString;
+    gitRemoteUrl: z$1.ZodNullable<z$1.ZodString>;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    sources: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          projectId: z$1.ZodString;
+          isDefault: z$1.ZodBoolean;
+          createdAt: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+          type: z$1.ZodLiteral<"local_path">;
+          hostId: z$1.ZodString;
+          path: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    threads: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          projectId: z$1.ZodString;
+          environmentId: z$1.ZodNullable<z$1.ZodString>;
+          providerId: z$1.ZodString;
+          title: z$1.ZodNullable<z$1.ZodString>;
+          titleFallback: z$1.ZodNullable<z$1.ZodString>;
+          sectionId: z$1.ZodNullable<z$1.ZodString>;
+          status: z$1.ZodEnum<{
+            error: "error";
+            stopping: "stopping";
+            idle: "idle";
+            starting: "starting";
+            active: "active";
+          }>;
+          parentThreadId: z$1.ZodNullable<z$1.ZodString>;
+          sourceThreadId: z$1.ZodNullable<z$1.ZodString>;
+          originKind: z$1.ZodNullable<
+            z$1.ZodEnum<{
+              fork: "fork";
+            }>
+          >;
+          childOrigin: z$1.ZodNullable<
+            z$1.ZodEnum<{
+              fork: "fork";
+            }>
+          >;
+          originPluginId: z$1.ZodNullable<z$1.ZodString>;
+          visibility: z$1.ZodEnum<{
+            visible: "visible";
+            hidden: "hidden";
+          }>;
+          archivedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          pinnedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          deletedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          lastReadAt: z$1.ZodNullable<z$1.ZodNumber>;
+          latestAttentionAt: z$1.ZodNumber;
+          createdAt: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+          runtime: z$1.ZodObject<
+            {
+              displayStatus: z$1.ZodEnum<{
+                error: "error";
+                provisioning: "provisioning";
+                stopping: "stopping";
+                idle: "idle";
+                starting: "starting";
+                active: "active";
+                "host-reconnecting": "host-reconnecting";
+                "waiting-for-host": "waiting-for-host";
+              }>;
+              hostReconnectGraceExpiresAt: z$1.ZodNullable<z$1.ZodNumber>;
+            },
+            z$1.core.$strip
+          >;
+          activity: z$1.ZodObject<
+            {
+              activeWorkflowCount: z$1.ZodNumber;
+              activeBackgroundAgentCount: z$1.ZodNumber;
+              activeBackgroundCommandCount: z$1.ZodNumber;
+              activePlanModeCount: z$1.ZodNumber;
+              activeGoalCount: z$1.ZodNumber;
+            },
+            z$1.core.$strip
+          >;
+          pinSortKey: z$1.ZodNullable<z$1.ZodString>;
+          hasPendingInteraction: z$1.ZodBoolean;
+          environmentHostId: z$1.ZodNullable<z$1.ZodString>;
+          environmentName: z$1.ZodNullable<z$1.ZodString>;
+          environmentBranchName: z$1.ZodNullable<z$1.ZodString>;
+          environmentWorkspaceDisplayKind: z$1.ZodEnum<{
+            "managed-worktree": "managed-worktree";
+            "unmanaged-worktree": "unmanaged-worktree";
+            other: "other";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    defaultExecutionOptions: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          providerId: z$1.ZodString;
+          model: z$1.ZodString;
+          serviceTier: z$1.ZodEnum<{
+            default: "default";
+            fast: "fast";
+          }>;
+          reasoningLevel: z$1.ZodEnum<{
+            none: "none";
+            low: "low";
+            medium: "medium";
+            high: "high";
+            xhigh: "xhigh";
+            ultracode: "ultracode";
+            max: "max";
+            ultra: "ultra";
+          }>;
+          permissionMode: z$1.ZodEnum<{
+            auto: "auto";
+            "accept-edits": "accept-edits";
+            full: "full";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProjectWithThreadsResponse = z$1.infer<
+  typeof projectWithThreadsResponseSchema
+>;
+declare const uploadedPromptAttachmentSchema: z$1.ZodObject<
+  {
+    type: z$1.ZodEnum<{
+      localImage: "localImage";
+      localFile: "localFile";
+    }>;
+    path: z$1.ZodString;
+    name: z$1.ZodString;
+    mimeType: z$1.ZodOptional<z$1.ZodString>;
+    sizeBytes: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type UploadedPromptAttachment = z$1.infer<
+  typeof uploadedPromptAttachmentSchema
+>;
+declare const copyProjectAttachmentsRequestSchema: z$1.ZodObject<
+  {
+    sourceProjectId: z$1.ZodString;
+    paths: z$1.ZodArray<z$1.ZodString>;
+  },
+  z$1.core.$strict
+>;
+type CopyProjectAttachmentsRequest = z$1.infer<
+  typeof copyProjectAttachmentsRequestSchema
+>;
+
+declare const registrySkillSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    source: z$1.ZodString;
+    skillId: z$1.ZodString;
+    name: z$1.ZodString;
+    installs: z$1.ZodNumber;
+    stars: z$1.ZodNullable<z$1.ZodNumber>;
+    installUrl: z$1.ZodNullable<z$1.ZodString>;
+    url: z$1.ZodString;
+    topic: z$1.ZodNullable<z$1.ZodString>;
+    summary: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type RegistrySkill = z$1.infer<typeof registrySkillSchema>;
+declare const registrySkillsPageSchema: z$1.ZodObject<
+  {
+    skills: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          source: z$1.ZodString;
+          skillId: z$1.ZodString;
+          name: z$1.ZodString;
+          installs: z$1.ZodNumber;
+          stars: z$1.ZodNullable<z$1.ZodNumber>;
+          installUrl: z$1.ZodNullable<z$1.ZodString>;
+          url: z$1.ZodString;
+          topic: z$1.ZodNullable<z$1.ZodString>;
+          summary: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    pagination: z$1.ZodObject<
+      {
+        page: z$1.ZodNumber;
+        perPage: z$1.ZodNumber;
+        total: z$1.ZodNumber;
+        hasMore: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >;
+  },
+  z$1.core.$strip
+>;
+type RegistrySkillsPage = z$1.infer<typeof registrySkillsPageSchema>;
+declare const registryRepositoryStarsSchema: z$1.ZodObject<
+  {
+    stars: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type RegistryRepositoryStars = z$1.infer<typeof registryRepositoryStarsSchema>;
+declare const registrySkillDetailSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    source: z$1.ZodString;
+    skillId: z$1.ZodString;
+    hash: z$1.ZodNullable<z$1.ZodString>;
+    files: z$1.ZodNullable<
+      z$1.ZodArray<
+        z$1.ZodObject<
+          {
+            path: z$1.ZodString;
+            contents: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type RegistrySkillDetail = z$1.infer<typeof registrySkillDetailSchema>;
+declare const registrySkillInstallResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    filePath: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type RegistrySkillInstallResponse = z$1.infer<
+  typeof registrySkillInstallResponseSchema
+>;
+
+declare const updateEnvironmentRequestSchema: z$1.ZodObject<
+  {
+    mergeBaseBranch: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+    name: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+  },
+  z$1.core.$strip
+>;
+type UpdateEnvironmentRequest = z$1.infer<
+  typeof updateEnvironmentRequestSchema
+>;
+/**
+ * Query for searching paths in an environment's workspace. Unlike the
+ * project-scoped variant this needs no `environmentId` — the environment is
+ * the route param — and is project-agnostic, so it works for projectless
+ * (personal) environments too.
+ */
+declare const environmentPathsQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodString>;
+    limit: z$1.ZodOptional<z$1.ZodString>;
+    includeFiles: z$1.ZodEnum<{
+      true: "true";
+      false: "false";
+    }>;
+    includeDirectories: z$1.ZodEnum<{
+      true: "true";
+      false: "false";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type EnvironmentPathsQuery = z$1.infer<typeof environmentPathsQuerySchema>;
+declare const environmentDiffBranchesQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodString>;
+    limit: z$1.ZodOptional<z$1.ZodString>;
+    selectedBranch: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type EnvironmentDiffBranchesQuery = z$1.infer<
+  typeof environmentDiffBranchesQuerySchema
+>;
+declare const environmentDiffBranchesResponseSchema: z$1.ZodObject<
+  {
+    branches: z$1.ZodArray<z$1.ZodString>;
+    branchesTruncated: z$1.ZodBoolean;
+    remoteBranches: z$1.ZodArray<z$1.ZodString>;
+    remoteBranchesTruncated: z$1.ZodBoolean;
+    selectedBranch: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          name: z$1.ZodString;
+          kind: z$1.ZodEnum<{
+            local: "local";
+            remote: "remote";
+            missing: "missing";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type EnvironmentDiffBranchesResponse = z$1.infer<
+  typeof environmentDiffBranchesResponseSchema
+>;
+declare const environmentStatusQuerySchema: z$1.ZodObject<
+  {
+    mergeBaseBranch: z$1.ZodOptional<z$1.ZodPipe<z$1.ZodString, z$1.ZodString>>;
+  },
+  z$1.core.$strip
+>;
+type EnvironmentStatusQuery = z$1.infer<typeof environmentStatusQuerySchema>;
+declare const environmentDiffQuerySchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"uncommitted">;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"branch_committed">;
+        mergeBaseBranch: z$1.ZodPipe<z$1.ZodString, z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"all">;
+        mergeBaseBranch: z$1.ZodPipe<z$1.ZodString, z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"commit">;
+        sha: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "target"
+>;
+type EnvironmentDiffQuery = z$1.infer<typeof environmentDiffQuerySchema>;
+/**
+ * Query for fetching a single file's contents at one side of a diff target.
+ * Used by the diff card to reparse the card's patch with full old/new contents
+ * so `@pierre/diffs` can render expand-context buttons between hunks.
+ *
+ * For `branch_committed` / `all`, callers pass the resolved merge-base SHA
+ * (`mergeBaseRef`, surfaced by `workspace.diff`) rather than the branch name
+ * — the diff itself was computed against that SHA, so reading the old side
+ * from the same SHA keeps the file content aligned with the hunk line
+ * numbers. Reading from the branch tip is wrong whenever the branch has
+ * moved past the merge-base since the file existed there.
+ */
+declare const environmentDiffFileQuerySchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"uncommitted">;
+        path: z$1.ZodString;
+        side: z$1.ZodEnum<{
+          new: "new";
+          old: "old";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"branch_committed">;
+        mergeBaseRef: z$1.ZodString;
+        path: z$1.ZodString;
+        side: z$1.ZodEnum<{
+          new: "new";
+          old: "old";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"all">;
+        mergeBaseRef: z$1.ZodString;
+        path: z$1.ZodString;
+        side: z$1.ZodEnum<{
+          new: "new";
+          old: "old";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        target: z$1.ZodLiteral<"commit">;
+        sha: z$1.ZodString;
+        path: z$1.ZodString;
+        side: z$1.ZodEnum<{
+          new: "new";
+          old: "old";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "target"
+>;
+type EnvironmentDiffFileQuery = z$1.infer<
+  typeof environmentDiffFileQuerySchema
+>;
+declare const environmentDiffFileResponseSchema: z$1.ZodObject<
+  {
+    path: z$1.ZodString;
+    content: z$1.ZodString;
+    contentEncoding: z$1.ZodEnum<{
+      base64: "base64";
+      utf8: "utf8";
+    }>;
+    mimeType: z$1.ZodOptional<z$1.ZodString>;
+    sizeBytes: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type EnvironmentDiffFileResponse = z$1.infer<
+  typeof environmentDiffFileResponseSchema
+>;
+declare const environmentArchiveThreadsResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    archivedThreadIds: z$1.ZodArray<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type EnvironmentArchiveThreadsResponse = z$1.infer<
+  typeof environmentArchiveThreadsResponseSchema
+>;
+declare const pullRequestMergeMethodSchema: z$1.ZodEnum<{
+  merge: "merge";
+  rebase: "rebase";
+  squash: "squash";
+}>;
+type PullRequestMergeMethod = z$1.infer<typeof pullRequestMergeMethodSchema>;
+declare const commitActionResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    action: z$1.ZodLiteral<"commit">;
+    message: z$1.ZodString;
+    commitSha: z$1.ZodString;
+    commitSubject: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type CommitActionResponse = z$1.infer<typeof commitActionResponseSchema>;
+declare const squashMergeActionResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    action: z$1.ZodLiteral<"squash_merge">;
+    merged: z$1.ZodBoolean;
+    message: z$1.ZodString;
+    commitSha: z$1.ZodString;
+    commitSubject: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type SquashMergeActionResponse = z$1.infer<
+  typeof squashMergeActionResponseSchema
+>;
+declare const pullRequestReadyActionResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    action: z$1.ZodLiteral<"pull_request_ready">;
+    message: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type PullRequestReadyActionResponse = z$1.infer<
+  typeof pullRequestReadyActionResponseSchema
+>;
+declare const pullRequestMergeActionResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    action: z$1.ZodLiteral<"pull_request_merge">;
+    method: z$1.ZodEnum<{
+      merge: "merge";
+      rebase: "rebase";
+      squash: "squash";
+    }>;
+    message: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type PullRequestMergeActionResponse = z$1.infer<
+  typeof pullRequestMergeActionResponseSchema
+>;
+declare const pullRequestDraftActionResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    action: z$1.ZodLiteral<"pull_request_draft">;
+    message: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type PullRequestDraftActionResponse = z$1.infer<
+  typeof pullRequestDraftActionResponseSchema
+>;
+declare const environmentStatusResponseSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"available">;
+        workspace: z$1.ZodObject<
+          {
+            workingTree: z$1.ZodObject<
+              {
+                insertions: z$1.ZodNumber;
+                deletions: z$1.ZodNumber;
+                files: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      path: z$1.ZodString;
+                      status: z$1.ZodEnum<{
+                        M: "M";
+                        A: "A";
+                        D: "D";
+                        R: "R";
+                        C: "C";
+                        U: "U";
+                        "??": "??";
+                        "?": "?";
+                      }>;
+                      insertions: z$1.ZodNullable<z$1.ZodNumber>;
+                      deletions: z$1.ZodNullable<z$1.ZodNumber>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+                hasUncommittedChanges: z$1.ZodBoolean;
+                state: z$1.ZodEnum<{
+                  clean: "clean";
+                  untracked: "untracked";
+                  dirty_uncommitted: "dirty_uncommitted";
+                  committed_unmerged: "committed_unmerged";
+                  dirty_and_committed_unmerged: "dirty_and_committed_unmerged";
+                }>;
+              },
+              z$1.core.$strip
+            >;
+            checkout: z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"branch">;
+                    branchName: z$1.ZodString;
+                    headSha: z$1.ZodNullable<z$1.ZodString>;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"detached">;
+                    headSha: z$1.ZodNullable<z$1.ZodString>;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"unborn">;
+                    branchName: z$1.ZodNullable<z$1.ZodString>;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"unknown">;
+                    reason: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "kind"
+            >;
+            branch: z$1.ZodObject<
+              {
+                currentBranch: z$1.ZodNullable<z$1.ZodString>;
+                defaultBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >;
+            mergeBase: z$1.ZodNullable<
+              z$1.ZodObject<
+                {
+                  insertions: z$1.ZodNumber;
+                  deletions: z$1.ZodNumber;
+                  files: z$1.ZodArray<
+                    z$1.ZodObject<
+                      {
+                        path: z$1.ZodString;
+                        status: z$1.ZodEnum<{
+                          M: "M";
+                          A: "A";
+                          D: "D";
+                          R: "R";
+                          C: "C";
+                          U: "U";
+                          "??": "??";
+                          "?": "?";
+                        }>;
+                        insertions: z$1.ZodNullable<z$1.ZodNumber>;
+                        deletions: z$1.ZodNullable<z$1.ZodNumber>;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                  mergeBaseBranch: z$1.ZodString;
+                  baseRef: z$1.ZodNullable<z$1.ZodString>;
+                  aheadCount: z$1.ZodNumber;
+                  behindCount: z$1.ZodNumber;
+                  hasCommittedUnmergedChanges: z$1.ZodBoolean;
+                  commits: z$1.ZodArray<
+                    z$1.ZodObject<
+                      {
+                        sha: z$1.ZodString;
+                        shortSha: z$1.ZodString;
+                        subject: z$1.ZodString;
+                        authorName: z$1.ZodString;
+                        authoredAt: z$1.ZodNumber;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >
+            >;
+          },
+          z$1.core.$strip
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"not_applicable">;
+        reason: z$1.ZodEnum<{
+          non_git_environment: "non_git_environment";
+        }>;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"unavailable">;
+        failure: z$1.ZodObject<
+          {
+            code: z$1.ZodEnum<{
+              unknown: "unknown";
+              path_not_found: "path_not_found";
+              not_git_repo: "not_git_repo";
+              not_worktree: "not_worktree";
+              workspace_type_mismatch: "workspace_type_mismatch";
+              permission_denied: "permission_denied";
+              unknown_environment: "unknown_environment";
+            }>;
+            workspacePath: z$1.ZodString;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "outcome"
+>;
+/**
+ * Structured pull-request lookup outcome. "absent" is a real answer — the
+ * host checked and the branch has no PR (non-git environments resolve to
+ * "absent" without a daemon call). "unavailable" means the lookup itself
+ * failed (gh missing, not authenticated, timeout, unreachable workspace), so
+ * callers must not render it as "no PR exists".
+ */
+declare const environmentPullRequestResponseSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"available">;
+        pullRequest: z$1.ZodObject<
+          {
+            number: z$1.ZodNumber;
+            title: z$1.ZodString;
+            state: z$1.ZodEnum<{
+              merged: "merged";
+              draft: "draft";
+              open: "open";
+              closed: "closed";
+            }>;
+            url: z$1.ZodString;
+            baseRefName: z$1.ZodString;
+            headRefName: z$1.ZodString;
+            updatedAt: z$1.ZodString;
+            checks: z$1.ZodObject<
+              {
+                state: z$1.ZodEnum<{
+                  unknown: "unknown";
+                  pending: "pending";
+                  passing: "passing";
+                  failing: "failing";
+                  no_checks: "no_checks";
+                }>;
+                totalCount: z$1.ZodNumber;
+                passedCount: z$1.ZodNumber;
+                failedCount: z$1.ZodNumber;
+                pendingCount: z$1.ZodNumber;
+              },
+              z$1.core.$strict
+            >;
+            review: z$1.ZodObject<
+              {
+                state: z$1.ZodEnum<{
+                  none: "none";
+                  approved: "approved";
+                  changes_requested: "changes_requested";
+                  review_required: "review_required";
+                  review_requested: "review_requested";
+                }>;
+                reviewRequestCount: z$1.ZodNumber;
+              },
+              z$1.core.$strict
+            >;
+            mergeability: z$1.ZodObject<
+              {
+                state: z$1.ZodEnum<{
+                  unknown: "unknown";
+                  draft: "draft";
+                  mergeable: "mergeable";
+                  conflicts: "conflicts";
+                  blocked: "blocked";
+                }>;
+                mergeStateStatus: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    BEHIND: "BEHIND";
+                    BLOCKED: "BLOCKED";
+                    CLEAN: "CLEAN";
+                    DIRTY: "DIRTY";
+                    DRAFT: "DRAFT";
+                    HAS_HOOKS: "HAS_HOOKS";
+                    UNKNOWN: "UNKNOWN";
+                    UNSTABLE: "UNSTABLE";
+                  }>
+                >;
+                mergeable: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    UNKNOWN: "UNKNOWN";
+                    CONFLICTING: "CONFLICTING";
+                    MERGEABLE: "MERGEABLE";
+                  }>
+                >;
+              },
+              z$1.core.$strict
+            >;
+            attention: z$1.ZodEnum<{
+              none: "none";
+              merged: "merged";
+              draft: "draft";
+              closed: "closed";
+              changes_requested: "changes_requested";
+              review_requested: "review_requested";
+              conflicts: "conflicts";
+              blocked: "blocked";
+              checks_failed: "checks_failed";
+              checks_pending: "checks_pending";
+              ready_to_merge: "ready_to_merge";
+            }>;
+          },
+          z$1.core.$strict
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"absent">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"unavailable">;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "outcome"
+>;
+type EnvironmentPullRequestResponse = z$1.infer<
+  typeof environmentPullRequestResponseSchema
+>;
+declare const environmentDiffResponseSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"available">;
+        diff: z$1.ZodObject<
+          {
+            diff: z$1.ZodString;
+            truncated: z$1.ZodBoolean;
+            shortstat: z$1.ZodString;
+            files: z$1.ZodString;
+            mergeBaseRef: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"not_applicable">;
+        reason: z$1.ZodEnum<{
+          non_git_environment: "non_git_environment";
+        }>;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"unavailable">;
+        failure: z$1.ZodObject<
+          {
+            code: z$1.ZodEnum<{
+              unknown: "unknown";
+              path_not_found: "path_not_found";
+              not_git_repo: "not_git_repo";
+              not_worktree: "not_worktree";
+              workspace_type_mismatch: "workspace_type_mismatch";
+              permission_denied: "permission_denied";
+              unknown_environment: "unknown_environment";
+            }>;
+            workspacePath: z$1.ZodString;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "outcome"
+>;
+type EnvironmentDiffResponse = z$1.infer<typeof environmentDiffResponseSchema>;
+declare const environmentDiffFilesResponseSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"available">;
+        files: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              path: z$1.ZodString;
+              previousPath: z$1.ZodNullable<z$1.ZodString>;
+              changeKind: z$1.ZodEnum<{
+                deleted: "deleted";
+                added: "added";
+                modified: "modified";
+                renamed: "renamed";
+                copied: "copied";
+                type_changed: "type_changed";
+              }>;
+              additions: z$1.ZodNumber;
+              deletions: z$1.ZodNumber;
+              binary: z$1.ZodBoolean;
+              origin: z$1.ZodEnum<{
+                untracked: "untracked";
+                tracked: "tracked";
+              }>;
+              loadMode: z$1.ZodEnum<{
+                auto: "auto";
+                on_demand: "on_demand";
+                too_large: "too_large";
+              }>;
+            },
+            z$1.core.$strip
+          >
+        >;
+        shortstat: z$1.ZodString;
+        mergeBaseRef: z$1.ZodNullable<z$1.ZodString>;
+        initialPatches: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              path: z$1.ZodString;
+              patch: z$1.ZodString;
+              truncated: z$1.ZodBoolean;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"not_applicable">;
+        reason: z$1.ZodEnum<{
+          non_git_environment: "non_git_environment";
+          too_many_files: "too_many_files";
+        }>;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"unavailable">;
+        failure: z$1.ZodObject<
+          {
+            code: z$1.ZodEnum<{
+              unknown: "unknown";
+              path_not_found: "path_not_found";
+              not_git_repo: "not_git_repo";
+              not_worktree: "not_worktree";
+              workspace_type_mismatch: "workspace_type_mismatch";
+              permission_denied: "permission_denied";
+              unknown_environment: "unknown_environment";
+            }>;
+            workspacePath: z$1.ZodString;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "outcome"
+>;
+type EnvironmentDiffFilesResponse = z$1.infer<
+  typeof environmentDiffFilesResponseSchema
+>;
+declare const environmentDiffPatchResponseSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"available">;
+        patches: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              path: z$1.ZodString;
+              patch: z$1.ZodString;
+              truncated: z$1.ZodBoolean;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"not_applicable">;
+        reason: z$1.ZodEnum<{
+          non_git_environment: "non_git_environment";
+        }>;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        outcome: z$1.ZodLiteral<"unavailable">;
+        failure: z$1.ZodObject<
+          {
+            code: z$1.ZodEnum<{
+              unknown: "unknown";
+              path_not_found: "path_not_found";
+              not_git_repo: "not_git_repo";
+              not_worktree: "not_worktree";
+              workspace_type_mismatch: "workspace_type_mismatch";
+              permission_denied: "permission_denied";
+              unknown_environment: "unknown_environment";
+            }>;
+            workspacePath: z$1.ZodString;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >;
+      },
+      z$1.core.$strict
+    >,
+  ],
+  "outcome"
+>;
+type EnvironmentDiffPatchResponse = z$1.infer<
+  typeof environmentDiffPatchResponseSchema
+>;
+/**
+ * Body for `POST /diff/patch`: the diff target plus the list of new paths whose
+ * patches the client wants. A POST (not GET) because the repeated `paths` array
+ * cannot survive flat query parsing. The client supplies only new paths; the
+ * server re-derives each file's rename/copy pairing (`previousPath`) from its
+ * own TOC.
+ */
+declare const environmentDiffPatchRequestSchema: z$1.ZodObject<
+  {
+    target: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"uncommitted">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"branch_committed">;
+            mergeBaseBranch: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"all">;
+            mergeBaseBranch: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"commit">;
+            sha: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "type"
+    >;
+    paths: z$1.ZodArray<z$1.ZodString>;
+  },
+  z$1.core.$strict
+>;
+type EnvironmentDiffPatchRequest = z$1.infer<
+  typeof environmentDiffPatchRequestSchema
+>;
+type EnvironmentStatusResponse = z$1.infer<
+  typeof environmentStatusResponseSchema
+>;
+
+declare const providerUsageResponseSchema: z$1.ZodObject<
+  {
+    codex: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"ok">;
+            accountEmail: z$1.ZodNullable<z$1.ZodString>;
+            planLabel: z$1.ZodNullable<z$1.ZodString>;
+            windows: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  label: z$1.ZodString;
+                  usedPercent: z$1.ZodNumber;
+                  resetsAt: z$1.ZodNullable<z$1.ZodString>;
+                  cost: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        usedUsdCents: z$1.ZodNumber;
+                        limitUsdCents: z$1.ZodNumber;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"not_installed">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"unauthenticated">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"expired">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"error">;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "status"
+    >;
+    claudeCode: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"ok">;
+            accountEmail: z$1.ZodNullable<z$1.ZodString>;
+            planLabel: z$1.ZodNullable<z$1.ZodString>;
+            windows: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  label: z$1.ZodString;
+                  usedPercent: z$1.ZodNumber;
+                  resetsAt: z$1.ZodNullable<z$1.ZodString>;
+                  cost: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        usedUsdCents: z$1.ZodNumber;
+                        limitUsdCents: z$1.ZodNumber;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"not_installed">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"unauthenticated">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"expired">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"error">;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "status"
+    >;
+    cursor: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"ok">;
+            accountEmail: z$1.ZodNullable<z$1.ZodString>;
+            planLabel: z$1.ZodNullable<z$1.ZodString>;
+            windows: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  label: z$1.ZodString;
+                  usedPercent: z$1.ZodNumber;
+                  resetsAt: z$1.ZodNullable<z$1.ZodString>;
+                  cost: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        usedUsdCents: z$1.ZodNumber;
+                        limitUsdCents: z$1.ZodNumber;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"not_installed">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"unauthenticated">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"expired">;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            status: z$1.ZodLiteral<"error">;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "status"
+    >;
+  },
+  z$1.core.$strip
+>;
+type ProviderUsageResponse = z$1.infer<typeof providerUsageResponseSchema>;
+type HostDaemonCommandTransport = "settled" | "onlineRpc";
+type HostDaemonCommandEnvironmentLane = "read" | "write";
+type HostDaemonFlushEventsBeforeResult = boolean | "when-initiated";
+interface HostDaemonCommandDescriptor<
+  Type extends string,
+  Schema extends z$1.ZodTypeAny,
+  ResultSchema extends z$1.ZodTypeAny,
+  Transport extends HostDaemonCommandTransport,
+  Retryable extends boolean,
+> {
+  type: Type;
+  schema: Schema;
+  resultSchema: ResultSchema;
+  transport: Transport;
+  retryable: Retryable;
+  flushEventsBeforeResult: HostDaemonFlushEventsBeforeResult;
+  envLane: HostDaemonCommandEnvironmentLane | null;
+}
+declare const hostDaemonCommandRegistry: {
+  "thread.start": HostDaemonCommandDescriptor<
+    "thread.start",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        projectId: z$1.ZodString;
+        providerId: z$1.ZodString;
+        acpLaunchSpec: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              displayName: z$1.ZodString;
+              command: z$1.ZodString;
+              args: z$1.ZodArray<z$1.ZodString>;
+              env: z$1.ZodRecord<z$1.ZodString, z$1.ZodString>;
+              cwd: z$1.ZodOptional<z$1.ZodString>;
+              modelCli: z$1.ZodOptional<
+                z$1.ZodPipe<
+                  z$1.ZodObject<
+                    {
+                      listArgs: z$1.ZodArray<z$1.ZodString>;
+                      selectFlag: z$1.ZodOptional<z$1.ZodString>;
+                      primaryModels: z$1.ZodArray<z$1.ZodString>;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodTransform<
+                    | {
+                        listArgs: string[];
+                        primaryModels: string[];
+                        selectFlag?: string | undefined;
+                      }
+                    | undefined,
+                    {
+                      listArgs: string[];
+                      primaryModels: string[];
+                      selectFlag?: string | undefined;
+                    }
+                  >
+                >
+              >;
+              reasoningCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    flag: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              nativeReasoning: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    configId: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              permissionCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    full: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    workspaceWrite: z$1.ZodOptional<
+                      z$1.ZodArray<z$1.ZodString>
+                    >;
+                    readonly: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    insertAfterArgs: z$1.ZodOptional<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+            },
+            z$1.core.$strict
+          >
+        >;
+        options: z$1.ZodIntersection<
+          z$1.ZodObject<
+            {
+              model: z$1.ZodString;
+              serviceTier: z$1.ZodEnum<{
+                default: "default";
+                fast: "fast";
+              }>;
+              reasoningLevel: z$1.ZodEnum<{
+                none: "none";
+                low: "low";
+                medium: "medium";
+                high: "high";
+                xhigh: "xhigh";
+                ultracode: "ultracode";
+                max: "max";
+                ultra: "ultra";
+              }>;
+              claudeCodePermissionMode: z$1.ZodOptional<z$1.ZodLiteral<"plan">>;
+              claudeCodeMockCliTraffic: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    enabled: z$1.ZodBoolean;
+                    endpoint: z$1.ZodString;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              workflowsEnabled: z$1.ZodBoolean;
+              memoryEnabled: z$1.ZodOptional<z$1.ZodBoolean>;
+              providerSubagentsEnabled: z$1.ZodOptional<z$1.ZodBoolean>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"accept-edits">;
+                  permissionScope: z$1.ZodLiteral<"workspace">;
+                  approvalReviewer: z$1.ZodLiteral<"user">;
+                  permissionEscalation: z$1.ZodEnum<{
+                    ask: "ask";
+                    deny: "deny";
+                  }>;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"auto">;
+                  permissionScope: z$1.ZodLiteral<"workspace">;
+                  approvalReviewer: z$1.ZodLiteral<"automatic">;
+                  permissionEscalation: z$1.ZodEnum<{
+                    ask: "ask";
+                    deny: "deny";
+                  }>;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"full">;
+                  permissionScope: z$1.ZodLiteral<"full">;
+                  approvalReviewer: z$1.ZodNull;
+                  permissionEscalation: z$1.ZodNull;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "permissionMode"
+          >
+        >;
+        instructions: z$1.ZodString;
+        dynamicTools: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              name: z$1.ZodString;
+              description: z$1.ZodString;
+              inputSchema: z$1.ZodUnknown;
+            },
+            z$1.core.$strip
+          >
+        >;
+        injectedSkillSources: z$1.ZodArray<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  name: z$1.ZodString;
+                  description: z$1.ZodString;
+                  kind: z$1.ZodLiteral<"tree">;
+                  treeHash: z$1.ZodString;
+                  entryPath: z$1.ZodString;
+                  sourceType: z$1.ZodEnum<{
+                    builtin: "builtin";
+                    "data-dir": "data-dir";
+                  }>;
+                },
+                z$1.core.$strict
+              >,
+              z$1.ZodObject<
+                {
+                  name: z$1.ZodString;
+                  description: z$1.ZodString;
+                  kind: z$1.ZodLiteral<"workspace-path">;
+                  sourceType: z$1.ZodLiteral<"project">;
+                  sourceRootPath: z$1.ZodString;
+                  skillFilePath: z$1.ZodString;
+                },
+                z$1.core.$strict
+              >,
+            ],
+            "kind"
+          >
+        >;
+        disallowedTools: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+        instructionMode: z$1.ZodEnum<{
+          append: "append";
+          replace: "replace";
+        }>;
+        type: z$1.ZodLiteral<"thread.start">;
+        requestId: z$1.ZodString;
+        input: z$1.ZodArray<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"text">;
+                  text: z$1.ZodString;
+                  mentions: z$1.ZodDefault<
+                    z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          start: z$1.ZodNumber;
+                          end: z$1.ZodNumber;
+                          resource: z$1.ZodPipe<
+                            z$1.ZodTransform<unknown, unknown>,
+                            z$1.ZodDiscriminatedUnion<
+                              [
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"thread">;
+                                    threadId: z$1.ZodString;
+                                    projectId: z$1.ZodOptional<z$1.ZodString>;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"project">;
+                                    projectId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"section">;
+                                    sectionId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"path">;
+                                    source: z$1.ZodEnum<{
+                                      workspace: "workspace";
+                                      "thread-storage": "thread-storage";
+                                    }>;
+                                    entryKind: z$1.ZodEnum<{
+                                      file: "file";
+                                      directory: "directory";
+                                    }>;
+                                    path: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"command">;
+                                    trigger: z$1.ZodEnum<{
+                                      "/": "/";
+                                    }>;
+                                    name: z$1.ZodString;
+                                    source: z$1.ZodEnum<{
+                                      command: "command";
+                                      skill: "skill";
+                                    }>;
+                                    origin: z$1.ZodEnum<{
+                                      builtin: "builtin";
+                                      project: "project";
+                                      user: "user";
+                                    }>;
+                                    label: z$1.ZodString;
+                                    argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"plugin">;
+                                    pluginId: z$1.ZodString;
+                                    icon: z$1.ZodOptional<
+                                      z$1.ZodNullable<z$1.ZodString>
+                                    >;
+                                    itemId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                              ],
+                              "kind"
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"image">;
+                  url: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localImage">;
+                  path: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localFile">;
+                  path: z$1.ZodString;
+                  name: z$1.ZodOptional<z$1.ZodString>;
+                  sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                  mimeType: z$1.ZodOptional<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "type"
+          >
+        >;
+        inputGroups: z$1.ZodOptional<
+          z$1.ZodArray<
+            z$1.ZodArray<
+              z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"text">;
+                      text: z$1.ZodString;
+                      mentions: z$1.ZodDefault<
+                        z$1.ZodArray<
+                          z$1.ZodObject<
+                            {
+                              start: z$1.ZodNumber;
+                              end: z$1.ZodNumber;
+                              resource: z$1.ZodPipe<
+                                z$1.ZodTransform<unknown, unknown>,
+                                z$1.ZodDiscriminatedUnion<
+                                  [
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"thread">;
+                                        threadId: z$1.ZodString;
+                                        projectId: z$1.ZodOptional<z$1.ZodString>;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"project">;
+                                        projectId: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"section">;
+                                        sectionId: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"path">;
+                                        source: z$1.ZodEnum<{
+                                          workspace: "workspace";
+                                          "thread-storage": "thread-storage";
+                                        }>;
+                                        entryKind: z$1.ZodEnum<{
+                                          file: "file";
+                                          directory: "directory";
+                                        }>;
+                                        path: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"command">;
+                                        trigger: z$1.ZodEnum<{
+                                          "/": "/";
+                                        }>;
+                                        name: z$1.ZodString;
+                                        source: z$1.ZodEnum<{
+                                          command: "command";
+                                          skill: "skill";
+                                        }>;
+                                        origin: z$1.ZodEnum<{
+                                          builtin: "builtin";
+                                          project: "project";
+                                          user: "user";
+                                        }>;
+                                        label: z$1.ZodString;
+                                        argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"plugin">;
+                                        pluginId: z$1.ZodString;
+                                        icon: z$1.ZodOptional<
+                                          z$1.ZodNullable<z$1.ZodString>
+                                        >;
+                                        itemId: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                  ],
+                                  "kind"
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >,
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"image">;
+                      url: z$1.ZodString;
+                    },
+                    z$1.core.$strip
+                  >,
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"localImage">;
+                      path: z$1.ZodString;
+                    },
+                    z$1.core.$strip
+                  >,
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"localFile">;
+                      path: z$1.ZodString;
+                      name: z$1.ZodOptional<z$1.ZodString>;
+                      sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                      mimeType: z$1.ZodOptional<z$1.ZodString>;
+                    },
+                    z$1.core.$strip
+                  >,
+                ],
+                "type"
+              >
+            >
+          >
+        >;
+        threadStoragePath: z$1.ZodOptional<z$1.ZodString>;
+        fork: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              sourceProviderThreadId: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        providerThreadId: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "turn.submit": HostDaemonCommandDescriptor<
+    "turn.submit",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"turn.submit">;
+        requestId: z$1.ZodString;
+        input: z$1.ZodArray<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"text">;
+                  text: z$1.ZodString;
+                  mentions: z$1.ZodDefault<
+                    z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          start: z$1.ZodNumber;
+                          end: z$1.ZodNumber;
+                          resource: z$1.ZodPipe<
+                            z$1.ZodTransform<unknown, unknown>,
+                            z$1.ZodDiscriminatedUnion<
+                              [
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"thread">;
+                                    threadId: z$1.ZodString;
+                                    projectId: z$1.ZodOptional<z$1.ZodString>;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"project">;
+                                    projectId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"section">;
+                                    sectionId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"path">;
+                                    source: z$1.ZodEnum<{
+                                      workspace: "workspace";
+                                      "thread-storage": "thread-storage";
+                                    }>;
+                                    entryKind: z$1.ZodEnum<{
+                                      file: "file";
+                                      directory: "directory";
+                                    }>;
+                                    path: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"command">;
+                                    trigger: z$1.ZodEnum<{
+                                      "/": "/";
+                                    }>;
+                                    name: z$1.ZodString;
+                                    source: z$1.ZodEnum<{
+                                      command: "command";
+                                      skill: "skill";
+                                    }>;
+                                    origin: z$1.ZodEnum<{
+                                      builtin: "builtin";
+                                      project: "project";
+                                      user: "user";
+                                    }>;
+                                    label: z$1.ZodString;
+                                    argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"plugin">;
+                                    pluginId: z$1.ZodString;
+                                    icon: z$1.ZodOptional<
+                                      z$1.ZodNullable<z$1.ZodString>
+                                    >;
+                                    itemId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                              ],
+                              "kind"
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"image">;
+                  url: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localImage">;
+                  path: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localFile">;
+                  path: z$1.ZodString;
+                  name: z$1.ZodOptional<z$1.ZodString>;
+                  sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                  mimeType: z$1.ZodOptional<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "type"
+          >
+        >;
+        inputGroups: z$1.ZodOptional<
+          z$1.ZodArray<
+            z$1.ZodArray<
+              z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"text">;
+                      text: z$1.ZodString;
+                      mentions: z$1.ZodDefault<
+                        z$1.ZodArray<
+                          z$1.ZodObject<
+                            {
+                              start: z$1.ZodNumber;
+                              end: z$1.ZodNumber;
+                              resource: z$1.ZodPipe<
+                                z$1.ZodTransform<unknown, unknown>,
+                                z$1.ZodDiscriminatedUnion<
+                                  [
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"thread">;
+                                        threadId: z$1.ZodString;
+                                        projectId: z$1.ZodOptional<z$1.ZodString>;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"project">;
+                                        projectId: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"section">;
+                                        sectionId: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"path">;
+                                        source: z$1.ZodEnum<{
+                                          workspace: "workspace";
+                                          "thread-storage": "thread-storage";
+                                        }>;
+                                        entryKind: z$1.ZodEnum<{
+                                          file: "file";
+                                          directory: "directory";
+                                        }>;
+                                        path: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"command">;
+                                        trigger: z$1.ZodEnum<{
+                                          "/": "/";
+                                        }>;
+                                        name: z$1.ZodString;
+                                        source: z$1.ZodEnum<{
+                                          command: "command";
+                                          skill: "skill";
+                                        }>;
+                                        origin: z$1.ZodEnum<{
+                                          builtin: "builtin";
+                                          project: "project";
+                                          user: "user";
+                                        }>;
+                                        label: z$1.ZodString;
+                                        argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                    z$1.ZodObject<
+                                      {
+                                        kind: z$1.ZodLiteral<"plugin">;
+                                        pluginId: z$1.ZodString;
+                                        icon: z$1.ZodOptional<
+                                          z$1.ZodNullable<z$1.ZodString>
+                                        >;
+                                        itemId: z$1.ZodString;
+                                        label: z$1.ZodString;
+                                      },
+                                      z$1.core.$strip
+                                    >,
+                                  ],
+                                  "kind"
+                                >
+                              >;
+                            },
+                            z$1.core.$strip
+                          >
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >,
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"image">;
+                      url: z$1.ZodString;
+                    },
+                    z$1.core.$strip
+                  >,
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"localImage">;
+                      path: z$1.ZodString;
+                    },
+                    z$1.core.$strip
+                  >,
+                  z$1.ZodObject<
+                    {
+                      visibility: z$1.ZodOptional<
+                        z$1.ZodEnum<{
+                          "agent-only": "agent-only";
+                        }>
+                      >;
+                      type: z$1.ZodLiteral<"localFile">;
+                      path: z$1.ZodString;
+                      name: z$1.ZodOptional<z$1.ZodString>;
+                      sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                      mimeType: z$1.ZodOptional<z$1.ZodString>;
+                    },
+                    z$1.core.$strip
+                  >,
+                ],
+                "type"
+              >
+            >
+          >
+        >;
+        options: z$1.ZodIntersection<
+          z$1.ZodObject<
+            {
+              model: z$1.ZodString;
+              serviceTier: z$1.ZodEnum<{
+                default: "default";
+                fast: "fast";
+              }>;
+              reasoningLevel: z$1.ZodEnum<{
+                none: "none";
+                low: "low";
+                medium: "medium";
+                high: "high";
+                xhigh: "xhigh";
+                ultracode: "ultracode";
+                max: "max";
+                ultra: "ultra";
+              }>;
+              claudeCodePermissionMode: z$1.ZodOptional<z$1.ZodLiteral<"plan">>;
+              claudeCodeMockCliTraffic: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    enabled: z$1.ZodBoolean;
+                    endpoint: z$1.ZodString;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              workflowsEnabled: z$1.ZodBoolean;
+              memoryEnabled: z$1.ZodOptional<z$1.ZodBoolean>;
+              providerSubagentsEnabled: z$1.ZodOptional<z$1.ZodBoolean>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"accept-edits">;
+                  permissionScope: z$1.ZodLiteral<"workspace">;
+                  approvalReviewer: z$1.ZodLiteral<"user">;
+                  permissionEscalation: z$1.ZodEnum<{
+                    ask: "ask";
+                    deny: "deny";
+                  }>;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"auto">;
+                  permissionScope: z$1.ZodLiteral<"workspace">;
+                  approvalReviewer: z$1.ZodLiteral<"automatic">;
+                  permissionEscalation: z$1.ZodEnum<{
+                    ask: "ask";
+                    deny: "deny";
+                  }>;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"full">;
+                  permissionScope: z$1.ZodLiteral<"full">;
+                  approvalReviewer: z$1.ZodNull;
+                  permissionEscalation: z$1.ZodNull;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "permissionMode"
+          >
+        >;
+        acpLaunchSpec: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              displayName: z$1.ZodString;
+              command: z$1.ZodString;
+              args: z$1.ZodArray<z$1.ZodString>;
+              env: z$1.ZodRecord<z$1.ZodString, z$1.ZodString>;
+              cwd: z$1.ZodOptional<z$1.ZodString>;
+              modelCli: z$1.ZodOptional<
+                z$1.ZodPipe<
+                  z$1.ZodObject<
+                    {
+                      listArgs: z$1.ZodArray<z$1.ZodString>;
+                      selectFlag: z$1.ZodOptional<z$1.ZodString>;
+                      primaryModels: z$1.ZodArray<z$1.ZodString>;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodTransform<
+                    | {
+                        listArgs: string[];
+                        primaryModels: string[];
+                        selectFlag?: string | undefined;
+                      }
+                    | undefined,
+                    {
+                      listArgs: string[];
+                      primaryModels: string[];
+                      selectFlag?: string | undefined;
+                    }
+                  >
+                >
+              >;
+              reasoningCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    flag: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              nativeReasoning: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    configId: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              permissionCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    full: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    workspaceWrite: z$1.ZodOptional<
+                      z$1.ZodArray<z$1.ZodString>
+                    >;
+                    readonly: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    insertAfterArgs: z$1.ZodOptional<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+            },
+            z$1.core.$strict
+          >
+        >;
+        resumeContext: z$1.ZodObject<
+          {
+            workspaceContext: z$1.ZodObject<
+              {
+                workspacePath: z$1.ZodString;
+                workspaceProvisionType: z$1.ZodEnum<{
+                  unmanaged: "unmanaged";
+                  "managed-worktree": "managed-worktree";
+                  personal: "personal";
+                }>;
+              },
+              z$1.core.$strip
+            >;
+            instructionMode: z$1.ZodEnum<{
+              append: "append";
+              replace: "replace";
+            }>;
+            projectId: z$1.ZodString;
+            providerId: z$1.ZodString;
+            acpLaunchSpec: z$1.ZodOptional<
+              z$1.ZodObject<
+                {
+                  displayName: z$1.ZodString;
+                  command: z$1.ZodString;
+                  args: z$1.ZodArray<z$1.ZodString>;
+                  env: z$1.ZodRecord<z$1.ZodString, z$1.ZodString>;
+                  cwd: z$1.ZodOptional<z$1.ZodString>;
+                  modelCli: z$1.ZodOptional<
+                    z$1.ZodPipe<
+                      z$1.ZodObject<
+                        {
+                          listArgs: z$1.ZodArray<z$1.ZodString>;
+                          selectFlag: z$1.ZodOptional<z$1.ZodString>;
+                          primaryModels: z$1.ZodArray<z$1.ZodString>;
+                        },
+                        z$1.core.$strict
+                      >,
+                      z$1.ZodTransform<
+                        | {
+                            listArgs: string[];
+                            primaryModels: string[];
+                            selectFlag?: string | undefined;
+                          }
+                        | undefined,
+                        {
+                          listArgs: string[];
+                          primaryModels: string[];
+                          selectFlag?: string | undefined;
+                        }
+                      >
+                    >
+                  >;
+                  reasoningCli: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        flag: z$1.ZodString;
+                        supportedLevels: z$1.ZodArray<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                        levelValues: z$1.ZodOptional<
+                          z$1.ZodRecord<
+                            z$1.ZodEnum<{
+                              none: "none";
+                              low: "low";
+                              medium: "medium";
+                              high: "high";
+                              xhigh: "xhigh";
+                              ultracode: "ultracode";
+                              max: "max";
+                              ultra: "ultra";
+                            }> &
+                              z$1.core.$partial,
+                            z$1.ZodString
+                          >
+                        >;
+                        defaultLevel: z$1.ZodOptional<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                  nativeReasoning: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        configId: z$1.ZodString;
+                        supportedLevels: z$1.ZodArray<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                        levelValues: z$1.ZodOptional<
+                          z$1.ZodRecord<
+                            z$1.ZodEnum<{
+                              none: "none";
+                              low: "low";
+                              medium: "medium";
+                              high: "high";
+                              xhigh: "xhigh";
+                              ultracode: "ultracode";
+                              max: "max";
+                              ultra: "ultra";
+                            }> &
+                              z$1.core.$partial,
+                            z$1.ZodString
+                          >
+                        >;
+                        defaultLevel: z$1.ZodOptional<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                  permissionCli: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        full: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                        workspaceWrite: z$1.ZodOptional<
+                          z$1.ZodArray<z$1.ZodString>
+                        >;
+                        readonly: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                        insertAfterArgs: z$1.ZodOptional<z$1.ZodNumber>;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                },
+                z$1.core.$strict
+              >
+            >;
+            instructions: z$1.ZodString;
+            dynamicTools: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  name: z$1.ZodString;
+                  description: z$1.ZodString;
+                  inputSchema: z$1.ZodUnknown;
+                },
+                z$1.core.$strip
+              >
+            >;
+            injectedSkillSources: z$1.ZodArray<
+              z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      name: z$1.ZodString;
+                      description: z$1.ZodString;
+                      kind: z$1.ZodLiteral<"tree">;
+                      treeHash: z$1.ZodString;
+                      entryPath: z$1.ZodString;
+                      sourceType: z$1.ZodEnum<{
+                        builtin: "builtin";
+                        "data-dir": "data-dir";
+                      }>;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      name: z$1.ZodString;
+                      description: z$1.ZodString;
+                      kind: z$1.ZodLiteral<"workspace-path">;
+                      sourceType: z$1.ZodLiteral<"project">;
+                      sourceRootPath: z$1.ZodString;
+                      skillFilePath: z$1.ZodString;
+                    },
+                    z$1.core.$strict
+                  >,
+                ],
+                "kind"
+              >
+            >;
+            disallowedTools: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+            providerThreadId: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >;
+        target: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                mode: z$1.ZodLiteral<"start">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                mode: z$1.ZodLiteral<"auto">;
+                expectedTurnId: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                mode: z$1.ZodLiteral<"steer">;
+                expectedTurnId: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "mode"
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        appliedAs: z$1.ZodEnum<{
+          steer: "steer";
+          "new-turn": "new-turn";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "thread.stop": HostDaemonCommandDescriptor<
+    "thread.stop",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"thread.stop">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<{}, z$1.core.$strip>,
+    "settled",
+    false
+  >;
+  "thread.goal.clear": HostDaemonCommandDescriptor<
+    "thread.goal.clear",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"thread.goal.clear">;
+        options: z$1.ZodIntersection<
+          z$1.ZodObject<
+            {
+              model: z$1.ZodString;
+              serviceTier: z$1.ZodEnum<{
+                default: "default";
+                fast: "fast";
+              }>;
+              reasoningLevel: z$1.ZodEnum<{
+                none: "none";
+                low: "low";
+                medium: "medium";
+                high: "high";
+                xhigh: "xhigh";
+                ultracode: "ultracode";
+                max: "max";
+                ultra: "ultra";
+              }>;
+              claudeCodePermissionMode: z$1.ZodOptional<z$1.ZodLiteral<"plan">>;
+              claudeCodeMockCliTraffic: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    enabled: z$1.ZodBoolean;
+                    endpoint: z$1.ZodString;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              workflowsEnabled: z$1.ZodBoolean;
+              memoryEnabled: z$1.ZodOptional<z$1.ZodBoolean>;
+              providerSubagentsEnabled: z$1.ZodOptional<z$1.ZodBoolean>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"accept-edits">;
+                  permissionScope: z$1.ZodLiteral<"workspace">;
+                  approvalReviewer: z$1.ZodLiteral<"user">;
+                  permissionEscalation: z$1.ZodEnum<{
+                    ask: "ask";
+                    deny: "deny";
+                  }>;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"auto">;
+                  permissionScope: z$1.ZodLiteral<"workspace">;
+                  approvalReviewer: z$1.ZodLiteral<"automatic">;
+                  permissionEscalation: z$1.ZodEnum<{
+                    ask: "ask";
+                    deny: "deny";
+                  }>;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  permissionMode: z$1.ZodLiteral<"full">;
+                  permissionScope: z$1.ZodLiteral<"full">;
+                  approvalReviewer: z$1.ZodNull;
+                  permissionEscalation: z$1.ZodNull;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "permissionMode"
+          >
+        >;
+        acpLaunchSpec: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              displayName: z$1.ZodString;
+              command: z$1.ZodString;
+              args: z$1.ZodArray<z$1.ZodString>;
+              env: z$1.ZodRecord<z$1.ZodString, z$1.ZodString>;
+              cwd: z$1.ZodOptional<z$1.ZodString>;
+              modelCli: z$1.ZodOptional<
+                z$1.ZodPipe<
+                  z$1.ZodObject<
+                    {
+                      listArgs: z$1.ZodArray<z$1.ZodString>;
+                      selectFlag: z$1.ZodOptional<z$1.ZodString>;
+                      primaryModels: z$1.ZodArray<z$1.ZodString>;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodTransform<
+                    | {
+                        listArgs: string[];
+                        primaryModels: string[];
+                        selectFlag?: string | undefined;
+                      }
+                    | undefined,
+                    {
+                      listArgs: string[];
+                      primaryModels: string[];
+                      selectFlag?: string | undefined;
+                    }
+                  >
+                >
+              >;
+              reasoningCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    flag: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              nativeReasoning: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    configId: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              permissionCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    full: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    workspaceWrite: z$1.ZodOptional<
+                      z$1.ZodArray<z$1.ZodString>
+                    >;
+                    readonly: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    insertAfterArgs: z$1.ZodOptional<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+            },
+            z$1.core.$strict
+          >
+        >;
+        resumeContext: z$1.ZodObject<
+          {
+            workspaceContext: z$1.ZodObject<
+              {
+                workspacePath: z$1.ZodString;
+                workspaceProvisionType: z$1.ZodEnum<{
+                  unmanaged: "unmanaged";
+                  "managed-worktree": "managed-worktree";
+                  personal: "personal";
+                }>;
+              },
+              z$1.core.$strip
+            >;
+            instructionMode: z$1.ZodEnum<{
+              append: "append";
+              replace: "replace";
+            }>;
+            projectId: z$1.ZodString;
+            providerId: z$1.ZodString;
+            acpLaunchSpec: z$1.ZodOptional<
+              z$1.ZodObject<
+                {
+                  displayName: z$1.ZodString;
+                  command: z$1.ZodString;
+                  args: z$1.ZodArray<z$1.ZodString>;
+                  env: z$1.ZodRecord<z$1.ZodString, z$1.ZodString>;
+                  cwd: z$1.ZodOptional<z$1.ZodString>;
+                  modelCli: z$1.ZodOptional<
+                    z$1.ZodPipe<
+                      z$1.ZodObject<
+                        {
+                          listArgs: z$1.ZodArray<z$1.ZodString>;
+                          selectFlag: z$1.ZodOptional<z$1.ZodString>;
+                          primaryModels: z$1.ZodArray<z$1.ZodString>;
+                        },
+                        z$1.core.$strict
+                      >,
+                      z$1.ZodTransform<
+                        | {
+                            listArgs: string[];
+                            primaryModels: string[];
+                            selectFlag?: string | undefined;
+                          }
+                        | undefined,
+                        {
+                          listArgs: string[];
+                          primaryModels: string[];
+                          selectFlag?: string | undefined;
+                        }
+                      >
+                    >
+                  >;
+                  reasoningCli: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        flag: z$1.ZodString;
+                        supportedLevels: z$1.ZodArray<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                        levelValues: z$1.ZodOptional<
+                          z$1.ZodRecord<
+                            z$1.ZodEnum<{
+                              none: "none";
+                              low: "low";
+                              medium: "medium";
+                              high: "high";
+                              xhigh: "xhigh";
+                              ultracode: "ultracode";
+                              max: "max";
+                              ultra: "ultra";
+                            }> &
+                              z$1.core.$partial,
+                            z$1.ZodString
+                          >
+                        >;
+                        defaultLevel: z$1.ZodOptional<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                  nativeReasoning: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        configId: z$1.ZodString;
+                        supportedLevels: z$1.ZodArray<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                        levelValues: z$1.ZodOptional<
+                          z$1.ZodRecord<
+                            z$1.ZodEnum<{
+                              none: "none";
+                              low: "low";
+                              medium: "medium";
+                              high: "high";
+                              xhigh: "xhigh";
+                              ultracode: "ultracode";
+                              max: "max";
+                              ultra: "ultra";
+                            }> &
+                              z$1.core.$partial,
+                            z$1.ZodString
+                          >
+                        >;
+                        defaultLevel: z$1.ZodOptional<
+                          z$1.ZodEnum<{
+                            none: "none";
+                            low: "low";
+                            medium: "medium";
+                            high: "high";
+                            xhigh: "xhigh";
+                            ultracode: "ultracode";
+                            max: "max";
+                            ultra: "ultra";
+                          }>
+                        >;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                  permissionCli: z$1.ZodOptional<
+                    z$1.ZodObject<
+                      {
+                        full: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                        workspaceWrite: z$1.ZodOptional<
+                          z$1.ZodArray<z$1.ZodString>
+                        >;
+                        readonly: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                        insertAfterArgs: z$1.ZodOptional<z$1.ZodNumber>;
+                      },
+                      z$1.core.$strict
+                    >
+                  >;
+                },
+                z$1.core.$strict
+              >
+            >;
+            instructions: z$1.ZodString;
+            dynamicTools: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  name: z$1.ZodString;
+                  description: z$1.ZodString;
+                  inputSchema: z$1.ZodUnknown;
+                },
+                z$1.core.$strip
+              >
+            >;
+            injectedSkillSources: z$1.ZodArray<
+              z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      name: z$1.ZodString;
+                      description: z$1.ZodString;
+                      kind: z$1.ZodLiteral<"tree">;
+                      treeHash: z$1.ZodString;
+                      entryPath: z$1.ZodString;
+                      sourceType: z$1.ZodEnum<{
+                        builtin: "builtin";
+                        "data-dir": "data-dir";
+                      }>;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      name: z$1.ZodString;
+                      description: z$1.ZodString;
+                      kind: z$1.ZodLiteral<"workspace-path">;
+                      sourceType: z$1.ZodLiteral<"project">;
+                      sourceRootPath: z$1.ZodString;
+                      skillFilePath: z$1.ZodString;
+                    },
+                    z$1.core.$strict
+                  >,
+                ],
+                "kind"
+              >
+            >;
+            disallowedTools: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+            providerThreadId: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        cleared: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >,
+    "settled",
+    false
+  >;
+  "thread.plan.cancel": HostDaemonCommandDescriptor<
+    "thread.plan.cancel",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"thread.plan.cancel">;
+        expectedTurnId: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        cancelled: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >,
+    "settled",
+    false
+  >;
+  "thread.rename": HostDaemonCommandDescriptor<
+    "thread.rename",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"thread.rename">;
+        title: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<{}, z$1.core.$strip>,
+    "settled",
+    false
+  >;
+  "thread.archive": HostDaemonCommandDescriptor<
+    "thread.archive",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"thread.archive">;
+        providerId: z$1.ZodString;
+        providerThreadId: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<{}, z$1.core.$strip>,
+    "settled",
+    false
+  >;
+  "thread.unarchive": HostDaemonCommandDescriptor<
+    "thread.unarchive",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"thread.unarchive">;
+        providerId: z$1.ZodString;
+        providerThreadId: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<{}, z$1.core.$strip>,
+    "settled",
+    false
+  >;
+  "interactive.resolve": HostDaemonCommandDescriptor<
+    "interactive.resolve",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        threadId: z$1.ZodString;
+        type: z$1.ZodLiteral<"interactive.resolve">;
+        interactionId: z$1.ZodString;
+        providerId: z$1.ZodString;
+        providerThreadId: z$1.ZodString;
+        providerRequestId: z$1.ZodString;
+        resolution: z$1.ZodUnion<
+          readonly [
+            z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    decision: z$1.ZodLiteral<"allow_once">;
+                    grantedPermissions: z$1.ZodNullable<
+                      z$1.ZodObject<
+                        {
+                          network: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                          fileSystem: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                read: z$1.ZodArray<z$1.ZodString>;
+                                write: z$1.ZodArray<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                        },
+                        z$1.core.$strict
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    decision: z$1.ZodLiteral<"allow_for_session">;
+                    grantedPermissions: z$1.ZodNullable<
+                      z$1.ZodObject<
+                        {
+                          network: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                          fileSystem: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                read: z$1.ZodArray<z$1.ZodString>;
+                                write: z$1.ZodArray<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >;
+                        },
+                        z$1.core.$strict
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    decision: z$1.ZodLiteral<"deny">;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "decision"
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"user_answer">;
+                answers: z$1.ZodRecord<
+                  z$1.ZodString,
+                  z$1.ZodObject<
+                    {
+                      selected: z$1.ZodArray<z$1.ZodString>;
+                      freeText: z$1.ZodOptional<z$1.ZodString>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"plugin_submitted">;
+              },
+              z$1.core.$strip
+            >,
+          ]
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<{}, z$1.core.$strip>,
+    "settled",
+    false
+  >;
+  "codex.inference.complete": HostDaemonCommandDescriptor<
+    "codex.inference.complete",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"codex.inference.complete">;
+        model: z$1.ZodString;
+        prompt: z$1.ZodString;
+        outputSchema: z$1.ZodType<
+          JsonObject,
+          unknown,
+          z$1.core.$ZodTypeInternals<JsonObject, unknown>
+        >;
+        timeoutMs: z$1.ZodNumber;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        model: z$1.ZodString;
+        value: z$1.ZodType<
+          JsonObject,
+          unknown,
+          z$1.core.$ZodTypeInternals<JsonObject, unknown>
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "codex.voice.transcribe": HostDaemonCommandDescriptor<
+    "codex.voice.transcribe",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"codex.voice.transcribe">;
+        model: z$1.ZodString;
+        audioBase64: z$1.ZodString;
+        mimeType: z$1.ZodString;
+        filename: z$1.ZodString;
+        prompt: z$1.ZodNullable<z$1.ZodString>;
+        timeoutMs: z$1.ZodNumber;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        model: z$1.ZodString;
+        text: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "environment.provision": HostDaemonCommandDescriptor<
+    "environment.provision",
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            environmentId: z$1.ZodString;
+            type: z$1.ZodLiteral<"environment.provision">;
+            initiator: z$1.ZodNullable<
+              z$1.ZodObject<
+                {
+                  threadId: z$1.ZodString;
+                  provisioningId: z$1.ZodString;
+                },
+                z$1.core.$strict
+              >
+            >;
+            workspaceProvisionType: z$1.ZodLiteral<"unmanaged">;
+            path: z$1.ZodString;
+            checkout: z$1.ZodOptional<
+              z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"existing">;
+                      name: z$1.ZodString;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"new">;
+                      name: z$1.ZodString;
+                      baseBranch: z$1.ZodString;
+                    },
+                    z$1.core.$strict
+                  >,
+                ],
+                "kind"
+              >
+            >;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            environmentId: z$1.ZodString;
+            type: z$1.ZodLiteral<"environment.provision">;
+            initiator: z$1.ZodNullable<
+              z$1.ZodObject<
+                {
+                  threadId: z$1.ZodString;
+                  provisioningId: z$1.ZodString;
+                },
+                z$1.core.$strict
+              >
+            >;
+            sourcePath: z$1.ZodString;
+            targetPath: z$1.ZodString;
+            branchName: z$1.ZodString;
+            baseBranch: z$1.ZodNullable<z$1.ZodString>;
+            setupTimeoutMs: z$1.ZodNumber;
+            workspaceProvisionType: z$1.ZodLiteral<"managed-worktree">;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            environmentId: z$1.ZodString;
+            type: z$1.ZodLiteral<"environment.provision">;
+            initiator: z$1.ZodNullable<
+              z$1.ZodObject<
+                {
+                  threadId: z$1.ZodString;
+                  provisioningId: z$1.ZodString;
+                },
+                z$1.core.$strict
+              >
+            >;
+            workspaceProvisionType: z$1.ZodLiteral<"personal">;
+            targetPath: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "workspaceProvisionType"
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        isGitRepo: z$1.ZodBoolean;
+        isWorktree: z$1.ZodBoolean;
+        branchName: z$1.ZodNullable<z$1.ZodString>;
+        defaultBranch: z$1.ZodNullable<z$1.ZodString>;
+        transcript: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              type: z$1.ZodEnum<{
+                output: "output";
+                step: "step";
+              }>;
+              key: z$1.ZodString;
+              text: z$1.ZodString;
+              startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+              status: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  started: "started";
+                  completed: "completed";
+                  failed: "failed";
+                }>
+              >;
+              metadata: z$1.ZodOptional<
+                z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>
+              >;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "project.clone": HostDaemonCommandDescriptor<
+    "project.clone",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"project.clone">;
+        remoteUrl: z$1.ZodString;
+        projectSlug: z$1.ZodString;
+        targetPath: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        gitRemoteUrl: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    "settled",
+    false
+  >;
+  "environment.provision.cancel": HostDaemonCommandDescriptor<
+    "environment.provision.cancel",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        type: z$1.ZodLiteral<"environment.provision.cancel">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        aborted: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "environment.destroy": HostDaemonCommandDescriptor<
+    "environment.destroy",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"environment.destroy">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<{}, z$1.core.$strip>,
+    "settled",
+    false
+  >;
+  "workspace.commit": HostDaemonCommandDescriptor<
+    "workspace.commit",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.commit">;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        commitSha: z$1.ZodString;
+        commitSubject: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "workspace.squash_merge": HostDaemonCommandDescriptor<
+    "workspace.squash_merge",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.squash_merge">;
+        targetBranch: z$1.ZodString;
+        commitMessage: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        commitSha: z$1.ZodString;
+        commitSubject: z$1.ZodString;
+        merged: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >,
+    "settled",
+    false
+  >;
+  "workspace.pull_request_action": HostDaemonCommandDescriptor<
+    "workspace.pull_request_action",
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            environmentId: z$1.ZodString;
+            workspaceContext: z$1.ZodObject<
+              {
+                workspacePath: z$1.ZodString;
+                workspaceProvisionType: z$1.ZodEnum<{
+                  unmanaged: "unmanaged";
+                  "managed-worktree": "managed-worktree";
+                  personal: "personal";
+                }>;
+              },
+              z$1.core.$strip
+            >;
+            type: z$1.ZodLiteral<"workspace.pull_request_action">;
+            operation: z$1.ZodLiteral<"ready">;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            environmentId: z$1.ZodString;
+            workspaceContext: z$1.ZodObject<
+              {
+                workspacePath: z$1.ZodString;
+                workspaceProvisionType: z$1.ZodEnum<{
+                  unmanaged: "unmanaged";
+                  "managed-worktree": "managed-worktree";
+                  personal: "personal";
+                }>;
+              },
+              z$1.core.$strip
+            >;
+            type: z$1.ZodLiteral<"workspace.pull_request_action">;
+            operation: z$1.ZodLiteral<"draft">;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            environmentId: z$1.ZodString;
+            workspaceContext: z$1.ZodObject<
+              {
+                workspacePath: z$1.ZodString;
+                workspaceProvisionType: z$1.ZodEnum<{
+                  unmanaged: "unmanaged";
+                  "managed-worktree": "managed-worktree";
+                  personal: "personal";
+                }>;
+              },
+              z$1.core.$strip
+            >;
+            type: z$1.ZodLiteral<"workspace.pull_request_action">;
+            operation: z$1.ZodLiteral<"merge">;
+            method: z$1.ZodEnum<{
+              merge: "merge";
+              squash: "squash";
+              rebase: "rebase";
+            }>;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "operation"
+    >,
+    z$1.ZodObject<{}, z$1.core.$strict>,
+    "settled",
+    false
+  >;
+  "host.list_files": HostDaemonCommandDescriptor<
+    "host.list_files",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.list_files">;
+        path: z$1.ZodString;
+        query: z$1.ZodOptional<z$1.ZodString>;
+        limit: z$1.ZodNumber;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        files: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              path: z$1.ZodString;
+              name: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >
+        >;
+        truncated: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.list_paths": HostDaemonCommandDescriptor<
+    "host.list_paths",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.list_paths">;
+        path: z$1.ZodString;
+        query: z$1.ZodOptional<z$1.ZodString>;
+        limit: z$1.ZodNumber;
+        includeFiles: z$1.ZodBoolean;
+        includeDirectories: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        paths: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              kind: z$1.ZodEnum<{
+                file: "file";
+                directory: "directory";
+              }>;
+              path: z$1.ZodString;
+              name: z$1.ZodString;
+              score: z$1.ZodNumber;
+              positions: z$1.ZodArray<z$1.ZodNumber>;
+            },
+            z$1.core.$strip
+          >
+        >;
+        truncated: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.mkdir": HostDaemonCommandDescriptor<
+    "host.mkdir",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.mkdir">;
+        path: z$1.ZodString;
+        rootPath: z$1.ZodOptional<z$1.ZodString>;
+        recursive: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        ok: z$1.ZodLiteral<true>;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.move_path": HostDaemonCommandDescriptor<
+    "host.move_path",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.move_path">;
+        sourcePath: z$1.ZodString;
+        destinationPath: z$1.ZodString;
+        rootPath: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        ok: z$1.ZodLiteral<true>;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.remove_path": HostDaemonCommandDescriptor<
+    "host.remove_path",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.remove_path">;
+        path: z$1.ZodString;
+        rootPath: z$1.ZodOptional<z$1.ZodString>;
+        recursive: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        ok: z$1.ZodLiteral<true>;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.browse_directory": HostDaemonCommandDescriptor<
+    "host.browse_directory",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.browse_directory">;
+        path: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        directory: z$1.ZodString;
+        parent: z$1.ZodNullable<z$1.ZodString>;
+        entries: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              kind: z$1.ZodEnum<{
+                file: "file";
+                directory: "directory";
+              }>;
+              name: z$1.ZodString;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.paths_exist": HostDaemonCommandDescriptor<
+    "host.paths_exist",
+    z$1.ZodObject<
+      {
+        paths: z$1.ZodPipe<
+          z$1.ZodArray<z$1.ZodString>,
+          z$1.ZodTransform<string[], string[]>
+        >;
+        type: z$1.ZodLiteral<"host.paths_exist">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        existence: z$1.ZodRecord<z$1.ZodString, z$1.ZodBoolean>;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "project.inspect": HostDaemonCommandDescriptor<
+    "project.inspect",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"project.inspect">;
+        path: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        gitRemoteUrl: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    true
+  >;
+  "project.clone_default_path": HostDaemonCommandDescriptor<
+    "project.clone_default_path",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"project.clone_default_path">;
+        projectSlug: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.pick_folder": HostDaemonCommandDescriptor<
+    "host.pick_folder",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.pick_folder">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.caffeinate": HostDaemonCommandDescriptor<
+    "host.caffeinate",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.caffeinate">;
+        enabled: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        enabled: z$1.ZodBoolean;
+        supported: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    false
+  >;
+  "connect-tunnel.ensure-identity": HostDaemonCommandDescriptor<
+    "connect-tunnel.ensure-identity",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"connect-tunnel.ensure-identity">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        label: z$1.ZodString;
+        baseDomain: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.list_commands": HostDaemonCommandDescriptor<
+    "host.list_commands",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.list_commands">;
+        providerId: z$1.ZodString;
+        cwd: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        commands: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              name: z$1.ZodString;
+              source: z$1.ZodEnum<{
+                command: "command";
+                skill: "skill";
+              }>;
+              origin: z$1.ZodEnum<{
+                project: "project";
+                user: "user";
+              }>;
+              description: z$1.ZodNullable<z$1.ZodString>;
+              argumentHint: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.list_skills": HostDaemonCommandDescriptor<
+    "host.list_skills",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.list_skills">;
+        providerId: z$1.ZodString;
+        cwd: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        skills: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              name: z$1.ZodString;
+              description: z$1.ZodNullable<z$1.ZodString>;
+              filePath: z$1.ZodString;
+              rootKind: z$1.ZodEnum<{
+                plugin: "plugin";
+                "bb-project": "bb-project";
+                "bb-data-dir": "bb-data-dir";
+                "bb-builtin": "bb-builtin";
+                "provider-project": "provider-project";
+                "provider-user": "provider-user";
+              }>;
+              linked: z$1.ZodBoolean;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.delete_skill": HostDaemonCommandDescriptor<
+    "host.delete_skill",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.delete_skill">;
+        scope: z$1.ZodEnum<{
+          "bb-project": "bb-project";
+          "bb-user": "bb-user";
+          "claude-user": "claude-user";
+          "claude-project": "claude-project";
+          "codex-user": "codex-user";
+          "codex-project": "codex-project";
+        }>;
+        name: z$1.ZodString;
+        cwd: z$1.ZodNullable<z$1.ZodString>;
+        rootPath: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        deletedPath: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.write_skill": HostDaemonCommandDescriptor<
+    "host.write_skill",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.write_skill">;
+        scope: z$1.ZodEnum<{
+          "bb-project": "bb-project";
+          "bb-user": "bb-user";
+        }>;
+        name: z$1.ZodString;
+        cwd: z$1.ZodNullable<z$1.ZodString>;
+        content: z$1.ZodString;
+        expectedSha256: z$1.ZodString;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"written">;
+            filePath: z$1.ZodString;
+            sha256: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"conflict">;
+            currentSha256: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.install_global_skills": HostDaemonCommandDescriptor<
+    "host.install_global_skills",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.install_global_skills">;
+        skills: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              name: z$1.ZodString;
+              treeHash: z$1.ZodString;
+              entryPath: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        installations: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              name: z$1.ZodString;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    false
+  >;
+  "host.global_skills_status": HostDaemonCommandDescriptor<
+    "host.global_skills_status",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.global_skills_status">;
+        names: z$1.ZodArray<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        entries: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              name: z$1.ZodString;
+              path: z$1.ZodString;
+              treeHash: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.list_branches": HostDaemonCommandDescriptor<
+    "host.list_branches",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.list_branches">;
+        path: z$1.ZodString;
+        query: z$1.ZodOptional<z$1.ZodString>;
+        selectedBranch: z$1.ZodOptional<z$1.ZodString>;
+        limit: z$1.ZodNumber;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        branches: z$1.ZodArray<z$1.ZodString>;
+        branchesTruncated: z$1.ZodBoolean;
+        checkout: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"branch">;
+                branchName: z$1.ZodString;
+                headSha: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"detached">;
+                headSha: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"unborn">;
+                branchName: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"unknown">;
+                reason: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "kind"
+        >;
+        defaultBranch: z$1.ZodNullable<z$1.ZodString>;
+        defaultBranchRelation: z$1.ZodNullable<
+          z$1.ZodEnum<{
+            unknown: "unknown";
+            equal: "equal";
+            "local-behind": "local-behind";
+            "local-ahead": "local-ahead";
+            diverged: "diverged";
+          }>
+        >;
+        hasUncommittedChanges: z$1.ZodBoolean;
+        operation: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"none">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"merge">;
+                hasConflicts: z$1.ZodBoolean;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"rebase">;
+                hasConflicts: z$1.ZodBoolean;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"cherry-pick">;
+                hasConflicts: z$1.ZodBoolean;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"revert">;
+                hasConflicts: z$1.ZodBoolean;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"unknown">;
+                reason: z$1.ZodString;
+                hasConflicts: z$1.ZodBoolean;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "kind"
+        >;
+        originDefaultBranch: z$1.ZodNullable<z$1.ZodString>;
+        remoteBranches: z$1.ZodArray<z$1.ZodString>;
+        remoteBranchesTruncated: z$1.ZodBoolean;
+        selectedBranch: z$1.ZodNullable<
+          z$1.ZodObject<
+            {
+              name: z$1.ZodString;
+              kind: z$1.ZodEnum<{
+                local: "local";
+                remote: "remote";
+                missing: "missing";
+              }>;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.file_metadata": HostDaemonCommandDescriptor<
+    "host.file_metadata",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.file_metadata">;
+        path: z$1.ZodString;
+        rootPath: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        modifiedAtMs: z$1.ZodNumber;
+        sizeBytes: z$1.ZodNumber;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.read_file": HostDaemonCommandDescriptor<
+    "host.read_file",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.read_file">;
+        path: z$1.ZodString;
+        rootPath: z$1.ZodOptional<z$1.ZodString>;
+        ref: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        content: z$1.ZodString;
+        contentEncoding: z$1.ZodEnum<{
+          base64: "base64";
+          utf8: "utf8";
+        }>;
+        mimeType: z$1.ZodOptional<z$1.ZodString>;
+        sizeBytes: z$1.ZodNumber;
+        modifiedAtMs: z$1.ZodOptional<z$1.ZodNumber>;
+        sha256: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.read_file_relative": HostDaemonCommandDescriptor<
+    "host.read_file_relative",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.read_file_relative">;
+        rootPath: z$1.ZodString;
+        path: z$1.ZodString;
+        dotfiles: z$1.ZodEnum<{
+          deny: "deny";
+          allow: "allow";
+        }>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        content: z$1.ZodString;
+        contentEncoding: z$1.ZodEnum<{
+          base64: "base64";
+          utf8: "utf8";
+        }>;
+        mimeType: z$1.ZodOptional<z$1.ZodString>;
+        sizeBytes: z$1.ZodNumber;
+        modifiedAtMs: z$1.ZodOptional<z$1.ZodNumber>;
+        sha256: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "host.write_file": HostDaemonCommandDescriptor<
+    "host.write_file",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"host.write_file">;
+        path: z$1.ZodString;
+        rootPath: z$1.ZodOptional<z$1.ZodString>;
+        content: z$1.ZodString;
+        contentEncoding: z$1.ZodEnum<{
+          base64: "base64";
+          utf8: "utf8";
+        }>;
+        createParents: z$1.ZodBoolean;
+        expectedSha256: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+        mode: z$1.ZodOptional<z$1.ZodNumber>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"written">;
+            sha256: z$1.ZodString;
+            sizeBytes: z$1.ZodNumber;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"conflict">;
+            currentSha256: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    false
+  >;
+  "provider.list_models": HostDaemonCommandDescriptor<
+    "provider.list_models",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"provider.list_models">;
+        providerId: z$1.ZodString;
+        acpLaunchSpec: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              displayName: z$1.ZodString;
+              command: z$1.ZodString;
+              args: z$1.ZodArray<z$1.ZodString>;
+              env: z$1.ZodRecord<z$1.ZodString, z$1.ZodString>;
+              cwd: z$1.ZodOptional<z$1.ZodString>;
+              modelCli: z$1.ZodOptional<
+                z$1.ZodPipe<
+                  z$1.ZodObject<
+                    {
+                      listArgs: z$1.ZodArray<z$1.ZodString>;
+                      selectFlag: z$1.ZodOptional<z$1.ZodString>;
+                      primaryModels: z$1.ZodArray<z$1.ZodString>;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodTransform<
+                    | {
+                        listArgs: string[];
+                        primaryModels: string[];
+                        selectFlag?: string | undefined;
+                      }
+                    | undefined,
+                    {
+                      listArgs: string[];
+                      primaryModels: string[];
+                      selectFlag?: string | undefined;
+                    }
+                  >
+                >
+              >;
+              reasoningCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    flag: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              nativeReasoning: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    configId: z$1.ZodString;
+                    supportedLevels: z$1.ZodArray<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                    levelValues: z$1.ZodOptional<
+                      z$1.ZodRecord<
+                        z$1.ZodEnum<{
+                          none: "none";
+                          low: "low";
+                          medium: "medium";
+                          high: "high";
+                          xhigh: "xhigh";
+                          ultracode: "ultracode";
+                          max: "max";
+                          ultra: "ultra";
+                        }> &
+                          z$1.core.$partial,
+                        z$1.ZodString
+                      >
+                    >;
+                    defaultLevel: z$1.ZodOptional<
+                      z$1.ZodEnum<{
+                        none: "none";
+                        low: "low";
+                        medium: "medium";
+                        high: "high";
+                        xhigh: "xhigh";
+                        ultracode: "ultracode";
+                        max: "max";
+                        ultra: "ultra";
+                      }>
+                    >;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              permissionCli: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    full: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    workspaceWrite: z$1.ZodOptional<
+                      z$1.ZodArray<z$1.ZodString>
+                    >;
+                    readonly: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+                    insertAfterArgs: z$1.ZodOptional<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        models: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              model: z$1.ZodString;
+              displayName: z$1.ZodString;
+              description: z$1.ZodString;
+              supportedReasoningEfforts: z$1.ZodArray<
+                z$1.ZodObject<
+                  {
+                    reasoningEffort: z$1.ZodEnum<{
+                      none: "none";
+                      low: "low";
+                      medium: "medium";
+                      high: "high";
+                      xhigh: "xhigh";
+                      ultracode: "ultracode";
+                      max: "max";
+                      ultra: "ultra";
+                    }>;
+                    description: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+              defaultReasoningEffort: z$1.ZodEnum<{
+                none: "none";
+                low: "low";
+                medium: "medium";
+                high: "high";
+                xhigh: "xhigh";
+                ultracode: "ultracode";
+                max: "max";
+                ultra: "ultra";
+              }>;
+              isDefault: z$1.ZodBoolean;
+            },
+            z$1.core.$strip
+          >
+        >;
+        selectedOnlyModels: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              model: z$1.ZodString;
+              displayName: z$1.ZodString;
+              description: z$1.ZodString;
+              supportedReasoningEfforts: z$1.ZodArray<
+                z$1.ZodObject<
+                  {
+                    reasoningEffort: z$1.ZodEnum<{
+                      none: "none";
+                      low: "low";
+                      medium: "medium";
+                      high: "high";
+                      xhigh: "xhigh";
+                      ultracode: "ultracode";
+                      max: "max";
+                      ultra: "ultra";
+                    }>;
+                    description: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+              defaultReasoningEffort: z$1.ZodEnum<{
+                none: "none";
+                low: "low";
+                medium: "medium";
+                high: "high";
+                xhigh: "xhigh";
+                ultracode: "ultracode";
+                max: "max";
+                ultra: "ultra";
+              }>;
+              isDefault: z$1.ZodBoolean;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "known_acp_agents.status": HostDaemonCommandDescriptor<
+    "known_acp_agents.status",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"known_acp_agents.status">;
+        agents: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              executableName: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        agents: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              executableName: z$1.ZodString;
+              installed: z$1.ZodBoolean;
+              executablePath: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    true
+  >;
+  "provider.usage": HostDaemonCommandDescriptor<
+    "provider.usage",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"provider.usage">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        codex: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"ok">;
+                accountEmail: z$1.ZodNullable<z$1.ZodString>;
+                planLabel: z$1.ZodNullable<z$1.ZodString>;
+                windows: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      label: z$1.ZodString;
+                      usedPercent: z$1.ZodNumber;
+                      resetsAt: z$1.ZodNullable<z$1.ZodString>;
+                      cost: z$1.ZodOptional<
+                        z$1.ZodObject<
+                          {
+                            usedUsdCents: z$1.ZodNumber;
+                            limitUsdCents: z$1.ZodNumber;
+                          },
+                          z$1.core.$strip
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"not_installed">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"unauthenticated">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"expired">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"error">;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "status"
+        >;
+        claudeCode: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"ok">;
+                accountEmail: z$1.ZodNullable<z$1.ZodString>;
+                planLabel: z$1.ZodNullable<z$1.ZodString>;
+                windows: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      label: z$1.ZodString;
+                      usedPercent: z$1.ZodNumber;
+                      resetsAt: z$1.ZodNullable<z$1.ZodString>;
+                      cost: z$1.ZodOptional<
+                        z$1.ZodObject<
+                          {
+                            usedUsdCents: z$1.ZodNumber;
+                            limitUsdCents: z$1.ZodNumber;
+                          },
+                          z$1.core.$strip
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"not_installed">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"unauthenticated">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"expired">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"error">;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "status"
+        >;
+        cursor: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"ok">;
+                accountEmail: z$1.ZodNullable<z$1.ZodString>;
+                planLabel: z$1.ZodNullable<z$1.ZodString>;
+                windows: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      label: z$1.ZodString;
+                      usedPercent: z$1.ZodNumber;
+                      resetsAt: z$1.ZodNullable<z$1.ZodString>;
+                      cost: z$1.ZodOptional<
+                        z$1.ZodObject<
+                          {
+                            usedUsdCents: z$1.ZodNumber;
+                            limitUsdCents: z$1.ZodNumber;
+                          },
+                          z$1.core.$strip
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"not_installed">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"unauthenticated">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"expired">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                status: z$1.ZodLiteral<"error">;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "status"
+        >;
+      },
+      z$1.core.$strip
+    >,
+    "onlineRpc",
+    true
+  >;
+  "provider_cli.status": HostDaemonCommandDescriptor<
+    "provider_cli.status",
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"provider_cli.status">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodRecord<
+      z$1.ZodEnum<{
+        codex: "codex";
+        claudeCode: "claudeCode";
+        cursor: "cursor";
+      }>,
+      z$1.ZodObject<
+        {
+          displayName: z$1.ZodString;
+          executableName: z$1.ZodString;
+          executablePath: z$1.ZodNullable<z$1.ZodString>;
+          installed: z$1.ZodBoolean;
+          installSource: z$1.ZodEnum<{
+            external: "external";
+            notInstalled: "notInstalled";
+            npmGlobal: "npmGlobal";
+          }>;
+          currentVersion: z$1.ZodNullable<z$1.ZodString>;
+          latestVersion: z$1.ZodNullable<z$1.ZodString>;
+          minimumSupportedVersion: z$1.ZodNullable<z$1.ZodString>;
+          npmPackageName: z$1.ZodNullable<z$1.ZodString>;
+          npmGlobalPackageVersion: z$1.ZodNullable<z$1.ZodString>;
+          installAction: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodEnum<{
+                  install: "install";
+                  update: "update";
+                }>;
+                label: z$1.ZodEnum<{
+                  Install: "Install";
+                  Update: "Update";
+                }>;
+                commandKind: z$1.ZodEnum<{
+                  exec: "exec";
+                  shell: "shell";
+                }>;
+                command: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >
+          >;
+          needsUpdate: z$1.ZodBoolean;
+          versionUnsupported: z$1.ZodBoolean;
+        },
+        z$1.core.$strip
+      >
+    >,
+    "onlineRpc",
+    true
+  >;
+  "provider_cli.install": HostDaemonCommandDescriptor<
+    "provider_cli.install",
+    z$1.ZodObject<
+      {
+        provider: z$1.ZodEnum<{
+          codex: "codex";
+          claudeCode: "claudeCode";
+          cursor: "cursor";
+        }>;
+        actionKind: z$1.ZodEnum<{
+          install: "install";
+          update: "update";
+        }>;
+        type: z$1.ZodLiteral<"provider_cli.install">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodObject<
+      {
+        events: z$1.ZodArray<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  type: z$1.ZodLiteral<"started">;
+                  provider: z$1.ZodEnum<{
+                    codex: "codex";
+                    claudeCode: "claudeCode";
+                    cursor: "cursor";
+                  }>;
+                  command: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  type: z$1.ZodLiteral<"output">;
+                  provider: z$1.ZodEnum<{
+                    codex: "codex";
+                    claudeCode: "claudeCode";
+                    cursor: "cursor";
+                  }>;
+                  stream: z$1.ZodEnum<{
+                    stdout: "stdout";
+                    stderr: "stderr";
+                  }>;
+                  text: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  type: z$1.ZodLiteral<"completed">;
+                  provider: z$1.ZodEnum<{
+                    codex: "codex";
+                    claudeCode: "claudeCode";
+                    cursor: "cursor";
+                  }>;
+                  exitCode: z$1.ZodNullable<z$1.ZodNumber>;
+                  signal: z$1.ZodNullable<z$1.ZodString>;
+                  success: z$1.ZodBoolean;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  type: z$1.ZodLiteral<"error">;
+                  provider: z$1.ZodEnum<{
+                    codex: "codex";
+                    claudeCode: "claudeCode";
+                    cursor: "cursor";
+                  }>;
+                  message: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "type"
+          >
+        >;
+      },
+      z$1.core.$strict
+    >,
+    "onlineRpc",
+    false
+  >;
+  "workspace.status": HostDaemonCommandDescriptor<
+    "workspace.status",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.status">;
+        mergeBaseBranch: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"available">;
+            workspaceStatus: z$1.ZodObject<
+              {
+                workingTree: z$1.ZodObject<
+                  {
+                    insertions: z$1.ZodNumber;
+                    deletions: z$1.ZodNumber;
+                    files: z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          path: z$1.ZodString;
+                          status: z$1.ZodEnum<{
+                            M: "M";
+                            A: "A";
+                            D: "D";
+                            R: "R";
+                            C: "C";
+                            U: "U";
+                            "??": "??";
+                            "?": "?";
+                          }>;
+                          insertions: z$1.ZodNullable<z$1.ZodNumber>;
+                          deletions: z$1.ZodNullable<z$1.ZodNumber>;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                    hasUncommittedChanges: z$1.ZodBoolean;
+                    state: z$1.ZodEnum<{
+                      clean: "clean";
+                      untracked: "untracked";
+                      dirty_uncommitted: "dirty_uncommitted";
+                      committed_unmerged: "committed_unmerged";
+                      dirty_and_committed_unmerged: "dirty_and_committed_unmerged";
+                    }>;
+                  },
+                  z$1.core.$strip
+                >;
+                checkout: z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"branch">;
+                        branchName: z$1.ZodString;
+                        headSha: z$1.ZodNullable<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"detached">;
+                        headSha: z$1.ZodNullable<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"unborn">;
+                        branchName: z$1.ZodNullable<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"unknown">;
+                        reason: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "kind"
+                >;
+                branch: z$1.ZodObject<
+                  {
+                    currentBranch: z$1.ZodNullable<z$1.ZodString>;
+                    defaultBranch: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >;
+                mergeBase: z$1.ZodNullable<
+                  z$1.ZodObject<
+                    {
+                      insertions: z$1.ZodNumber;
+                      deletions: z$1.ZodNumber;
+                      files: z$1.ZodArray<
+                        z$1.ZodObject<
+                          {
+                            path: z$1.ZodString;
+                            status: z$1.ZodEnum<{
+                              M: "M";
+                              A: "A";
+                              D: "D";
+                              R: "R";
+                              C: "C";
+                              U: "U";
+                              "??": "??";
+                              "?": "?";
+                            }>;
+                            insertions: z$1.ZodNullable<z$1.ZodNumber>;
+                            deletions: z$1.ZodNullable<z$1.ZodNumber>;
+                          },
+                          z$1.core.$strip
+                        >
+                      >;
+                      mergeBaseBranch: z$1.ZodString;
+                      baseRef: z$1.ZodNullable<z$1.ZodString>;
+                      aheadCount: z$1.ZodNumber;
+                      behindCount: z$1.ZodNumber;
+                      hasCommittedUnmergedChanges: z$1.ZodBoolean;
+                      commits: z$1.ZodArray<
+                        z$1.ZodObject<
+                          {
+                            sha: z$1.ZodString;
+                            shortSha: z$1.ZodString;
+                            subject: z$1.ZodString;
+                            authorName: z$1.ZodString;
+                            authoredAt: z$1.ZodNumber;
+                          },
+                          z$1.core.$strip
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"unavailable">;
+            failure: z$1.ZodObject<
+              {
+                code: z$1.ZodEnum<{
+                  path_not_found: "path_not_found";
+                  not_git_repo: "not_git_repo";
+                  not_worktree: "not_worktree";
+                  workspace_type_mismatch: "workspace_type_mismatch";
+                  permission_denied: "permission_denied";
+                  unknown_environment: "unknown_environment";
+                  unknown: "unknown";
+                }>;
+                workspacePath: z$1.ZodString;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strict
+            >;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    true
+  >;
+  "workspace.diff": HostDaemonCommandDescriptor<
+    "workspace.diff",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.diff">;
+        target: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"uncommitted">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"branch_committed">;
+                mergeBaseBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"all">;
+                mergeBaseBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"commit">;
+                sha: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >;
+        maxDiffBytes: z$1.ZodNumber;
+        maxFileListBytes: z$1.ZodNumber;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"available">;
+            diff: z$1.ZodObject<
+              {
+                diff: z$1.ZodString;
+                truncated: z$1.ZodBoolean;
+                shortstat: z$1.ZodString;
+                files: z$1.ZodString;
+                mergeBaseRef: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"unavailable">;
+            failure: z$1.ZodObject<
+              {
+                code: z$1.ZodEnum<{
+                  path_not_found: "path_not_found";
+                  not_git_repo: "not_git_repo";
+                  not_worktree: "not_worktree";
+                  workspace_type_mismatch: "workspace_type_mismatch";
+                  permission_denied: "permission_denied";
+                  unknown_environment: "unknown_environment";
+                  unknown: "unknown";
+                }>;
+                workspacePath: z$1.ZodString;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strict
+            >;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    true
+  >;
+  "workspace.diffFiles": HostDaemonCommandDescriptor<
+    "workspace.diffFiles",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.diffFiles">;
+        target: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"uncommitted">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"branch_committed">;
+                mergeBaseBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"all">;
+                mergeBaseBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"commit">;
+                sha: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"available">;
+            files: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  path: z$1.ZodString;
+                  previousPath: z$1.ZodNullable<z$1.ZodString>;
+                  statusLetter: z$1.ZodEnum<{
+                    M: "M";
+                    A: "A";
+                    D: "D";
+                    R: "R";
+                    C: "C";
+                    T: "T";
+                  }>;
+                  additions: z$1.ZodNumber;
+                  deletions: z$1.ZodNumber;
+                  binary: z$1.ZodBoolean;
+                  origin: z$1.ZodEnum<{
+                    untracked: "untracked";
+                    tracked: "tracked";
+                  }>;
+                },
+                z$1.core.$strip
+              >
+            >;
+            shortstat: z$1.ZodString;
+            mergeBaseRef: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"unavailable">;
+            failure: z$1.ZodObject<
+              {
+                code: z$1.ZodEnum<{
+                  path_not_found: "path_not_found";
+                  not_git_repo: "not_git_repo";
+                  not_worktree: "not_worktree";
+                  workspace_type_mismatch: "workspace_type_mismatch";
+                  permission_denied: "permission_denied";
+                  unknown_environment: "unknown_environment";
+                  unknown: "unknown";
+                }>;
+                workspacePath: z$1.ZodString;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strict
+            >;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    true
+  >;
+  "workspace.diffPatch": HostDaemonCommandDescriptor<
+    "workspace.diffPatch",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.diffPatch">;
+        target: z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"uncommitted">;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"branch_committed">;
+                mergeBaseBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"all">;
+                mergeBaseBranch: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                type: z$1.ZodLiteral<"commit">;
+                sha: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >;
+        paths: z$1.ZodArray<z$1.ZodString>;
+        maxBytesPerFile: z$1.ZodNumber;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"available">;
+            patches: z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  path: z$1.ZodString;
+                  patch: z$1.ZodString;
+                  truncated: z$1.ZodBoolean;
+                },
+                z$1.core.$strict
+              >
+            >;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"unavailable">;
+            failure: z$1.ZodObject<
+              {
+                code: z$1.ZodEnum<{
+                  path_not_found: "path_not_found";
+                  not_git_repo: "not_git_repo";
+                  not_worktree: "not_worktree";
+                  workspace_type_mismatch: "workspace_type_mismatch";
+                  permission_denied: "permission_denied";
+                  unknown_environment: "unknown_environment";
+                  unknown: "unknown";
+                }>;
+                workspacePath: z$1.ZodString;
+                message: z$1.ZodString;
+              },
+              z$1.core.$strict
+            >;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    true
+  >;
+  "workspace.pull_request": HostDaemonCommandDescriptor<
+    "workspace.pull_request",
+    z$1.ZodObject<
+      {
+        environmentId: z$1.ZodString;
+        workspaceContext: z$1.ZodObject<
+          {
+            workspacePath: z$1.ZodString;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        type: z$1.ZodLiteral<"workspace.pull_request">;
+      },
+      z$1.core.$strict
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"available">;
+            pullRequest: z$1.ZodObject<
+              {
+                number: z$1.ZodNumber;
+                title: z$1.ZodString;
+                state: z$1.ZodEnum<{
+                  OPEN: "OPEN";
+                  CLOSED: "CLOSED";
+                  MERGED: "MERGED";
+                }>;
+                url: z$1.ZodString;
+                isDraft: z$1.ZodBoolean;
+                baseRefName: z$1.ZodString;
+                headRefName: z$1.ZodString;
+                updatedAt: z$1.ZodString;
+                checks: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      name: z$1.ZodString;
+                      status: z$1.ZodEnum<{
+                        unknown: "unknown";
+                        completed: "completed";
+                        queued: "queued";
+                        in_progress: "in_progress";
+                      }>;
+                      conclusion: z$1.ZodNullable<
+                        z$1.ZodEnum<{
+                          unknown: "unknown";
+                          success: "success";
+                          cancelled: "cancelled";
+                          failure: "failure";
+                          skipped: "skipped";
+                          neutral: "neutral";
+                          timed_out: "timed_out";
+                          action_required: "action_required";
+                          startup_failure: "startup_failure";
+                          stale: "stale";
+                        }>
+                      >;
+                      url: z$1.ZodNullable<z$1.ZodString>;
+                    },
+                    z$1.core.$strict
+                  >
+                >;
+                reviewDecision: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    APPROVED: "APPROVED";
+                    CHANGES_REQUESTED: "CHANGES_REQUESTED";
+                    REVIEW_REQUIRED: "REVIEW_REQUIRED";
+                  }>
+                >;
+                reviewRequestCount: z$1.ZodNumber;
+                mergeStateStatus: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    BEHIND: "BEHIND";
+                    BLOCKED: "BLOCKED";
+                    CLEAN: "CLEAN";
+                    DIRTY: "DIRTY";
+                    DRAFT: "DRAFT";
+                    HAS_HOOKS: "HAS_HOOKS";
+                    UNKNOWN: "UNKNOWN";
+                    UNSTABLE: "UNSTABLE";
+                  }>
+                >;
+                mergeable: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    UNKNOWN: "UNKNOWN";
+                    CONFLICTING: "CONFLICTING";
+                    MERGEABLE: "MERGEABLE";
+                  }>
+                >;
+              },
+              z$1.core.$strict
+            >;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"absent">;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            outcome: z$1.ZodLiteral<"unavailable">;
+            message: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "outcome"
+    >,
+    "onlineRpc",
+    true
+  >;
+};
+type HostDaemonCommandRegistry = typeof hostDaemonCommandRegistry;
+type AnyHostDaemonCommandDescriptor =
+  HostDaemonCommandRegistry[keyof HostDaemonCommandRegistry];
+type HostDaemonCommandDescriptorForTransport<
+  Transport extends HostDaemonCommandTransport,
+> = Extract<
+  AnyHostDaemonCommandDescriptor,
+  {
+    transport: Transport;
+  }
+>;
+type HostDaemonResultSchemaMapForTransport<
+  Transport extends HostDaemonCommandTransport,
+> = {
+  [Descriptor in HostDaemonCommandDescriptorForTransport<Transport> as Descriptor["type"]]: Descriptor["resultSchema"];
+};
+type HostDaemonOnlineRpcResultSchemaMap =
+  HostDaemonResultSchemaMapForTransport<"onlineRpc">;
+type HostDaemonOnlineRpcResultByType = {
+  [K in keyof HostDaemonOnlineRpcResultSchemaMap]: z$1.infer<
+    HostDaemonOnlineRpcResultSchemaMap[K]
+  >;
+};
+
+declare const pickFolderResponseSchema: z$1.ZodObject<
+  {
+    path: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type PickFolderResponse = z$1.infer<typeof pickFolderResponseSchema>;
+declare const pathsExistRequestSchema: z$1.ZodObject<
+  {
+    paths: z$1.ZodPipe<
+      z$1.ZodArray<z$1.ZodString>,
+      z$1.ZodTransform<string[], string[]>
+    >;
+  },
+  z$1.core.$strip
+>;
+type PathsExistRequest = z$1.infer<typeof pathsExistRequestSchema>;
+declare const pathsExistResponseSchema: z$1.ZodObject<
+  {
+    existence: z$1.ZodRecord<z$1.ZodString, z$1.ZodBoolean>;
+  },
+  z$1.core.$strip
+>;
+type PathsExistResponse = z$1.infer<typeof pathsExistResponseSchema>;
+declare const providerCliStatusResponseSchema: z$1.ZodRecord<
+  z$1.ZodEnum<{
+    codex: "codex";
+    claudeCode: "claudeCode";
+    cursor: "cursor";
+  }>,
+  z$1.ZodObject<
+    {
+      displayName: z$1.ZodString;
+      executableName: z$1.ZodString;
+      executablePath: z$1.ZodNullable<z$1.ZodString>;
+      installed: z$1.ZodBoolean;
+      installSource: z$1.ZodEnum<{
+        external: "external";
+        notInstalled: "notInstalled";
+        npmGlobal: "npmGlobal";
+      }>;
+      currentVersion: z$1.ZodNullable<z$1.ZodString>;
+      latestVersion: z$1.ZodNullable<z$1.ZodString>;
+      minimumSupportedVersion: z$1.ZodNullable<z$1.ZodString>;
+      npmPackageName: z$1.ZodNullable<z$1.ZodString>;
+      npmGlobalPackageVersion: z$1.ZodNullable<z$1.ZodString>;
+      installAction: z$1.ZodNullable<
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodEnum<{
+              install: "install";
+              update: "update";
+            }>;
+            label: z$1.ZodEnum<{
+              Install: "Install";
+              Update: "Update";
+            }>;
+            commandKind: z$1.ZodEnum<{
+              exec: "exec";
+              shell: "shell";
+            }>;
+            command: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >
+      >;
+      needsUpdate: z$1.ZodBoolean;
+      versionUnsupported: z$1.ZodBoolean;
+    },
+    z$1.core.$strip
+  >
+>;
+type ProviderCliStatusResponse = z$1.infer<
+  typeof providerCliStatusResponseSchema
+>;
+declare const providerCliInstallRequestSchema: z$1.ZodObject<
+  {
+    provider: z$1.ZodEnum<{
+      codex: "codex";
+      claudeCode: "claudeCode";
+      cursor: "cursor";
+    }>;
+    actionKind: z$1.ZodEnum<{
+      install: "install";
+      update: "update";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type ProviderCliInstallRequest = z$1.infer<
+  typeof providerCliInstallRequestSchema
+>;
+declare const providerCliInstallEventSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"started">;
+        provider: z$1.ZodEnum<{
+          codex: "codex";
+          claudeCode: "claudeCode";
+          cursor: "cursor";
+        }>;
+        command: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"output">;
+        provider: z$1.ZodEnum<{
+          codex: "codex";
+          claudeCode: "claudeCode";
+          cursor: "cursor";
+        }>;
+        stream: z$1.ZodEnum<{
+          stdout: "stdout";
+          stderr: "stderr";
+        }>;
+        text: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"completed">;
+        provider: z$1.ZodEnum<{
+          codex: "codex";
+          claudeCode: "claudeCode";
+          cursor: "cursor";
+        }>;
+        exitCode: z$1.ZodNullable<z$1.ZodNumber>;
+        signal: z$1.ZodNullable<z$1.ZodString>;
+        success: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        type: z$1.ZodLiteral<"error">;
+        provider: z$1.ZodEnum<{
+          codex: "codex";
+          claudeCode: "claudeCode";
+          cursor: "cursor";
+        }>;
+        message: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "type"
+>;
+type ProviderCliInstallEvent = z$1.infer<typeof providerCliInstallEventSchema>;
+
+interface CreateFilePreviewResponse {
+  baseUrl: string;
+  expiresAtMs: number;
+}
+type HostFileReadResponse = HostDaemonOnlineRpcResultByType["host.read_file"];
+type HostFileWriteResponse = HostDaemonOnlineRpcResultByType["host.write_file"];
+type HostFileListResponse = HostDaemonOnlineRpcResultByType["host.list_files"];
+type HostPathListResponse = HostDaemonOnlineRpcResultByType["host.list_paths"];
+type HostMkdirResponse = HostDaemonOnlineRpcResultByType["host.mkdir"];
+type HostMovePathResponse = HostDaemonOnlineRpcResultByType["host.move_path"];
+type HostRemovePathResponse =
+  HostDaemonOnlineRpcResultByType["host.remove_path"];
+
+/**
+ * Query for `GET /hosts/:id/directory`, the interactive path browser's
+ * single-level directory read. `path` is an absolute directory on the host;
+ * omitting it lists the host's home directory (the daemon resolves it, since a
+ * remote caller cannot know the host's home).
+ */
+declare const hostDirectoryQuerySchema: z$1.ZodObject<
+  {
+    path: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type HostDirectoryQuery = z$1.infer<typeof hostDirectoryQuerySchema>;
+declare const hostDirectoryListingSchema: z$1.ZodObject<
+  {
+    directory: z$1.ZodString;
+    parent: z$1.ZodNullable<z$1.ZodString>;
+    entries: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          kind: z$1.ZodEnum<{
+            file: "file";
+            directory: "directory";
+          }>;
+          name: z$1.ZodString;
+          path: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type HostDirectoryListing = z$1.infer<typeof hostDirectoryListingSchema>;
+/** Project name is sent so the daemon can derive its host-local checkout path. */
+declare const hostCloneDefaultPathQuerySchema: z$1.ZodObject<
+  {
+    projectId: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type HostCloneDefaultPathQuery = z$1.infer<
+  typeof hostCloneDefaultPathQuerySchema
+>;
+declare const hostCloneDefaultPathResponseSchema: z$1.ZodObject<
+  {
+    path: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type HostCloneDefaultPathResponse = z$1.infer<
+  typeof hostCloneDefaultPathResponseSchema
+>;
+declare const createHostJoinCodeResponseSchema: z$1.ZodObject<
+  {
+    joinCode: z$1.ZodString;
+    hostId: z$1.ZodString;
+    expiresAt: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type CreateHostJoinCodeResponse = z$1.infer<
+  typeof createHostJoinCodeResponseSchema
+>;
+declare const updateHostRequestSchema: z$1.ZodObject<
+  {
+    name: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type UpdateHostRequest = z$1.infer<typeof updateHostRequestSchema>;
+declare const hostRetryUpdateResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+  },
+  z$1.core.$strict
+>;
+type HostRetryUpdateResponse = z$1.infer<typeof hostRetryUpdateResponseSchema>;
+type HostPathsExistRequest = PathsExistRequest;
+type HostPathsExistResponse = PathsExistResponse;
+declare const hostPickFolderRequestSchema: z$1.ZodObject<
+  {
+    clientHostId: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type HostPickFolderRequest = z$1.infer<typeof hostPickFolderRequestSchema>;
+type HostPickFolderResponse = PickFolderResponse;
+type HostProviderCliStatusResponse = ProviderCliStatusResponse;
+type HostProviderCliInstallRequest = ProviderCliInstallRequest;
+type HostProviderCliInstallEvent = ProviderCliInstallEvent;
+
+declare const pluginUpdateCheckEntrySchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    outcome: z$1.ZodEnum<{
+      unavailable: "unavailable";
+      incompatible: "incompatible";
+      current: "current";
+      "update-available": "update-available";
+      pinned: "pinned";
+    }>;
+    devMode: z$1.ZodOptional<z$1.ZodLiteral<true>>;
+    installed: z$1.ZodObject<
+      {
+        version: z$1.ZodString;
+        display: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >;
+    candidate: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          version: z$1.ZodString;
+          display: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    blocked: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          version: z$1.ZodString;
+          reasons: z$1.ZodArray<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    detail: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type PluginUpdateCheckEntry = z$1.infer<typeof pluginUpdateCheckEntrySchema>;
+declare const pluginApplyUpdateResultSchema: z$1.ZodObject<
+  {
+    applied: z$1.ZodBoolean;
+    from: z$1.ZodObject<
+      {
+        version: z$1.ZodString;
+        display: z$1.ZodString;
+      },
+      z$1.core.$strip
+    >;
+    to: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          version: z$1.ZodString;
+          display: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    outcome: z$1.ZodEnum<{
+      current: "current";
+      updated: "updated";
+      "rolled-back": "rolled-back";
+    }>;
+    detail: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type PluginApplyUpdateResult$1 = z$1.infer<
+  typeof pluginApplyUpdateResultSchema
+>;
+declare const pluginSourceDetailSchema: z$1.ZodObject<
+  {
+    requested: z$1.ZodString;
+    resolved: z$1.ZodString;
+    integrity: z$1.ZodOptional<z$1.ZodString>;
+    registry: z$1.ZodOptional<z$1.ZodString>;
+    engines: z$1.ZodObject<
+      {
+        bb: z$1.ZodOptional<z$1.ZodString>;
+        bbPluginSdk: z$1.ZodOptional<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >;
+    installedAt: z$1.ZodOptional<z$1.ZodNumber>;
+    history: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          version: z$1.ZodString;
+          activatedAt: z$1.ZodNumber;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type PluginSourceDetail = z$1.infer<typeof pluginSourceDetailSchema>;
+declare const installedPluginSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    source: z$1.ZodString;
+    rootDir: z$1.ZodString;
+    version: z$1.ZodString;
+    provenance: z$1.ZodEnum<{
+      builtin: "builtin";
+      direct: "direct";
+      catalog: "catalog";
+    }>;
+    isOrphanedBuiltin: z$1.ZodBoolean;
+    catalogEntryId: z$1.ZodOptional<z$1.ZodString>;
+    sourceDisplay: z$1.ZodString;
+    updateState: z$1.ZodObject<
+      {
+        outcome: z$1.ZodOptional<
+          z$1.ZodEnum<{
+            unavailable: "unavailable";
+            incompatible: "incompatible";
+            current: "current";
+            "update-available": "update-available";
+            pinned: "pinned";
+          }>
+        >;
+        availableVersion: z$1.ZodOptional<z$1.ZodString>;
+        blockedVersion: z$1.ZodOptional<z$1.ZodString>;
+        blockedReasons: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+        lastCheckAt: z$1.ZodOptional<z$1.ZodNumber>;
+        lastFailure: z$1.ZodOptional<
+          z$1.ZodObject<
+            {
+              version: z$1.ZodString;
+              at: z$1.ZodNumber;
+              detail: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >;
+    enabled: z$1.ZodBoolean;
+    description: z$1.ZodNullable<z$1.ZodString>;
+    name: z$1.ZodNullable<z$1.ZodString>;
+    icon: z$1.ZodNullable<z$1.ZodString>;
+    iconUrl: z$1.ZodNullable<z$1.ZodString>;
+    status: z$1.ZodEnum<{
+      error: "error";
+      running: "running";
+      missing: "missing";
+      incompatible: "incompatible";
+      disabled: "disabled";
+      degraded: "degraded";
+      "needs-configuration": "needs-configuration";
+    }>;
+    statusDetail: z$1.ZodNullable<z$1.ZodString>;
+    handlerStats: z$1.ZodObject<
+      {
+        count: z$1.ZodNumber;
+        totalMs: z$1.ZodNumber;
+        maxMs: z$1.ZodNumber;
+        errorCount: z$1.ZodNumber;
+      },
+      z$1.core.$strip
+    >;
+    services: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          name: z$1.ZodString;
+          state: z$1.ZodEnum<{
+            running: "running";
+            stopped: "stopped";
+            backoff: "backoff";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    schedules: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          name: z$1.ZodString;
+          cron: z$1.ZodString;
+          nextRunAt: z$1.ZodNumber;
+          lastRunAt: z$1.ZodNullable<z$1.ZodNumber>;
+          lastStatus: z$1.ZodNullable<
+            z$1.ZodEnum<{
+              error: "error";
+              running: "running";
+              ok: "ok";
+            }>
+          >;
+          lastError: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    cliCommand: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          name: z$1.ZodString;
+          summary: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    capabilities: z$1.ZodDefault<
+      z$1.ZodArray<
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodEnum<{
+              skill: "skill";
+              theme: "theme";
+              "agent-tool": "agent-tool";
+              "thread-integration": "thread-integration";
+            }>;
+            id: z$1.ZodString;
+            label: z$1.ZodString;
+            detail: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >
+      >
+    >;
+    hasSettings: z$1.ZodBoolean;
+    app: z$1.ZodObject<
+      {
+        hasApp: z$1.ZodBoolean;
+        bundle: z$1.ZodNullable<
+          z$1.ZodObject<
+            {
+              jsUrl: z$1.ZodString;
+              cssUrl: z$1.ZodNullable<z$1.ZodString>;
+              hash: z$1.ZodString;
+              sdkMajor: z$1.ZodNumber;
+              sdkVersion: z$1.ZodString;
+              compatible: z$1.ZodBoolean;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >;
+    logoUrl: z$1.ZodNullable<z$1.ZodString>;
+    logoDarkUrl: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type InstalledPlugin = z$1.infer<typeof installedPluginSchema>;
+declare const pluginListResponseSchema: z$1.ZodObject<
+  {
+    plugins: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          source: z$1.ZodString;
+          rootDir: z$1.ZodString;
+          version: z$1.ZodString;
+          provenance: z$1.ZodEnum<{
+            builtin: "builtin";
+            direct: "direct";
+            catalog: "catalog";
+          }>;
+          isOrphanedBuiltin: z$1.ZodBoolean;
+          catalogEntryId: z$1.ZodOptional<z$1.ZodString>;
+          sourceDisplay: z$1.ZodString;
+          updateState: z$1.ZodObject<
+            {
+              outcome: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  unavailable: "unavailable";
+                  incompatible: "incompatible";
+                  current: "current";
+                  "update-available": "update-available";
+                  pinned: "pinned";
+                }>
+              >;
+              availableVersion: z$1.ZodOptional<z$1.ZodString>;
+              blockedVersion: z$1.ZodOptional<z$1.ZodString>;
+              blockedReasons: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+              lastCheckAt: z$1.ZodOptional<z$1.ZodNumber>;
+              lastFailure: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    version: z$1.ZodString;
+                    at: z$1.ZodNumber;
+                    detail: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+            },
+            z$1.core.$strip
+          >;
+          enabled: z$1.ZodBoolean;
+          description: z$1.ZodNullable<z$1.ZodString>;
+          name: z$1.ZodNullable<z$1.ZodString>;
+          icon: z$1.ZodNullable<z$1.ZodString>;
+          iconUrl: z$1.ZodNullable<z$1.ZodString>;
+          status: z$1.ZodEnum<{
+            error: "error";
+            running: "running";
+            missing: "missing";
+            incompatible: "incompatible";
+            disabled: "disabled";
+            degraded: "degraded";
+            "needs-configuration": "needs-configuration";
+          }>;
+          statusDetail: z$1.ZodNullable<z$1.ZodString>;
+          handlerStats: z$1.ZodObject<
+            {
+              count: z$1.ZodNumber;
+              totalMs: z$1.ZodNumber;
+              maxMs: z$1.ZodNumber;
+              errorCount: z$1.ZodNumber;
+            },
+            z$1.core.$strip
+          >;
+          services: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                name: z$1.ZodString;
+                state: z$1.ZodEnum<{
+                  running: "running";
+                  stopped: "stopped";
+                  backoff: "backoff";
+                }>;
+              },
+              z$1.core.$strip
+            >
+          >;
+          schedules: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                name: z$1.ZodString;
+                cron: z$1.ZodString;
+                nextRunAt: z$1.ZodNumber;
+                lastRunAt: z$1.ZodNullable<z$1.ZodNumber>;
+                lastStatus: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    error: "error";
+                    running: "running";
+                    ok: "ok";
+                  }>
+                >;
+                lastError: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >
+          >;
+          cliCommand: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                name: z$1.ZodString;
+                summary: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >
+          >;
+          capabilities: z$1.ZodDefault<
+            z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  kind: z$1.ZodEnum<{
+                    skill: "skill";
+                    theme: "theme";
+                    "agent-tool": "agent-tool";
+                    "thread-integration": "thread-integration";
+                  }>;
+                  id: z$1.ZodString;
+                  label: z$1.ZodString;
+                  detail: z$1.ZodNullable<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >
+            >
+          >;
+          hasSettings: z$1.ZodBoolean;
+          app: z$1.ZodObject<
+            {
+              hasApp: z$1.ZodBoolean;
+              bundle: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    jsUrl: z$1.ZodString;
+                    cssUrl: z$1.ZodNullable<z$1.ZodString>;
+                    hash: z$1.ZodString;
+                    sdkMajor: z$1.ZodNumber;
+                    sdkVersion: z$1.ZodString;
+                    compatible: z$1.ZodBoolean;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+            },
+            z$1.core.$strip
+          >;
+          logoUrl: z$1.ZodNullable<z$1.ZodString>;
+          logoDarkUrl: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type PluginListResponse = z$1.infer<typeof pluginListResponseSchema>;
+declare const pluginReloadResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    plugins: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          source: z$1.ZodString;
+          rootDir: z$1.ZodString;
+          version: z$1.ZodString;
+          provenance: z$1.ZodEnum<{
+            builtin: "builtin";
+            direct: "direct";
+            catalog: "catalog";
+          }>;
+          isOrphanedBuiltin: z$1.ZodBoolean;
+          catalogEntryId: z$1.ZodOptional<z$1.ZodString>;
+          sourceDisplay: z$1.ZodString;
+          updateState: z$1.ZodObject<
+            {
+              outcome: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  unavailable: "unavailable";
+                  incompatible: "incompatible";
+                  current: "current";
+                  "update-available": "update-available";
+                  pinned: "pinned";
+                }>
+              >;
+              availableVersion: z$1.ZodOptional<z$1.ZodString>;
+              blockedVersion: z$1.ZodOptional<z$1.ZodString>;
+              blockedReasons: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+              lastCheckAt: z$1.ZodOptional<z$1.ZodNumber>;
+              lastFailure: z$1.ZodOptional<
+                z$1.ZodObject<
+                  {
+                    version: z$1.ZodString;
+                    at: z$1.ZodNumber;
+                    detail: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+            },
+            z$1.core.$strip
+          >;
+          enabled: z$1.ZodBoolean;
+          description: z$1.ZodNullable<z$1.ZodString>;
+          name: z$1.ZodNullable<z$1.ZodString>;
+          icon: z$1.ZodNullable<z$1.ZodString>;
+          iconUrl: z$1.ZodNullable<z$1.ZodString>;
+          status: z$1.ZodEnum<{
+            error: "error";
+            running: "running";
+            missing: "missing";
+            incompatible: "incompatible";
+            disabled: "disabled";
+            degraded: "degraded";
+            "needs-configuration": "needs-configuration";
+          }>;
+          statusDetail: z$1.ZodNullable<z$1.ZodString>;
+          handlerStats: z$1.ZodObject<
+            {
+              count: z$1.ZodNumber;
+              totalMs: z$1.ZodNumber;
+              maxMs: z$1.ZodNumber;
+              errorCount: z$1.ZodNumber;
+            },
+            z$1.core.$strip
+          >;
+          services: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                name: z$1.ZodString;
+                state: z$1.ZodEnum<{
+                  running: "running";
+                  stopped: "stopped";
+                  backoff: "backoff";
+                }>;
+              },
+              z$1.core.$strip
+            >
+          >;
+          schedules: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                name: z$1.ZodString;
+                cron: z$1.ZodString;
+                nextRunAt: z$1.ZodNumber;
+                lastRunAt: z$1.ZodNullable<z$1.ZodNumber>;
+                lastStatus: z$1.ZodNullable<
+                  z$1.ZodEnum<{
+                    error: "error";
+                    running: "running";
+                    ok: "ok";
+                  }>
+                >;
+                lastError: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >
+          >;
+          cliCommand: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                name: z$1.ZodString;
+                summary: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >
+          >;
+          capabilities: z$1.ZodDefault<
+            z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  kind: z$1.ZodEnum<{
+                    skill: "skill";
+                    theme: "theme";
+                    "agent-tool": "agent-tool";
+                    "thread-integration": "thread-integration";
+                  }>;
+                  id: z$1.ZodString;
+                  label: z$1.ZodString;
+                  detail: z$1.ZodNullable<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >
+            >
+          >;
+          hasSettings: z$1.ZodBoolean;
+          app: z$1.ZodObject<
+            {
+              hasApp: z$1.ZodBoolean;
+              bundle: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    jsUrl: z$1.ZodString;
+                    cssUrl: z$1.ZodNullable<z$1.ZodString>;
+                    hash: z$1.ZodString;
+                    sdkMajor: z$1.ZodNumber;
+                    sdkVersion: z$1.ZodString;
+                    compatible: z$1.ZodBoolean;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+            },
+            z$1.core.$strip
+          >;
+          logoUrl: z$1.ZodNullable<z$1.ZodString>;
+          logoDarkUrl: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type PluginReloadResponse = z$1.infer<typeof pluginReloadResponseSchema>;
+declare const pluginRemoveResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+  },
+  z$1.core.$strip
+>;
+type PluginRemoveResponse = z$1.infer<typeof pluginRemoveResponseSchema>;
+declare const pluginSettingsResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    schema: z$1.ZodRecord<
+      z$1.ZodString,
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"string">;
+              secret: z$1.ZodOptional<z$1.ZodLiteral<true>>;
+              default: z$1.ZodOptional<z$1.ZodString>;
+              label: z$1.ZodString;
+              description: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"boolean">;
+              default: z$1.ZodOptional<z$1.ZodBoolean>;
+              label: z$1.ZodString;
+              description: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"select">;
+              options: z$1.ZodArray<z$1.ZodString>;
+              default: z$1.ZodOptional<z$1.ZodString>;
+              label: z$1.ZodString;
+              description: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"project">;
+              default: z$1.ZodOptional<z$1.ZodString>;
+              label: z$1.ZodString;
+              description: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+        ],
+        "type"
+      >
+    >;
+    values: z$1.ZodRecord<
+      z$1.ZodString,
+      z$1.ZodType<
+        JsonValue$1,
+        unknown,
+        z$1.core.$ZodTypeInternals<JsonValue$1, unknown>
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type PluginSettingsResponse = z$1.infer<typeof pluginSettingsResponseSchema>;
+declare const pluginTokenResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    token: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type PluginTokenResponse = z$1.infer<typeof pluginTokenResponseSchema>;
+declare const pluginCatalogStatusSchema: z$1.ZodObject<
+  {
+    pluginCount: z$1.ZodNumber;
+    includedPluginCount: z$1.ZodNumber;
+    optionalPluginCount: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type PluginCatalogStatus = z$1.infer<typeof pluginCatalogStatusSchema>;
+declare const pluginCatalogSearchResultSchema: z$1.ZodObject<
+  {
+    entryId: z$1.ZodString;
+    pluginId: z$1.ZodString;
+    displayName: z$1.ZodString;
+    description: z$1.ZodString;
+    icon: z$1.ZodNullable<z$1.ZodString>;
+    category: z$1.ZodString;
+    source: z$1.ZodString;
+    installed: z$1.ZodBoolean;
+    compatible: z$1.ZodBoolean;
+    incompatibleReason: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type PluginCatalogSearchResult$1 = z$1.infer<
+  typeof pluginCatalogSearchResultSchema
+>;
+
+declare const systemExecutionOptionsResponseSchema: z$1.ZodObject<
+  {
+    providers: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          displayName: z$1.ZodString;
+          logoUrl: z$1.ZodNullable<z$1.ZodString>;
+          capabilities: z$1.ZodObject<
+            {
+              supportsArchive: z$1.ZodBoolean;
+              supportsRename: z$1.ZodBoolean;
+              supportsServiceTier: z$1.ZodBoolean;
+              supportsUserQuestion: z$1.ZodBoolean;
+              supportsFork: z$1.ZodBoolean;
+              supportedPermissionModes: z$1.ZodArray<
+                z$1.ZodEnum<{
+                  auto: "auto";
+                  "accept-edits": "accept-edits";
+                  full: "full";
+                }>
+              >;
+            },
+            z$1.core.$strip
+          >;
+          composerActions: z$1.ZodArray<
+            z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"skills">;
+                    trigger: z$1.ZodEnum<{
+                      "/": "/";
+                    }>;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"plan">;
+                    command: z$1.ZodObject<
+                      {
+                        trigger: z$1.ZodEnum<{
+                          "/": "/";
+                        }>;
+                        name: z$1.ZodString;
+                        trailingText: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"goal">;
+                    command: z$1.ZodObject<
+                      {
+                        trigger: z$1.ZodEnum<{
+                          "/": "/";
+                        }>;
+                        name: z$1.ZodString;
+                        trailingText: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "kind"
+            >
+          >;
+          available: z$1.ZodBoolean;
+        },
+        z$1.core.$strip
+      >
+    >;
+    permissionCeiling: z$1.ZodEnum<{
+      auto: "auto";
+      "accept-edits": "accept-edits";
+      full: "full";
+    }>;
+    models: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          model: z$1.ZodString;
+          displayName: z$1.ZodString;
+          description: z$1.ZodString;
+          supportedReasoningEfforts: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                reasoningEffort: z$1.ZodEnum<{
+                  none: "none";
+                  low: "low";
+                  medium: "medium";
+                  high: "high";
+                  xhigh: "xhigh";
+                  ultracode: "ultracode";
+                  max: "max";
+                  ultra: "ultra";
+                }>;
+                description: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >
+          >;
+          defaultReasoningEffort: z$1.ZodEnum<{
+            none: "none";
+            low: "low";
+            medium: "medium";
+            high: "high";
+            xhigh: "xhigh";
+            ultracode: "ultracode";
+            max: "max";
+            ultra: "ultra";
+          }>;
+          isDefault: z$1.ZodBoolean;
+        },
+        z$1.core.$strip
+      >
+    >;
+    selectedOnlyModels: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          model: z$1.ZodString;
+          displayName: z$1.ZodString;
+          description: z$1.ZodString;
+          supportedReasoningEfforts: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                reasoningEffort: z$1.ZodEnum<{
+                  none: "none";
+                  low: "low";
+                  medium: "medium";
+                  high: "high";
+                  xhigh: "xhigh";
+                  ultracode: "ultracode";
+                  max: "max";
+                  ultra: "ultra";
+                }>;
+                description: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >
+          >;
+          defaultReasoningEffort: z$1.ZodEnum<{
+            none: "none";
+            low: "low";
+            medium: "medium";
+            high: "high";
+            xhigh: "xhigh";
+            ultracode: "ultracode";
+            max: "max";
+            ultra: "ultra";
+          }>;
+          isDefault: z$1.ZodBoolean;
+        },
+        z$1.core.$strip
+      >
+    >;
+    modelLoadError: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          providerId: z$1.ZodString;
+          code: z$1.ZodEnum<{
+            failed: "failed";
+            missing_executable: "missing_executable";
+            auth_required: "auth_required";
+            timeout: "timeout";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type SystemExecutionOptionsResponse = z$1.infer<
+  typeof systemExecutionOptionsResponseSchema
+>;
+declare const systemExecutionOptionsQuerySchema: z$1.ZodObject<
+  {
+    providerId: z$1.ZodOptional<z$1.ZodString>;
+    hostId: z$1.ZodOptional<z$1.ZodString>;
+    environmentId: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type SystemExecutionOptionsQuery = z$1.infer<
+  typeof systemExecutionOptionsQuerySchema
+>;
+/** Omission preserves the existing behavior of reading the primary machine. */
+declare const systemUsageLimitsQuerySchema: z$1.ZodObject<
+  {
+    hostId: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type SystemUsageLimitsQuery = z$1.infer<typeof systemUsageLimitsQuerySchema>;
+declare const systemVoiceTranscriptionResponseSchema: z$1.ZodObject<
+  {
+    text: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type SystemVoiceTranscriptionResponse = z$1.infer<
+  typeof systemVoiceTranscriptionResponseSchema
+>;
+declare const systemConfigResponseSchema: z$1.ZodObject<
+  {
+    generalSettings: z$1.ZodObject<
+      {
+        caffeinate: z$1.ZodBoolean;
+        showKeyboardHints: z$1.ZodBoolean;
+        steerActiveThreadOnEnter: z$1.ZodBoolean;
+        showUnhandledProviderEvents: z$1.ZodBoolean;
+        codexMemoryEnabled: z$1.ZodBoolean;
+        claudeCodeMemoryEnabled: z$1.ZodBoolean;
+        codexSubagentsDisabled: z$1.ZodBoolean;
+        claudeCodeSubagentsDisabled: z$1.ZodBoolean;
+        claudeCodeWorkflowsDisabled: z$1.ZodBoolean;
+      },
+      z$1.core.$strict
+    >;
+    keybindings: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          command: z$1.ZodEnum<{
+            "thread.new": "thread.new";
+            "thread.search": "thread.search";
+            "thread.previous": "thread.previous";
+            "thread.next": "thread.next";
+            "thread.jump.1": "thread.jump.1";
+            "thread.jump.2": "thread.jump.2";
+            "thread.jump.3": "thread.jump.3";
+            "thread.jump.4": "thread.jump.4";
+            "thread.jump.5": "thread.jump.5";
+            "thread.jump.6": "thread.jump.6";
+            "thread.jump.7": "thread.jump.7";
+            "thread.jump.8": "thread.jump.8";
+            "thread.jump.9": "thread.jump.9";
+            "pane.focus.previous": "pane.focus.previous";
+            "pane.focus.next": "pane.focus.next";
+            "pane.focus.1": "pane.focus.1";
+            "pane.focus.2": "pane.focus.2";
+            "pane.focus.3": "pane.focus.3";
+            "pane.focus.4": "pane.focus.4";
+            "pane.focus.5": "pane.focus.5";
+            "pane.focus.6": "pane.focus.6";
+            "pane.focus.7": "pane.focus.7";
+            "pane.focus.8": "pane.focus.8";
+            "pane.maximize.toggle": "pane.maximize.toggle";
+            "pane.close": "pane.close";
+            "window.new": "window.new";
+            "settings.open": "settings.open";
+            "settings.openServers": "settings.openServers";
+            "sidebar.toggle": "sidebar.toggle";
+            "panel.newTab": "panel.newTab";
+            "panel.close": "panel.close";
+            "panel.toggle": "panel.toggle";
+            "file.quickOpen": "file.quickOpen";
+            "diff.toggle": "diff.toggle";
+            "terminal.open": "terminal.open";
+            "composer.focus": "composer.focus";
+            "modelPicker.toggle": "modelPicker.toggle";
+            "browser.focusLocation": "browser.focusLocation";
+            "browser.reload": "browser.reload";
+            "workspace.openPreferred": "workspace.openPreferred";
+            "question.select.1": "question.select.1";
+            "question.select.2": "question.select.2";
+            "question.select.3": "question.select.3";
+            "question.select.4": "question.select.4";
+            "question.select.5": "question.select.5";
+            "question.select.6": "question.select.6";
+            "question.select.7": "question.select.7";
+            "question.select.8": "question.select.8";
+            "question.select.9": "question.select.9";
+          }>;
+          desktopOnly: z$1.ZodBoolean;
+          shortcut: z$1.ZodObject<
+            {
+              key: z$1.ZodString;
+              mod: z$1.ZodBoolean;
+              meta: z$1.ZodBoolean;
+              control: z$1.ZodBoolean;
+              alt: z$1.ZodBoolean;
+              shift: z$1.ZodBoolean;
+            },
+            z$1.core.$strict
+          >;
+          when: z$1.ZodObject<
+            {
+              all: z$1.ZodArray<
+                z$1.ZodEnum<{
+                  mainSurface: "mainSurface";
+                  modalOpen: "modalOpen";
+                  editableFocus: "editableFocus";
+                  terminalFocus: "terminalFocus";
+                  browserFocus: "browserFocus";
+                  modelPickerOpen: "modelPickerOpen";
+                  questionOpen: "questionOpen";
+                  promptAvailable: "promptAvailable";
+                  splitActive: "splitActive";
+                  webSurface: "webSurface";
+                  macPlatform: "macPlatform";
+                }>
+              >;
+              none: z$1.ZodArray<
+                z$1.ZodEnum<{
+                  mainSurface: "mainSurface";
+                  modalOpen: "modalOpen";
+                  editableFocus: "editableFocus";
+                  terminalFocus: "terminalFocus";
+                  browserFocus: "browserFocus";
+                  modelPickerOpen: "modelPickerOpen";
+                  questionOpen: "questionOpen";
+                  promptAvailable: "promptAvailable";
+                  splitActive: "splitActive";
+                  webSurface: "webSurface";
+                  macPlatform: "macPlatform";
+                }>
+              >;
+            },
+            z$1.core.$strict
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    defaultKeybindings: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          command: z$1.ZodEnum<{
+            "thread.new": "thread.new";
+            "thread.search": "thread.search";
+            "thread.previous": "thread.previous";
+            "thread.next": "thread.next";
+            "thread.jump.1": "thread.jump.1";
+            "thread.jump.2": "thread.jump.2";
+            "thread.jump.3": "thread.jump.3";
+            "thread.jump.4": "thread.jump.4";
+            "thread.jump.5": "thread.jump.5";
+            "thread.jump.6": "thread.jump.6";
+            "thread.jump.7": "thread.jump.7";
+            "thread.jump.8": "thread.jump.8";
+            "thread.jump.9": "thread.jump.9";
+            "pane.focus.previous": "pane.focus.previous";
+            "pane.focus.next": "pane.focus.next";
+            "pane.focus.1": "pane.focus.1";
+            "pane.focus.2": "pane.focus.2";
+            "pane.focus.3": "pane.focus.3";
+            "pane.focus.4": "pane.focus.4";
+            "pane.focus.5": "pane.focus.5";
+            "pane.focus.6": "pane.focus.6";
+            "pane.focus.7": "pane.focus.7";
+            "pane.focus.8": "pane.focus.8";
+            "pane.maximize.toggle": "pane.maximize.toggle";
+            "pane.close": "pane.close";
+            "window.new": "window.new";
+            "settings.open": "settings.open";
+            "settings.openServers": "settings.openServers";
+            "sidebar.toggle": "sidebar.toggle";
+            "panel.newTab": "panel.newTab";
+            "panel.close": "panel.close";
+            "panel.toggle": "panel.toggle";
+            "file.quickOpen": "file.quickOpen";
+            "diff.toggle": "diff.toggle";
+            "terminal.open": "terminal.open";
+            "composer.focus": "composer.focus";
+            "modelPicker.toggle": "modelPicker.toggle";
+            "browser.focusLocation": "browser.focusLocation";
+            "browser.reload": "browser.reload";
+            "workspace.openPreferred": "workspace.openPreferred";
+            "question.select.1": "question.select.1";
+            "question.select.2": "question.select.2";
+            "question.select.3": "question.select.3";
+            "question.select.4": "question.select.4";
+            "question.select.5": "question.select.5";
+            "question.select.6": "question.select.6";
+            "question.select.7": "question.select.7";
+            "question.select.8": "question.select.8";
+            "question.select.9": "question.select.9";
+          }>;
+          desktopOnly: z$1.ZodBoolean;
+          shortcut: z$1.ZodObject<
+            {
+              key: z$1.ZodString;
+              mod: z$1.ZodBoolean;
+              meta: z$1.ZodBoolean;
+              control: z$1.ZodBoolean;
+              alt: z$1.ZodBoolean;
+              shift: z$1.ZodBoolean;
+            },
+            z$1.core.$strict
+          >;
+          when: z$1.ZodObject<
+            {
+              all: z$1.ZodArray<
+                z$1.ZodEnum<{
+                  mainSurface: "mainSurface";
+                  modalOpen: "modalOpen";
+                  editableFocus: "editableFocus";
+                  terminalFocus: "terminalFocus";
+                  browserFocus: "browserFocus";
+                  modelPickerOpen: "modelPickerOpen";
+                  questionOpen: "questionOpen";
+                  promptAvailable: "promptAvailable";
+                  splitActive: "splitActive";
+                  webSurface: "webSurface";
+                  macPlatform: "macPlatform";
+                }>
+              >;
+              none: z$1.ZodArray<
+                z$1.ZodEnum<{
+                  mainSurface: "mainSurface";
+                  modalOpen: "modalOpen";
+                  editableFocus: "editableFocus";
+                  terminalFocus: "terminalFocus";
+                  browserFocus: "browserFocus";
+                  modelPickerOpen: "modelPickerOpen";
+                  questionOpen: "questionOpen";
+                  promptAvailable: "promptAvailable";
+                  splitActive: "splitActive";
+                  webSurface: "webSurface";
+                  macPlatform: "macPlatform";
+                }>
+              >;
+            },
+            z$1.core.$strict
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    keybindingOverrides: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          command: z$1.ZodEnum<{
+            "thread.new": "thread.new";
+            "thread.search": "thread.search";
+            "thread.previous": "thread.previous";
+            "thread.next": "thread.next";
+            "thread.jump.1": "thread.jump.1";
+            "thread.jump.2": "thread.jump.2";
+            "thread.jump.3": "thread.jump.3";
+            "thread.jump.4": "thread.jump.4";
+            "thread.jump.5": "thread.jump.5";
+            "thread.jump.6": "thread.jump.6";
+            "thread.jump.7": "thread.jump.7";
+            "thread.jump.8": "thread.jump.8";
+            "thread.jump.9": "thread.jump.9";
+            "pane.focus.previous": "pane.focus.previous";
+            "pane.focus.next": "pane.focus.next";
+            "pane.focus.1": "pane.focus.1";
+            "pane.focus.2": "pane.focus.2";
+            "pane.focus.3": "pane.focus.3";
+            "pane.focus.4": "pane.focus.4";
+            "pane.focus.5": "pane.focus.5";
+            "pane.focus.6": "pane.focus.6";
+            "pane.focus.7": "pane.focus.7";
+            "pane.focus.8": "pane.focus.8";
+            "pane.maximize.toggle": "pane.maximize.toggle";
+            "pane.close": "pane.close";
+            "window.new": "window.new";
+            "settings.open": "settings.open";
+            "settings.openServers": "settings.openServers";
+            "sidebar.toggle": "sidebar.toggle";
+            "panel.newTab": "panel.newTab";
+            "panel.close": "panel.close";
+            "panel.toggle": "panel.toggle";
+            "file.quickOpen": "file.quickOpen";
+            "diff.toggle": "diff.toggle";
+            "terminal.open": "terminal.open";
+            "composer.focus": "composer.focus";
+            "modelPicker.toggle": "modelPicker.toggle";
+            "browser.focusLocation": "browser.focusLocation";
+            "browser.reload": "browser.reload";
+            "workspace.openPreferred": "workspace.openPreferred";
+            "question.select.1": "question.select.1";
+            "question.select.2": "question.select.2";
+            "question.select.3": "question.select.3";
+            "question.select.4": "question.select.4";
+            "question.select.5": "question.select.5";
+            "question.select.6": "question.select.6";
+            "question.select.7": "question.select.7";
+            "question.select.8": "question.select.8";
+            "question.select.9": "question.select.9";
+          }>;
+          shortcut: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                key: z$1.ZodString;
+                mod: z$1.ZodBoolean;
+                meta: z$1.ZodBoolean;
+                control: z$1.ZodBoolean;
+                alt: z$1.ZodBoolean;
+                shift: z$1.ZodBoolean;
+              },
+              z$1.core.$strict
+            >
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    experiments: z$1.ZodObject<
+      {
+        claudeCodeMockCliTraffic: z$1.ZodBoolean;
+        toolsHub: z$1.ZodBoolean;
+      },
+      z$1.core.$strip
+    >;
+    appearance: z$1.ZodObject<
+      {
+        themeId: z$1.ZodString;
+        customCss: z$1.ZodNullable<z$1.ZodString>;
+        faviconColor: z$1.ZodEnum<{
+          default: "default";
+          red: "red";
+          orange: "orange";
+          yellow: "yellow";
+          green: "green";
+          teal: "teal";
+          blue: "blue";
+          purple: "purple";
+          pink: "pink";
+        }>;
+      },
+      z$1.core.$strip
+    >;
+    customThemes: z$1.ZodArray<z$1.ZodString>;
+    pluginThemes: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          pluginId: z$1.ZodString;
+          name: z$1.ZodString;
+          description: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    featureFlags: z$1.ZodObject<
+      {
+        placeholder: z$1.ZodBoolean;
+        timelineWindowEventBudget: z$1.ZodNumber;
+      },
+      z$1.core.$strip
+    >;
+    hostDaemonPort: z$1.ZodNullable<z$1.ZodNumber>;
+    primaryHostId: z$1.ZodNullable<z$1.ZodString>;
+    primaryHostPlatform: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        unknown: "unknown";
+        darwin: "darwin";
+        linux: "linux";
+        wsl: "wsl";
+      }>
+    >;
+    voiceTranscriptionEnabled: z$1.ZodBoolean;
+    dataDir: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type SystemConfigResponse = z$1.infer<typeof systemConfigResponseSchema>;
+declare const systemAttentionResponseSchema: z$1.ZodObject<
+  {
+    hasAttention: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type SystemAttentionResponse = z$1.infer<typeof systemAttentionResponseSchema>;
+/**
+ * Theme catalog: the on-disk custom-theme directory plus the discovered custom
+ * themes and the active palette. Drives `bb theme list` / `bb theme dir`.
+ */
+declare const themeCatalogResponseSchema: z$1.ZodObject<
+  {
+    dir: z$1.ZodString;
+    custom: z$1.ZodArray<z$1.ZodString>;
+    plugins: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          pluginId: z$1.ZodString;
+          name: z$1.ZodString;
+          description: z$1.ZodNullable<z$1.ZodString>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    active: z$1.ZodObject<
+      {
+        themeId: z$1.ZodString;
+        customCss: z$1.ZodNullable<z$1.ZodString>;
+        faviconColor: z$1.ZodEnum<{
+          default: "default";
+          red: "red";
+          orange: "orange";
+          yellow: "yellow";
+          green: "green";
+          teal: "teal";
+          blue: "blue";
+          purple: "purple";
+          pink: "pink";
+        }>;
+      },
+      z$1.core.$strip
+    >;
+  },
+  z$1.core.$strip
+>;
+type ThemeCatalogResponse = z$1.infer<typeof themeCatalogResponseSchema>;
+declare const systemVersionResponseSchema: z$1.ZodObject<
+  {
+    currentVersion: z$1.ZodString;
+    latestVersion: z$1.ZodNullable<z$1.ZodString>;
+    source: z$1.ZodLiteral<"npm">;
+    updateAvailable: z$1.ZodBoolean;
+    isDevelopment: z$1.ZodBoolean;
+    upgradeCommand: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type SystemVersionResponse = z$1.infer<typeof systemVersionResponseSchema>;
+declare const systemConfigReloadResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+  },
+  z$1.core.$strip
+>;
+declare const systemCliSkillsStatusResponseSchema: z$1.ZodObject<
+  {
+    machines: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          hostId: z$1.ZodString;
+          hostName: z$1.ZodString;
+          status: z$1.ZodEnum<{
+            unknown: "unknown";
+            missing: "missing";
+            installed: "installed";
+            outdated: "outdated";
+          }>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type SystemCliSkillsStatusResponse = z$1.infer<
+  typeof systemCliSkillsStatusResponseSchema
+>;
+/** The machines to copy the built-in bb CLI skills onto. */
+declare const systemInstallCliSkillsRequestSchema: z$1.ZodObject<
+  {
+    hostIds: z$1.ZodArray<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type SystemInstallCliSkillsRequest = z$1.infer<
+  typeof systemInstallCliSkillsRequestSchema
+>;
+/**
+ * One entry per requested machine. A machine that is offline or otherwise
+ * refuses the install fails on its own without taking the others down, so the
+ * caller can report exactly which machines got the skills.
+ */
+declare const systemInstallCliSkillsResponseSchema: z$1.ZodObject<
+  {
+    results: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              ok: z$1.ZodLiteral<true>;
+              hostId: z$1.ZodString;
+              hostName: z$1.ZodString;
+              installations: z$1.ZodArray<
+                z$1.ZodObject<
+                  {
+                    name: z$1.ZodString;
+                    path: z$1.ZodString;
+                  },
+                  z$1.core.$strip
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              ok: z$1.ZodLiteral<false>;
+              hostId: z$1.ZodString;
+              hostName: z$1.ZodString;
+              errorMessage: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "ok"
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type SystemInstallCliSkillsResponse = z$1.infer<
+  typeof systemInstallCliSkillsResponseSchema
+>;
+type SystemConfigReloadResponse = z$1.infer<
+  typeof systemConfigReloadResponseSchema
+>;
+
+declare const terminalSessionSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodNullable<z$1.ZodString>;
+    environmentId: z$1.ZodNullable<z$1.ZodString>;
+    hostId: z$1.ZodString;
+    title: z$1.ZodString;
+    initialCwd: z$1.ZodString;
+    cols: z$1.ZodNumber;
+    rows: z$1.ZodNumber;
+    status: z$1.ZodEnum<{
+      starting: "starting";
+      disconnected: "disconnected";
+      running: "running";
+      exited: "exited";
+    }>;
+    exitCode: z$1.ZodNullable<z$1.ZodNumber>;
+    closeReason: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        user: "user";
+        "thread-deleted": "thread-deleted";
+        "process-exit": "process-exit";
+        "daemon-disconnect": "daemon-disconnect";
+        "environment-destroyed": "environment-destroyed";
+        "thread-archived": "thread-archived";
+        "open-timeout": "open-timeout";
+      }>
+    >;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    lastUserInputAt: z$1.ZodNullable<z$1.ZodNumber>;
+  },
+  z$1.core.$strip
+>;
+type TerminalSession = z$1.infer<typeof terminalSessionSchema>;
+declare const terminalListResponseSchema: z$1.ZodObject<
+  {
+    sessions: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          threadId: z$1.ZodNullable<z$1.ZodString>;
+          environmentId: z$1.ZodNullable<z$1.ZodString>;
+          hostId: z$1.ZodString;
+          title: z$1.ZodString;
+          initialCwd: z$1.ZodString;
+          cols: z$1.ZodNumber;
+          rows: z$1.ZodNumber;
+          status: z$1.ZodEnum<{
+            starting: "starting";
+            disconnected: "disconnected";
+            running: "running";
+            exited: "exited";
+          }>;
+          exitCode: z$1.ZodNullable<z$1.ZodNumber>;
+          closeReason: z$1.ZodNullable<
+            z$1.ZodEnum<{
+              user: "user";
+              "thread-deleted": "thread-deleted";
+              "process-exit": "process-exit";
+              "daemon-disconnect": "daemon-disconnect";
+              "environment-destroyed": "environment-destroyed";
+              "thread-archived": "thread-archived";
+              "open-timeout": "open-timeout";
+            }>
+          >;
+          createdAt: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+          lastUserInputAt: z$1.ZodNullable<z$1.ZodNumber>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type TerminalListResponse = z$1.infer<typeof terminalListResponseSchema>;
+declare const createTerminalRequestSchema: z$1.ZodObject<
+  {
+    cols: z$1.ZodNumber;
+    rows: z$1.ZodNumber;
+    start: z$1.ZodOptional<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              mode: z$1.ZodLiteral<"shell">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              mode: z$1.ZodLiteral<"command">;
+              command: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+        ],
+        "mode"
+      >
+    >;
+    target: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"thread">;
+            threadId: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"environment">;
+            environmentId: z$1.ZodString;
+          },
+          z$1.core.$strict
+        >,
+        z$1.ZodObject<
+          {
+            kind: z$1.ZodLiteral<"host_path">;
+            hostId: z$1.ZodString;
+            cwd: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strict
+        >,
+      ],
+      "kind"
+    >;
+    title: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strict
+>;
+type CreateTerminalRequest = z$1.infer<typeof createTerminalRequestSchema>;
+declare const updateTerminalRequestSchema: z$1.ZodObject<
+  {
+    title: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type UpdateTerminalRequest = z$1.infer<typeof updateTerminalRequestSchema>;
+declare const terminalInputRequestSchema: z$1.ZodObject<
+  {
+    dataBase64: z$1.ZodString;
+  },
+  z$1.core.$strict
+>;
+type TerminalInputRequest = z$1.infer<typeof terminalInputRequestSchema>;
+declare const terminalResizeRequestSchema: z$1.ZodObject<
+  {
+    cols: z$1.ZodNumber;
+    rows: z$1.ZodNumber;
+  },
+  z$1.core.$strict
+>;
+type TerminalResizeRequest = z$1.infer<typeof terminalResizeRequestSchema>;
+declare const terminalOutputQuerySchema: z$1.ZodObject<
+  {
+    sinceSeq: z$1.ZodOptional<z$1.ZodCoercedNumber<unknown>>;
+    tailBytes: z$1.ZodOptional<z$1.ZodCoercedNumber<unknown>>;
+    limitChunks: z$1.ZodOptional<z$1.ZodCoercedNumber<unknown>>;
+  },
+  z$1.core.$strict
+>;
+type TerminalOutputQuery = z$1.infer<typeof terminalOutputQuerySchema>;
+declare const terminalOutputResponseSchema: z$1.ZodObject<
+  {
+    chunks: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          seq: z$1.ZodNumber;
+          dataBase64: z$1.ZodString;
+        },
+        z$1.core.$strict
+      >
+    >;
+    nextSeq: z$1.ZodNumber;
+    truncated: z$1.ZodBoolean;
+  },
+  z$1.core.$strict
+>;
+type TerminalOutputResponse = z$1.infer<typeof terminalOutputResponseSchema>;
+
+declare const timelineRowStatusSchema: z$1.ZodEnum<{
+  error: "error";
+  pending: "pending";
+  completed: "completed";
+  interrupted: "interrupted";
+}>;
+type TimelineRowStatus = z$1.infer<typeof timelineRowStatusSchema>;
+declare const timelineRowBaseSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type TimelineRowBase = z$1.infer<typeof timelineRowBaseSchema>;
+declare const timelineConversationRowSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        id: z$1.ZodString;
+        threadId: z$1.ZodString;
+        turnId: z$1.ZodNullable<z$1.ZodString>;
+        sourceSeqStart: z$1.ZodNumber;
+        sourceSeqEnd: z$1.ZodNumber;
+        startedAt: z$1.ZodNumber;
+        createdAt: z$1.ZodNumber;
+        kind: z$1.ZodLiteral<"conversation">;
+        text: z$1.ZodString;
+        attachments: z$1.ZodNullable<
+          z$1.ZodObject<
+            {
+              webImages: z$1.ZodNumber;
+              localImages: z$1.ZodNumber;
+              localFiles: z$1.ZodNumber;
+              imageUrls: z$1.ZodArray<z$1.ZodString>;
+              localImagePaths: z$1.ZodArray<z$1.ZodString>;
+              localFilePaths: z$1.ZodArray<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >
+        >;
+        role: z$1.ZodLiteral<"user">;
+        initiator: z$1.ZodEnum<{
+          user: "user";
+          agent: "agent";
+          system: "system";
+        }>;
+        senderThreadId: z$1.ZodNullable<z$1.ZodString>;
+        systemMessageKind: z$1.ZodEnum<{
+          "ownership-assigned": "ownership-assigned";
+          "ownership-removed": "ownership-removed";
+          "child-needs-attention": "child-needs-attention";
+          "child-completed": "child-completed";
+          "child-failed": "child-failed";
+          "child-interrupted": "child-interrupted";
+          "child-outcome-batch": "child-outcome-batch";
+          unlabeled: "unlabeled";
+        }>;
+        systemMessageSubject: z$1.ZodNullable<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  kind: z$1.ZodLiteral<"thread">;
+                  threadId: z$1.ZodString;
+                  threadName: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  kind: z$1.ZodLiteral<"thread-batch">;
+                  count: z$1.ZodNumber;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "kind"
+          >
+        >;
+        turnRequest: z$1.ZodObject<
+          {
+            kind: z$1.ZodEnum<{
+              message: "message";
+              steer: "steer";
+            }>;
+            status: z$1.ZodEnum<{
+              pending: "pending";
+              accepted: "accepted";
+            }>;
+          },
+          z$1.core.$strip
+        >;
+        mentions: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              start: z$1.ZodNumber;
+              end: z$1.ZodNumber;
+              resource: z$1.ZodPipe<
+                z$1.ZodTransform<unknown, unknown>,
+                z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"thread">;
+                        threadId: z$1.ZodString;
+                        projectId: z$1.ZodOptional<z$1.ZodString>;
+                        label: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"project">;
+                        projectId: z$1.ZodString;
+                        label: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"section">;
+                        sectionId: z$1.ZodString;
+                        label: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"path">;
+                        source: z$1.ZodEnum<{
+                          workspace: "workspace";
+                          "thread-storage": "thread-storage";
+                        }>;
+                        entryKind: z$1.ZodEnum<{
+                          file: "file";
+                          directory: "directory";
+                        }>;
+                        path: z$1.ZodString;
+                        label: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"command">;
+                        trigger: z$1.ZodEnum<{
+                          "/": "/";
+                        }>;
+                        name: z$1.ZodString;
+                        source: z$1.ZodEnum<{
+                          command: "command";
+                          skill: "skill";
+                        }>;
+                        origin: z$1.ZodEnum<{
+                          user: "user";
+                          project: "project";
+                          builtin: "builtin";
+                        }>;
+                        label: z$1.ZodString;
+                        argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        kind: z$1.ZodLiteral<"plugin">;
+                        pluginId: z$1.ZodString;
+                        icon: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+                        itemId: z$1.ZodString;
+                        label: z$1.ZodString;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "kind"
+                >
+              >;
+            },
+            z$1.core.$strip
+          >
+        >;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        id: z$1.ZodString;
+        threadId: z$1.ZodString;
+        turnId: z$1.ZodNullable<z$1.ZodString>;
+        sourceSeqStart: z$1.ZodNumber;
+        sourceSeqEnd: z$1.ZodNumber;
+        startedAt: z$1.ZodNumber;
+        createdAt: z$1.ZodNumber;
+        kind: z$1.ZodLiteral<"conversation">;
+        text: z$1.ZodString;
+        attachments: z$1.ZodNullable<
+          z$1.ZodObject<
+            {
+              webImages: z$1.ZodNumber;
+              localImages: z$1.ZodNumber;
+              localFiles: z$1.ZodNumber;
+              imageUrls: z$1.ZodArray<z$1.ZodString>;
+              localImagePaths: z$1.ZodArray<z$1.ZodString>;
+              localFilePaths: z$1.ZodArray<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >
+        >;
+        role: z$1.ZodLiteral<"assistant">;
+        turnRequest: z$1.ZodNull;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "role"
+>;
+type TimelineConversationRow = z$1.infer<typeof timelineConversationRowSchema>;
+declare const timelineSystemRowSchema: z$1.ZodUnion<
+  readonly [
+    z$1.ZodObject<
+      {
+        id: z$1.ZodString;
+        threadId: z$1.ZodString;
+        turnId: z$1.ZodNullable<z$1.ZodString>;
+        sourceSeqStart: z$1.ZodNumber;
+        sourceSeqEnd: z$1.ZodNumber;
+        startedAt: z$1.ZodNumber;
+        createdAt: z$1.ZodNumber;
+        kind: z$1.ZodLiteral<"system">;
+        title: z$1.ZodString;
+        detail: z$1.ZodNullable<z$1.ZodString>;
+        status: z$1.ZodNullable<
+          z$1.ZodEnum<{
+            error: "error";
+            pending: "pending";
+            completed: "completed";
+            interrupted: "interrupted";
+          }>
+        >;
+        systemKind: z$1.ZodEnum<{
+          error: "error";
+          debug: "debug";
+          reconnect: "reconnect";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            id: z$1.ZodString;
+            threadId: z$1.ZodString;
+            turnId: z$1.ZodNullable<z$1.ZodString>;
+            sourceSeqStart: z$1.ZodNumber;
+            sourceSeqEnd: z$1.ZodNumber;
+            startedAt: z$1.ZodNumber;
+            createdAt: z$1.ZodNumber;
+            kind: z$1.ZodLiteral<"system">;
+            title: z$1.ZodString;
+            detail: z$1.ZodNullable<z$1.ZodString>;
+            status: z$1.ZodNullable<
+              z$1.ZodEnum<{
+                error: "error";
+                pending: "pending";
+                completed: "completed";
+                interrupted: "interrupted";
+              }>
+            >;
+            systemKind: z$1.ZodLiteral<"operation">;
+            operationKind: z$1.ZodEnum<{
+              generic: "generic";
+              compaction: "compaction";
+              "thread-provisioning": "thread-provisioning";
+              "thread-interrupted": "thread-interrupted";
+              "provider-unhandled": "provider-unhandled";
+              warning: "warning";
+              deprecation: "deprecation";
+            }>;
+            completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            id: z$1.ZodString;
+            threadId: z$1.ZodString;
+            turnId: z$1.ZodNullable<z$1.ZodString>;
+            sourceSeqStart: z$1.ZodNumber;
+            sourceSeqEnd: z$1.ZodNumber;
+            startedAt: z$1.ZodNumber;
+            createdAt: z$1.ZodNumber;
+            kind: z$1.ZodLiteral<"system">;
+            title: z$1.ZodString;
+            detail: z$1.ZodNullable<z$1.ZodString>;
+            systemKind: z$1.ZodLiteral<"operation">;
+            operationKind: z$1.ZodLiteral<"parent-change">;
+            status: z$1.ZodEnum<{
+              error: "error";
+              pending: "pending";
+              completed: "completed";
+              interrupted: "interrupted";
+            }>;
+            parentChange: z$1.ZodObject<
+              {
+                action: z$1.ZodEnum<{
+                  assign: "assign";
+                  release: "release";
+                  transfer: "transfer";
+                }>;
+                previousParentThreadId: z$1.ZodNullable<z$1.ZodString>;
+                previousParentThreadTitle: z$1.ZodNullable<z$1.ZodString>;
+                nextParentThreadId: z$1.ZodNullable<z$1.ZodString>;
+                nextParentThreadTitle: z$1.ZodNullable<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >;
+            completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "operationKind"
+    >,
+  ]
+>;
+type TimelineSystemRow = z$1.infer<typeof timelineSystemRowSchema>;
+interface TimelineWorkRowBase extends TimelineRowBase {
+  kind: "work";
+  status: TimelineRowStatus;
+}
+declare const timelineCommandWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"command">;
+    callId: z$1.ZodString;
+    command: z$1.ZodString;
+    cwd: z$1.ZodNullable<z$1.ZodString>;
+    source: z$1.ZodNullable<z$1.ZodString>;
+    output: z$1.ZodString;
+    exitCode: z$1.ZodNullable<z$1.ZodNumber>;
+    completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    approvalStatus: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        waiting_for_approval: "waiting_for_approval";
+        denied: "denied";
+      }>
+    >;
+    activityIntents: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"read">;
+              command: z$1.ZodString;
+              name: z$1.ZodString;
+              path: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"list_files">;
+              command: z$1.ZodString;
+              path: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"search">;
+              command: z$1.ZodString;
+              query: z$1.ZodNullable<z$1.ZodString>;
+              path: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"unknown">;
+              command: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type TimelineCommandWorkRow = z$1.infer<typeof timelineCommandWorkRowSchema>;
+declare const timelineToolWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"tool">;
+    callId: z$1.ZodString;
+    toolName: z$1.ZodString;
+    toolArgs: z$1.ZodNullable<
+      z$1.ZodRecord<
+        z$1.ZodString,
+        z$1.ZodType<
+          JsonValue$1,
+          unknown,
+          z$1.core.$ZodTypeInternals<JsonValue$1, unknown>
+        >
+      >
+    >;
+    statusLabels: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          pending: z$1.ZodString;
+          completed: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    output: z$1.ZodString;
+    completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    approvalStatus: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        waiting_for_approval: "waiting_for_approval";
+        denied: "denied";
+      }>
+    >;
+    activityIntents: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"read">;
+              command: z$1.ZodString;
+              name: z$1.ZodString;
+              path: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"list_files">;
+              command: z$1.ZodString;
+              path: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"search">;
+              command: z$1.ZodString;
+              query: z$1.ZodNullable<z$1.ZodString>;
+              path: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              type: z$1.ZodLiteral<"unknown">;
+              command: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type TimelineToolWorkRow = z$1.infer<typeof timelineToolWorkRowSchema>;
+declare const timelineFileChangeWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"file-change">;
+    callId: z$1.ZodString;
+    change: z$1.ZodObject<
+      {
+        path: z$1.ZodString;
+        kind: z$1.ZodNullable<z$1.ZodString>;
+        movePath: z$1.ZodNullable<z$1.ZodString>;
+        diff: z$1.ZodNullable<z$1.ZodString>;
+        diffStats: z$1.ZodObject<
+          {
+            added: z$1.ZodNumber;
+            removed: z$1.ZodNumber;
+          },
+          z$1.core.$strip
+        >;
+      },
+      z$1.core.$strip
+    >;
+    stdout: z$1.ZodNullable<z$1.ZodString>;
+    stderr: z$1.ZodNullable<z$1.ZodString>;
+    approvalStatus: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        waiting_for_approval: "waiting_for_approval";
+        denied: "denied";
+      }>
+    >;
+  },
+  z$1.core.$strip
+>;
+type TimelineFileChangeWorkRow = z$1.infer<
+  typeof timelineFileChangeWorkRowSchema
+>;
+declare const timelineWebSearchWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"web-search">;
+    callId: z$1.ZodString;
+    queries: z$1.ZodArray<z$1.ZodString>;
+    completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+  },
+  z$1.core.$strip
+>;
+type TimelineWebSearchWorkRow = z$1.infer<
+  typeof timelineWebSearchWorkRowSchema
+>;
+declare const timelineWebFetchWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"web-fetch">;
+    callId: z$1.ZodString;
+    url: z$1.ZodString;
+    prompt: z$1.ZodNullable<z$1.ZodString>;
+    pattern: z$1.ZodNullable<z$1.ZodString>;
+    completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+  },
+  z$1.core.$strip
+>;
+type TimelineWebFetchWorkRow = z$1.infer<typeof timelineWebFetchWorkRowSchema>;
+declare const timelineImageViewWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"image-view">;
+    callId: z$1.ZodString;
+    path: z$1.ZodString;
+    completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+  },
+  z$1.core.$strip
+>;
+type TimelineImageViewWorkRow = z$1.infer<
+  typeof timelineImageViewWorkRowSchema
+>;
+declare const timelineApprovalWorkRowSchema: z$1.ZodDiscriminatedUnion<
+  [
+    z$1.ZodObject<
+      {
+        id: z$1.ZodString;
+        threadId: z$1.ZodString;
+        turnId: z$1.ZodNullable<z$1.ZodString>;
+        sourceSeqStart: z$1.ZodNumber;
+        sourceSeqEnd: z$1.ZodNumber;
+        startedAt: z$1.ZodNumber;
+        createdAt: z$1.ZodNumber;
+        kind: z$1.ZodLiteral<"work">;
+        status: z$1.ZodEnum<{
+          error: "error";
+          pending: "pending";
+          completed: "completed";
+          interrupted: "interrupted";
+        }>;
+        workKind: z$1.ZodLiteral<"approval">;
+        interactionId: z$1.ZodString;
+        target: z$1.ZodObject<
+          {
+            itemId: z$1.ZodString;
+            toolName: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >;
+        approvalKind: z$1.ZodLiteral<"file-edit">;
+        lifecycle: z$1.ZodEnum<{
+          denied: "denied";
+          waiting: "waiting";
+        }>;
+      },
+      z$1.core.$strip
+    >,
+    z$1.ZodObject<
+      {
+        id: z$1.ZodString;
+        threadId: z$1.ZodString;
+        turnId: z$1.ZodNullable<z$1.ZodString>;
+        sourceSeqStart: z$1.ZodNumber;
+        sourceSeqEnd: z$1.ZodNumber;
+        startedAt: z$1.ZodNumber;
+        createdAt: z$1.ZodNumber;
+        kind: z$1.ZodLiteral<"work">;
+        status: z$1.ZodEnum<{
+          error: "error";
+          pending: "pending";
+          completed: "completed";
+          interrupted: "interrupted";
+        }>;
+        workKind: z$1.ZodLiteral<"approval">;
+        interactionId: z$1.ZodString;
+        target: z$1.ZodObject<
+          {
+            itemId: z$1.ZodString;
+            toolName: z$1.ZodNullable<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >;
+        approvalKind: z$1.ZodLiteral<"permission-grant">;
+        lifecycle: z$1.ZodEnum<{
+          pending: "pending";
+          interrupted: "interrupted";
+          denied: "denied";
+          resolving: "resolving";
+          granted: "granted";
+        }>;
+        grantScope: z$1.ZodNullable<
+          z$1.ZodEnum<{
+            turn: "turn";
+            session: "session";
+          }>
+        >;
+        statusReason: z$1.ZodNullable<z$1.ZodString>;
+      },
+      z$1.core.$strip
+    >,
+  ],
+  "approvalKind"
+>;
+type TimelineApprovalWorkRow = z$1.infer<typeof timelineApprovalWorkRowSchema>;
+declare const timelineQuestionWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"question">;
+    interactionId: z$1.ZodString;
+    lifecycle: z$1.ZodEnum<{
+      pending: "pending";
+      interrupted: "interrupted";
+      resolving: "resolving";
+      answered: "answered";
+    }>;
+    questions: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          prompt: z$1.ZodString;
+          shortLabel: z$1.ZodOptional<z$1.ZodString>;
+          multiSelect: z$1.ZodBoolean;
+          options: z$1.ZodOptional<
+            z$1.ZodArray<
+              z$1.ZodObject<
+                {
+                  value: z$1.ZodString;
+                  label: z$1.ZodString;
+                  description: z$1.ZodOptional<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >
+            >
+          >;
+          allowFreeText: z$1.ZodBoolean;
+        },
+        z$1.core.$strip
+      >
+    >;
+    answers: z$1.ZodNullable<
+      z$1.ZodRecord<
+        z$1.ZodString,
+        z$1.ZodObject<
+          {
+            selected: z$1.ZodArray<z$1.ZodString>;
+            freeText: z$1.ZodOptional<z$1.ZodString>;
+          },
+          z$1.core.$strip
+        >
+      >
+    >;
+    statusReason: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type TimelineQuestionWorkRow = z$1.infer<typeof timelineQuestionWorkRowSchema>;
+interface TimelineDelegationWorkRow extends TimelineWorkRowBase {
+  workKind: "delegation";
+  callId: string;
+  toolName: string;
+  subagentType: string | null;
+  description: string | null;
+  output: string;
+  completedAt: number | null;
+  childRows: TimelineRow[];
+}
+/**
+ * A provider background task — a dynamic workflow (Claude Code Workflow tool)
+ * or a backgrounded shell command (Bash run_in_background), discriminated by
+ * `taskType`. The row outlives its spawning turn: progress and terminal state
+ * arrive via thread-scoped events folded into this single row. `workflow` is
+ * the merged phase/agent tree, present only for workflows; null for shell
+ * commands and for workflows the provider reported no progress records for
+ * (degraded rendering falls back to description + summary).
+ */
+declare const timelineWorkflowWorkRowSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    threadId: z$1.ZodString;
+    turnId: z$1.ZodNullable<z$1.ZodString>;
+    sourceSeqStart: z$1.ZodNumber;
+    sourceSeqEnd: z$1.ZodNumber;
+    startedAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    kind: z$1.ZodLiteral<"work">;
+    status: z$1.ZodEnum<{
+      error: "error";
+      pending: "pending";
+      completed: "completed";
+      interrupted: "interrupted";
+    }>;
+    workKind: z$1.ZodLiteral<"workflow">;
+    itemId: z$1.ZodString;
+    taskType: z$1.ZodString;
+    workflowName: z$1.ZodNullable<z$1.ZodString>;
+    description: z$1.ZodString;
+    taskStatus: z$1.ZodEnum<{
+      pending: "pending";
+      completed: "completed";
+      running: "running";
+      paused: "paused";
+      failed: "failed";
+      killed: "killed";
+      stopped: "stopped";
+    }>;
+    workflow: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          phases: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                index: z$1.ZodNumber;
+                title: z$1.ZodString;
+                kind: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >
+          >;
+          agents: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                index: z$1.ZodNumber;
+                label: z$1.ZodString;
+                state: z$1.ZodEnum<{
+                  running: "running";
+                  failed: "failed";
+                  queued: "queued";
+                  done: "done";
+                  skipped: "skipped";
+                }>;
+                model: z$1.ZodString;
+                attempt: z$1.ZodNumber;
+                cached: z$1.ZodBoolean;
+                lastProgressAt: z$1.ZodNumber;
+                phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                agentType: z$1.ZodOptional<z$1.ZodString>;
+                isolation: z$1.ZodOptional<z$1.ZodString>;
+                queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                error: z$1.ZodOptional<z$1.ZodString>;
+                tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+              },
+              z$1.core.$strip
+            >
+          >;
+        },
+        z$1.core.$strip
+      >
+    >;
+    usage: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          totalTokens: z$1.ZodNumber;
+          toolUses: z$1.ZodNumber;
+          durationMs: z$1.ZodNumber;
+        },
+        z$1.core.$strip
+      >
+    >;
+    summary: z$1.ZodNullable<z$1.ZodString>;
+    error: z$1.ZodNullable<z$1.ZodString>;
+    completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+  },
+  z$1.core.$strip
+>;
+type TimelineWorkflowWorkRow = z$1.infer<typeof timelineWorkflowWorkRowSchema>;
+type TimelineWorkRow =
+  | TimelineCommandWorkRow
+  | TimelineToolWorkRow
+  | TimelineFileChangeWorkRow
+  | TimelineWebSearchWorkRow
+  | TimelineWebFetchWorkRow
+  | TimelineImageViewWorkRow
+  | TimelineApprovalWorkRow
+  | TimelineQuestionWorkRow
+  | TimelineDelegationWorkRow
+  | TimelineWorkflowWorkRow;
+interface TimelineTurnRow extends TimelineRowBase {
+  kind: "turn";
+  turnId: string;
+  status: TimelineRowStatus;
+  summaryCount: number;
+  completedAt: number | null;
+  children: TimelineRow[] | null;
+}
+type TimelineSourceRow =
+  | TimelineConversationRow
+  | TimelineWorkRow
+  | TimelineSystemRow;
+type TimelineRow = TimelineSourceRow | TimelineTurnRow;
+
+declare const createExecutionInputSourcesSchema: z$1.ZodObject<
+  {
+    providerId: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        explicit: "explicit";
+        "client-preference": "client-preference";
+      }>
+    >;
+    model: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        explicit: "explicit";
+        "client-preference": "client-preference";
+      }>
+    >;
+    serviceTier: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        explicit: "explicit";
+        "client-preference": "client-preference";
+      }>
+    >;
+    reasoningLevel: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        explicit: "explicit";
+        "client-preference": "client-preference";
+      }>
+    >;
+    permissionMode: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        explicit: "explicit";
+        "client-preference": "client-preference";
+      }>
+    >;
+  },
+  z$1.core.$strict
+>;
+type CreateExecutionInputSources = z$1.infer<
+  typeof createExecutionInputSourcesSchema
+>;
+declare const createThreadRequestSchema: z$1.ZodObject<
+  {
+    projectId: z$1.ZodString;
+    providerId: z$1.ZodOptional<z$1.ZodString>;
+    origin: z$1.ZodEnum<{
+      plugin: "plugin";
+      app: "app";
+      cli: "cli";
+      sdk: "sdk";
+    }>;
+    originPluginId: z$1.ZodOptional<z$1.ZodString>;
+    visibility: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        visible: "visible";
+        hidden: "hidden";
+      }>
+    >;
+    title: z$1.ZodOptional<z$1.ZodString>;
+    input: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"text">;
+              text: z$1.ZodString;
+              mentions: z$1.ZodDefault<
+                z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      start: z$1.ZodNumber;
+                      end: z$1.ZodNumber;
+                      resource: z$1.ZodPipe<
+                        z$1.ZodTransform<unknown, unknown>,
+                        z$1.ZodDiscriminatedUnion<
+                          [
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"thread">;
+                                threadId: z$1.ZodString;
+                                projectId: z$1.ZodOptional<z$1.ZodString>;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"project">;
+                                projectId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"section">;
+                                sectionId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"path">;
+                                source: z$1.ZodEnum<{
+                                  workspace: "workspace";
+                                  "thread-storage": "thread-storage";
+                                }>;
+                                entryKind: z$1.ZodEnum<{
+                                  file: "file";
+                                  directory: "directory";
+                                }>;
+                                path: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"command">;
+                                trigger: z$1.ZodEnum<{
+                                  "/": "/";
+                                }>;
+                                name: z$1.ZodString;
+                                source: z$1.ZodEnum<{
+                                  command: "command";
+                                  skill: "skill";
+                                }>;
+                                origin: z$1.ZodEnum<{
+                                  user: "user";
+                                  project: "project";
+                                  builtin: "builtin";
+                                }>;
+                                label: z$1.ZodString;
+                                argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"plugin">;
+                                pluginId: z$1.ZodString;
+                                icon: z$1.ZodOptional<
+                                  z$1.ZodNullable<z$1.ZodString>
+                                >;
+                                itemId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                          ],
+                          "kind"
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"image">;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localImage">;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localFile">;
+              path: z$1.ZodString;
+              name: z$1.ZodOptional<z$1.ZodString>;
+              sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+              mimeType: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+    model: z$1.ZodOptional<z$1.ZodString>;
+    serviceTier: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        default: "default";
+        fast: "fast";
+      }>
+    >;
+    reasoningLevel: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        none: "none";
+        low: "low";
+        medium: "medium";
+        high: "high";
+        xhigh: "xhigh";
+        ultracode: "ultracode";
+        max: "max";
+        ultra: "ultra";
+      }>
+    >;
+    permissionMode: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodUnion<
+          readonly [
+            z$1.ZodEnum<{
+              auto: "auto";
+              "accept-edits": "accept-edits";
+              full: "full";
+            }>,
+            z$1.ZodLiteral<"workspace-write">,
+          ]
+        >,
+        z$1.ZodTransform<
+          "auto" | "accept-edits" | "full",
+          "auto" | "accept-edits" | "full" | "workspace-write"
+        >
+      >
+    >;
+    executionInputSources: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          providerId: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          model: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          serviceTier: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          reasoningLevel: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          permissionMode: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    environment: z$1.ZodDiscriminatedUnion<
+      [
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"reuse">;
+            environmentId: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"host">;
+            hostId: z$1.ZodOptional<z$1.ZodString>;
+            workspace: z$1.ZodDiscriminatedUnion<
+              [
+                z$1.ZodObject<
+                  {
+                    type: z$1.ZodLiteral<"unmanaged">;
+                    path: z$1.ZodNullable<z$1.ZodString>;
+                    branch: z$1.ZodOptional<
+                      z$1.ZodDiscriminatedUnion<
+                        [
+                          z$1.ZodObject<
+                            {
+                              kind: z$1.ZodLiteral<"existing">;
+                              name: z$1.ZodString;
+                            },
+                            z$1.core.$strict
+                          >,
+                          z$1.ZodObject<
+                            {
+                              kind: z$1.ZodLiteral<"new">;
+                              baseBranch: z$1.ZodString;
+                            },
+                            z$1.core.$strict
+                          >,
+                        ],
+                        "kind"
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    type: z$1.ZodLiteral<"managed-worktree">;
+                    baseBranch: z$1.ZodDiscriminatedUnion<
+                      [
+                        z$1.ZodObject<
+                          {
+                            kind: z$1.ZodLiteral<"named">;
+                            name: z$1.ZodString;
+                          },
+                          z$1.core.$strip
+                        >,
+                        z$1.ZodObject<
+                          {
+                            kind: z$1.ZodLiteral<"default">;
+                          },
+                          z$1.core.$strip
+                        >,
+                      ],
+                      "kind"
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+                z$1.ZodObject<
+                  {
+                    type: z$1.ZodLiteral<"personal">;
+                  },
+                  z$1.core.$strip
+                >,
+              ],
+              "type"
+            >;
+          },
+          z$1.core.$strip
+        >,
+        z$1.ZodObject<
+          {
+            type: z$1.ZodLiteral<"project-default">;
+          },
+          z$1.core.$strip
+        >,
+      ],
+      "type"
+    >;
+    parentThreadId: z$1.ZodOptional<z$1.ZodString>;
+    sectionId: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+    sourceThreadId: z$1.ZodOptional<z$1.ZodString>;
+    sourceSeqEnd: z$1.ZodOptional<z$1.ZodNumber>;
+    startedOnBehalfOf: z$1.ZodDefault<
+      z$1.ZodNullable<
+        z$1.ZodObject<
+          {
+            initiator: z$1.ZodEnum<{
+              agent: "agent";
+              system: "system";
+            }>;
+            senderThreadId: z$1.ZodString;
+          },
+          z$1.core.$strip
+        >
+      >
+    >;
+    originKind: z$1.ZodDefault<
+      z$1.ZodNullable<
+        z$1.ZodEnum<{
+          fork: "fork";
+        }>
+      >
+    >;
+    childOrigin: z$1.ZodDefault<
+      z$1.ZodNullable<
+        z$1.ZodEnum<{
+          fork: "fork";
+        }>
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type CreateThreadRequest = z$1.infer<typeof createThreadRequestSchema>;
+declare const forkThreadRequestSchema: z$1.ZodObject<
+  {
+    sourceThreadId: z$1.ZodString;
+    sourceSeqEnd: z$1.ZodOptional<z$1.ZodNumber>;
+    input: z$1.ZodOptional<
+      z$1.ZodArray<
+        z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"text">;
+                text: z$1.ZodString;
+                mentions: z$1.ZodDefault<
+                  z$1.ZodArray<
+                    z$1.ZodObject<
+                      {
+                        start: z$1.ZodNumber;
+                        end: z$1.ZodNumber;
+                        resource: z$1.ZodPipe<
+                          z$1.ZodTransform<unknown, unknown>,
+                          z$1.ZodDiscriminatedUnion<
+                            [
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"thread">;
+                                  threadId: z$1.ZodString;
+                                  projectId: z$1.ZodOptional<z$1.ZodString>;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"project">;
+                                  projectId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"section">;
+                                  sectionId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"path">;
+                                  source: z$1.ZodEnum<{
+                                    workspace: "workspace";
+                                    "thread-storage": "thread-storage";
+                                  }>;
+                                  entryKind: z$1.ZodEnum<{
+                                    file: "file";
+                                    directory: "directory";
+                                  }>;
+                                  path: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"command">;
+                                  trigger: z$1.ZodEnum<{
+                                    "/": "/";
+                                  }>;
+                                  name: z$1.ZodString;
+                                  source: z$1.ZodEnum<{
+                                    command: "command";
+                                    skill: "skill";
+                                  }>;
+                                  origin: z$1.ZodEnum<{
+                                    user: "user";
+                                    project: "project";
+                                    builtin: "builtin";
+                                  }>;
+                                  label: z$1.ZodString;
+                                  argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"plugin">;
+                                  pluginId: z$1.ZodString;
+                                  icon: z$1.ZodOptional<
+                                    z$1.ZodNullable<z$1.ZodString>
+                                  >;
+                                  itemId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                            ],
+                            "kind"
+                          >
+                        >;
+                      },
+                      z$1.core.$strip
+                    >
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"image">;
+                url: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"localImage">;
+                path: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"localFile">;
+                path: z$1.ZodString;
+                name: z$1.ZodOptional<z$1.ZodString>;
+                sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                mimeType: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >
+      >
+    >;
+    agentContextSeed: z$1.ZodOptional<
+      z$1.ZodArray<
+        z$1.ZodIntersection<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"text">;
+                  text: z$1.ZodString;
+                  mentions: z$1.ZodDefault<
+                    z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          start: z$1.ZodNumber;
+                          end: z$1.ZodNumber;
+                          resource: z$1.ZodPipe<
+                            z$1.ZodTransform<unknown, unknown>,
+                            z$1.ZodDiscriminatedUnion<
+                              [
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"thread">;
+                                    threadId: z$1.ZodString;
+                                    projectId: z$1.ZodOptional<z$1.ZodString>;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"project">;
+                                    projectId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"section">;
+                                    sectionId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"path">;
+                                    source: z$1.ZodEnum<{
+                                      workspace: "workspace";
+                                      "thread-storage": "thread-storage";
+                                    }>;
+                                    entryKind: z$1.ZodEnum<{
+                                      file: "file";
+                                      directory: "directory";
+                                    }>;
+                                    path: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"command">;
+                                    trigger: z$1.ZodEnum<{
+                                      "/": "/";
+                                    }>;
+                                    name: z$1.ZodString;
+                                    source: z$1.ZodEnum<{
+                                      command: "command";
+                                      skill: "skill";
+                                    }>;
+                                    origin: z$1.ZodEnum<{
+                                      user: "user";
+                                      project: "project";
+                                      builtin: "builtin";
+                                    }>;
+                                    label: z$1.ZodString;
+                                    argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"plugin">;
+                                    pluginId: z$1.ZodString;
+                                    icon: z$1.ZodOptional<
+                                      z$1.ZodNullable<z$1.ZodString>
+                                    >;
+                                    itemId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                              ],
+                              "kind"
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"image">;
+                  url: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localImage">;
+                  path: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localFile">;
+                  path: z$1.ZodString;
+                  name: z$1.ZodOptional<z$1.ZodString>;
+                  sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                  mimeType: z$1.ZodOptional<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "type"
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodLiteral<"agent-only">;
+            },
+            z$1.core.$strip
+          >
+        >
+      >
+    >;
+    title: z$1.ZodOptional<z$1.ZodString>;
+    permissionMode: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodUnion<
+          readonly [
+            z$1.ZodEnum<{
+              auto: "auto";
+              "accept-edits": "accept-edits";
+              full: "full";
+            }>,
+            z$1.ZodLiteral<"workspace-write">,
+          ]
+        >,
+        z$1.ZodTransform<
+          "auto" | "accept-edits" | "full",
+          "auto" | "accept-edits" | "full" | "workspace-write"
+        >
+      >
+    >;
+    visibility: z$1.ZodDefault<
+      z$1.ZodEnum<{
+        visible: "visible";
+        hidden: "hidden";
+      }>
+    >;
+    workspace: z$1.ZodDefault<
+      z$1.ZodEnum<{
+        reuse: "reuse";
+        isolated: "isolated";
+      }>
+    >;
+    origin: z$1.ZodDefault<
+      z$1.ZodEnum<{
+        plugin: "plugin";
+        app: "app";
+        cli: "cli";
+        sdk: "sdk";
+      }>
+    >;
+    originPluginId: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ForkThreadRequest = z$1.infer<typeof forkThreadRequestSchema>;
+declare const sendMessageRequestSchema: z$1.ZodObject<
+  {
+    input: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"text">;
+              text: z$1.ZodString;
+              mentions: z$1.ZodDefault<
+                z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      start: z$1.ZodNumber;
+                      end: z$1.ZodNumber;
+                      resource: z$1.ZodPipe<
+                        z$1.ZodTransform<unknown, unknown>,
+                        z$1.ZodDiscriminatedUnion<
+                          [
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"thread">;
+                                threadId: z$1.ZodString;
+                                projectId: z$1.ZodOptional<z$1.ZodString>;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"project">;
+                                projectId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"section">;
+                                sectionId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"path">;
+                                source: z$1.ZodEnum<{
+                                  workspace: "workspace";
+                                  "thread-storage": "thread-storage";
+                                }>;
+                                entryKind: z$1.ZodEnum<{
+                                  file: "file";
+                                  directory: "directory";
+                                }>;
+                                path: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"command">;
+                                trigger: z$1.ZodEnum<{
+                                  "/": "/";
+                                }>;
+                                name: z$1.ZodString;
+                                source: z$1.ZodEnum<{
+                                  command: "command";
+                                  skill: "skill";
+                                }>;
+                                origin: z$1.ZodEnum<{
+                                  user: "user";
+                                  project: "project";
+                                  builtin: "builtin";
+                                }>;
+                                label: z$1.ZodString;
+                                argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"plugin">;
+                                pluginId: z$1.ZodString;
+                                icon: z$1.ZodOptional<
+                                  z$1.ZodNullable<z$1.ZodString>
+                                >;
+                                itemId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                          ],
+                          "kind"
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"image">;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localImage">;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localFile">;
+              path: z$1.ZodString;
+              name: z$1.ZodOptional<z$1.ZodString>;
+              sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+              mimeType: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+    model: z$1.ZodOptional<z$1.ZodString>;
+    serviceTier: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        default: "default";
+        fast: "fast";
+      }>
+    >;
+    reasoningLevel: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        none: "none";
+        low: "low";
+        medium: "medium";
+        high: "high";
+        xhigh: "xhigh";
+        ultracode: "ultracode";
+        max: "max";
+        ultra: "ultra";
+      }>
+    >;
+    permissionMode: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodUnion<
+          readonly [
+            z$1.ZodEnum<{
+              auto: "auto";
+              "accept-edits": "accept-edits";
+              full: "full";
+            }>,
+            z$1.ZodLiteral<"workspace-write">,
+          ]
+        >,
+        z$1.ZodTransform<
+          "auto" | "accept-edits" | "full",
+          "auto" | "accept-edits" | "full" | "workspace-write"
+        >
+      >
+    >;
+    executionInputSources: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          model: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          serviceTier: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          reasoningLevel: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          permissionMode: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    mode: z$1.ZodEnum<{
+      steer: "steer";
+      start: "start";
+      auto: "auto";
+      "queue-if-active": "queue-if-active";
+      "steer-if-active": "steer-if-active";
+    }>;
+    senderThreadId: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type SendMessageRequest = z$1.infer<typeof sendMessageRequestSchema>;
+declare const createQueuedMessageRequestSchema: z$1.ZodObject<
+  {
+    input: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"text">;
+              text: z$1.ZodString;
+              mentions: z$1.ZodDefault<
+                z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      start: z$1.ZodNumber;
+                      end: z$1.ZodNumber;
+                      resource: z$1.ZodPipe<
+                        z$1.ZodTransform<unknown, unknown>,
+                        z$1.ZodDiscriminatedUnion<
+                          [
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"thread">;
+                                threadId: z$1.ZodString;
+                                projectId: z$1.ZodOptional<z$1.ZodString>;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"project">;
+                                projectId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"section">;
+                                sectionId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"path">;
+                                source: z$1.ZodEnum<{
+                                  workspace: "workspace";
+                                  "thread-storage": "thread-storage";
+                                }>;
+                                entryKind: z$1.ZodEnum<{
+                                  file: "file";
+                                  directory: "directory";
+                                }>;
+                                path: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"command">;
+                                trigger: z$1.ZodEnum<{
+                                  "/": "/";
+                                }>;
+                                name: z$1.ZodString;
+                                source: z$1.ZodEnum<{
+                                  command: "command";
+                                  skill: "skill";
+                                }>;
+                                origin: z$1.ZodEnum<{
+                                  user: "user";
+                                  project: "project";
+                                  builtin: "builtin";
+                                }>;
+                                label: z$1.ZodString;
+                                argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"plugin">;
+                                pluginId: z$1.ZodString;
+                                icon: z$1.ZodOptional<
+                                  z$1.ZodNullable<z$1.ZodString>
+                                >;
+                                itemId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                          ],
+                          "kind"
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"image">;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localImage">;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localFile">;
+              path: z$1.ZodString;
+              name: z$1.ZodOptional<z$1.ZodString>;
+              sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+              mimeType: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+    model: z$1.ZodOptional<z$1.ZodString>;
+    serviceTier: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        default: "default";
+        fast: "fast";
+      }>
+    >;
+    reasoningLevel: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        none: "none";
+        low: "low";
+        medium: "medium";
+        high: "high";
+        xhigh: "xhigh";
+        ultracode: "ultracode";
+        max: "max";
+        ultra: "ultra";
+      }>
+    >;
+    permissionMode: z$1.ZodOptional<
+      z$1.ZodPipe<
+        z$1.ZodUnion<
+          readonly [
+            z$1.ZodEnum<{
+              auto: "auto";
+              "accept-edits": "accept-edits";
+              full: "full";
+            }>,
+            z$1.ZodLiteral<"workspace-write">,
+          ]
+        >,
+        z$1.ZodTransform<
+          "auto" | "accept-edits" | "full",
+          "auto" | "accept-edits" | "full" | "workspace-write"
+        >
+      >
+    >;
+    executionInputSources: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          model: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          serviceTier: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          reasoningLevel: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+          permissionMode: z$1.ZodOptional<
+            z$1.ZodEnum<{
+              explicit: "explicit";
+              "client-preference": "client-preference";
+            }>
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    senderThreadId: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type CreateQueuedMessageRequest = z$1.infer<
+  typeof createQueuedMessageRequestSchema
+>;
+declare const updateQueuedMessageRequestSchema: z$1.ZodObject<
+  {
+    expectedUpdatedAt: z$1.ZodNumber;
+    input: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"text">;
+              text: z$1.ZodString;
+              mentions: z$1.ZodDefault<
+                z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      start: z$1.ZodNumber;
+                      end: z$1.ZodNumber;
+                      resource: z$1.ZodPipe<
+                        z$1.ZodTransform<unknown, unknown>,
+                        z$1.ZodDiscriminatedUnion<
+                          [
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"thread">;
+                                threadId: z$1.ZodString;
+                                projectId: z$1.ZodOptional<z$1.ZodString>;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"project">;
+                                projectId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"section">;
+                                sectionId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"path">;
+                                source: z$1.ZodEnum<{
+                                  workspace: "workspace";
+                                  "thread-storage": "thread-storage";
+                                }>;
+                                entryKind: z$1.ZodEnum<{
+                                  file: "file";
+                                  directory: "directory";
+                                }>;
+                                path: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"command">;
+                                trigger: z$1.ZodEnum<{
+                                  "/": "/";
+                                }>;
+                                name: z$1.ZodString;
+                                source: z$1.ZodEnum<{
+                                  command: "command";
+                                  skill: "skill";
+                                }>;
+                                origin: z$1.ZodEnum<{
+                                  user: "user";
+                                  project: "project";
+                                  builtin: "builtin";
+                                }>;
+                                label: z$1.ZodString;
+                                argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >,
+                            z$1.ZodObject<
+                              {
+                                kind: z$1.ZodLiteral<"plugin">;
+                                pluginId: z$1.ZodString;
+                                icon: z$1.ZodOptional<
+                                  z$1.ZodNullable<z$1.ZodString>
+                                >;
+                                itemId: z$1.ZodString;
+                                label: z$1.ZodString;
+                              },
+                              z$1.core.$strip
+                            >,
+                          ],
+                          "kind"
+                        >
+                      >;
+                    },
+                    z$1.core.$strip
+                  >
+                >
+              >;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"image">;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localImage">;
+              path: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >,
+          z$1.ZodObject<
+            {
+              visibility: z$1.ZodOptional<
+                z$1.ZodEnum<{
+                  "agent-only": "agent-only";
+                }>
+              >;
+              type: z$1.ZodLiteral<"localFile">;
+              path: z$1.ZodString;
+              name: z$1.ZodOptional<z$1.ZodString>;
+              sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+              mimeType: z$1.ZodOptional<z$1.ZodString>;
+            },
+            z$1.core.$strip
+          >,
+        ],
+        "type"
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type UpdateQueuedMessageRequest = z$1.infer<
+  typeof updateQueuedMessageRequestSchema
+>;
+declare const sendQueuedMessageRequestSchema: z$1.ZodObject<
+  {
+    mode: z$1.ZodEnum<{
+      steer: "steer";
+      auto: "auto";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type SendQueuedMessageRequest = z$1.infer<
+  typeof sendQueuedMessageRequestSchema
+>;
+declare const reorderQueuedMessageRequestSchema: z$1.ZodObject<
+  {
+    previousQueuedMessageId: z$1.ZodNullable<z$1.ZodString>;
+    nextQueuedMessageId: z$1.ZodNullable<z$1.ZodString>;
+    groupBoundaryQueuedMessageId: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ReorderQueuedMessageRequest = z$1.infer<
+  typeof reorderQueuedMessageRequestSchema
+>;
+declare const setQueuedMessageGroupBoundaryRequestSchema: z$1.ZodObject<
+  {
+    expectedGroupedPrefixQueuedMessageIds: z$1.ZodArray<z$1.ZodString>;
+    groupBoundaryQueuedMessageId: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type SetQueuedMessageGroupBoundaryRequest = z$1.infer<
+  typeof setQueuedMessageGroupBoundaryRequestSchema
+>;
+declare const sendQueuedMessageResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    queuedMessage: z$1.ZodObject<
+      {
+        id: z$1.ZodString;
+        content: z$1.ZodArray<
+          z$1.ZodDiscriminatedUnion<
+            [
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"text">;
+                  text: z$1.ZodString;
+                  mentions: z$1.ZodDefault<
+                    z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          start: z$1.ZodNumber;
+                          end: z$1.ZodNumber;
+                          resource: z$1.ZodPipe<
+                            z$1.ZodTransform<unknown, unknown>,
+                            z$1.ZodDiscriminatedUnion<
+                              [
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"thread">;
+                                    threadId: z$1.ZodString;
+                                    projectId: z$1.ZodOptional<z$1.ZodString>;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"project">;
+                                    projectId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"section">;
+                                    sectionId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"path">;
+                                    source: z$1.ZodEnum<{
+                                      workspace: "workspace";
+                                      "thread-storage": "thread-storage";
+                                    }>;
+                                    entryKind: z$1.ZodEnum<{
+                                      file: "file";
+                                      directory: "directory";
+                                    }>;
+                                    path: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"command">;
+                                    trigger: z$1.ZodEnum<{
+                                      "/": "/";
+                                    }>;
+                                    name: z$1.ZodString;
+                                    source: z$1.ZodEnum<{
+                                      command: "command";
+                                      skill: "skill";
+                                    }>;
+                                    origin: z$1.ZodEnum<{
+                                      user: "user";
+                                      project: "project";
+                                      builtin: "builtin";
+                                    }>;
+                                    label: z$1.ZodString;
+                                    argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    kind: z$1.ZodLiteral<"plugin">;
+                                    pluginId: z$1.ZodString;
+                                    icon: z$1.ZodOptional<
+                                      z$1.ZodNullable<z$1.ZodString>
+                                    >;
+                                    itemId: z$1.ZodString;
+                                    label: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                              ],
+                              "kind"
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"image">;
+                  url: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localImage">;
+                  path: z$1.ZodString;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  visibility: z$1.ZodOptional<
+                    z$1.ZodEnum<{
+                      "agent-only": "agent-only";
+                    }>
+                  >;
+                  type: z$1.ZodLiteral<"localFile">;
+                  path: z$1.ZodString;
+                  name: z$1.ZodOptional<z$1.ZodString>;
+                  sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                  mimeType: z$1.ZodOptional<z$1.ZodString>;
+                },
+                z$1.core.$strip
+              >,
+            ],
+            "type"
+          >
+        >;
+        model: z$1.ZodString;
+        reasoningLevel: z$1.ZodEnum<{
+          none: "none";
+          low: "low";
+          medium: "medium";
+          high: "high";
+          xhigh: "xhigh";
+          ultracode: "ultracode";
+          max: "max";
+          ultra: "ultra";
+        }>;
+        permissionMode: z$1.ZodEnum<{
+          auto: "auto";
+          "accept-edits": "accept-edits";
+          full: "full";
+        }>;
+        serviceTier: z$1.ZodEnum<{
+          default: "default";
+          fast: "fast";
+        }>;
+        groupWithNext: z$1.ZodBoolean;
+        createdAt: z$1.ZodNumber;
+        updatedAt: z$1.ZodNumber;
+      },
+      z$1.core.$strip
+    >;
+  },
+  z$1.core.$strip
+>;
+type SendQueuedMessageResponse = z$1.infer<
+  typeof sendQueuedMessageResponseSchema
+>;
+declare const threadListResponseSchema: z$1.ZodArray<
+  z$1.ZodObject<
+    {
+      id: z$1.ZodString;
+      projectId: z$1.ZodString;
+      environmentId: z$1.ZodNullable<z$1.ZodString>;
+      providerId: z$1.ZodString;
+      title: z$1.ZodNullable<z$1.ZodString>;
+      titleFallback: z$1.ZodNullable<z$1.ZodString>;
+      sectionId: z$1.ZodNullable<z$1.ZodString>;
+      status: z$1.ZodEnum<{
+        error: "error";
+        stopping: "stopping";
+        idle: "idle";
+        starting: "starting";
+        active: "active";
+      }>;
+      parentThreadId: z$1.ZodNullable<z$1.ZodString>;
+      sourceThreadId: z$1.ZodNullable<z$1.ZodString>;
+      originKind: z$1.ZodNullable<
+        z$1.ZodEnum<{
+          fork: "fork";
+        }>
+      >;
+      childOrigin: z$1.ZodNullable<
+        z$1.ZodEnum<{
+          fork: "fork";
+        }>
+      >;
+      originPluginId: z$1.ZodNullable<z$1.ZodString>;
+      visibility: z$1.ZodEnum<{
+        visible: "visible";
+        hidden: "hidden";
+      }>;
+      archivedAt: z$1.ZodNullable<z$1.ZodNumber>;
+      pinnedAt: z$1.ZodNullable<z$1.ZodNumber>;
+      deletedAt: z$1.ZodNullable<z$1.ZodNumber>;
+      lastReadAt: z$1.ZodNullable<z$1.ZodNumber>;
+      latestAttentionAt: z$1.ZodNumber;
+      createdAt: z$1.ZodNumber;
+      updatedAt: z$1.ZodNumber;
+      runtime: z$1.ZodObject<
+        {
+          displayStatus: z$1.ZodEnum<{
+            error: "error";
+            provisioning: "provisioning";
+            stopping: "stopping";
+            idle: "idle";
+            starting: "starting";
+            active: "active";
+            "host-reconnecting": "host-reconnecting";
+            "waiting-for-host": "waiting-for-host";
+          }>;
+          hostReconnectGraceExpiresAt: z$1.ZodNullable<z$1.ZodNumber>;
+        },
+        z$1.core.$strip
+      >;
+      activity: z$1.ZodObject<
+        {
+          activeWorkflowCount: z$1.ZodNumber;
+          activeBackgroundAgentCount: z$1.ZodNumber;
+          activeBackgroundCommandCount: z$1.ZodNumber;
+          activePlanModeCount: z$1.ZodNumber;
+          activeGoalCount: z$1.ZodNumber;
+        },
+        z$1.core.$strip
+      >;
+      pinSortKey: z$1.ZodNullable<z$1.ZodString>;
+      hasPendingInteraction: z$1.ZodBoolean;
+      environmentHostId: z$1.ZodNullable<z$1.ZodString>;
+      environmentName: z$1.ZodNullable<z$1.ZodString>;
+      environmentBranchName: z$1.ZodNullable<z$1.ZodString>;
+      environmentWorkspaceDisplayKind: z$1.ZodEnum<{
+        "managed-worktree": "managed-worktree";
+        "unmanaged-worktree": "unmanaged-worktree";
+        other: "other";
+      }>;
+    },
+    z$1.core.$strip
+  >
+>;
+type ThreadListResponse = z$1.infer<typeof threadListResponseSchema>;
+declare const threadSearchResponseSchema: z$1.ZodObject<
+  {
+    active: z$1.ZodObject<
+      {
+        total: z$1.ZodNumber;
+        results: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              thread: z$1.ZodObject<
+                {
+                  id: z$1.ZodString;
+                  projectId: z$1.ZodString;
+                  environmentId: z$1.ZodNullable<z$1.ZodString>;
+                  providerId: z$1.ZodString;
+                  title: z$1.ZodNullable<z$1.ZodString>;
+                  titleFallback: z$1.ZodNullable<z$1.ZodString>;
+                  sectionId: z$1.ZodNullable<z$1.ZodString>;
+                  status: z$1.ZodEnum<{
+                    error: "error";
+                    stopping: "stopping";
+                    idle: "idle";
+                    starting: "starting";
+                    active: "active";
+                  }>;
+                  parentThreadId: z$1.ZodNullable<z$1.ZodString>;
+                  sourceThreadId: z$1.ZodNullable<z$1.ZodString>;
+                  originKind: z$1.ZodNullable<
+                    z$1.ZodEnum<{
+                      fork: "fork";
+                    }>
+                  >;
+                  childOrigin: z$1.ZodNullable<
+                    z$1.ZodEnum<{
+                      fork: "fork";
+                    }>
+                  >;
+                  originPluginId: z$1.ZodNullable<z$1.ZodString>;
+                  visibility: z$1.ZodEnum<{
+                    visible: "visible";
+                    hidden: "hidden";
+                  }>;
+                  archivedAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  pinnedAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  deletedAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  lastReadAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  latestAttentionAt: z$1.ZodNumber;
+                  createdAt: z$1.ZodNumber;
+                  updatedAt: z$1.ZodNumber;
+                  runtime: z$1.ZodObject<
+                    {
+                      displayStatus: z$1.ZodEnum<{
+                        error: "error";
+                        provisioning: "provisioning";
+                        stopping: "stopping";
+                        idle: "idle";
+                        starting: "starting";
+                        active: "active";
+                        "host-reconnecting": "host-reconnecting";
+                        "waiting-for-host": "waiting-for-host";
+                      }>;
+                      hostReconnectGraceExpiresAt: z$1.ZodNullable<z$1.ZodNumber>;
+                    },
+                    z$1.core.$strip
+                  >;
+                  activity: z$1.ZodObject<
+                    {
+                      activeWorkflowCount: z$1.ZodNumber;
+                      activeBackgroundAgentCount: z$1.ZodNumber;
+                      activeBackgroundCommandCount: z$1.ZodNumber;
+                      activePlanModeCount: z$1.ZodNumber;
+                      activeGoalCount: z$1.ZodNumber;
+                    },
+                    z$1.core.$strip
+                  >;
+                  pinSortKey: z$1.ZodNullable<z$1.ZodString>;
+                  hasPendingInteraction: z$1.ZodBoolean;
+                  environmentHostId: z$1.ZodNullable<z$1.ZodString>;
+                  environmentName: z$1.ZodNullable<z$1.ZodString>;
+                  environmentBranchName: z$1.ZodNullable<z$1.ZodString>;
+                  environmentWorkspaceDisplayKind: z$1.ZodEnum<{
+                    "managed-worktree": "managed-worktree";
+                    "unmanaged-worktree": "unmanaged-worktree";
+                    other: "other";
+                  }>;
+                },
+                z$1.core.$strip
+              >;
+              matches: z$1.ZodArray<
+                z$1.ZodObject<
+                  {
+                    sourceKind: z$1.ZodEnum<{
+                      title: "title";
+                      title_fallback: "title_fallback";
+                      user_message: "user_message";
+                      assistant_message: "assistant_message";
+                      system_message: "system_message";
+                    }>;
+                    text: z$1.ZodString;
+                    highlightRanges: z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          start: z$1.ZodNumber;
+                          end: z$1.ZodNumber;
+                        },
+                        z$1.core.$strict
+                      >
+                    >;
+                    sourceSeq: z$1.ZodNullable<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >;
+    archived: z$1.ZodObject<
+      {
+        total: z$1.ZodNumber;
+        results: z$1.ZodArray<
+          z$1.ZodObject<
+            {
+              thread: z$1.ZodObject<
+                {
+                  id: z$1.ZodString;
+                  projectId: z$1.ZodString;
+                  environmentId: z$1.ZodNullable<z$1.ZodString>;
+                  providerId: z$1.ZodString;
+                  title: z$1.ZodNullable<z$1.ZodString>;
+                  titleFallback: z$1.ZodNullable<z$1.ZodString>;
+                  sectionId: z$1.ZodNullable<z$1.ZodString>;
+                  status: z$1.ZodEnum<{
+                    error: "error";
+                    stopping: "stopping";
+                    idle: "idle";
+                    starting: "starting";
+                    active: "active";
+                  }>;
+                  parentThreadId: z$1.ZodNullable<z$1.ZodString>;
+                  sourceThreadId: z$1.ZodNullable<z$1.ZodString>;
+                  originKind: z$1.ZodNullable<
+                    z$1.ZodEnum<{
+                      fork: "fork";
+                    }>
+                  >;
+                  childOrigin: z$1.ZodNullable<
+                    z$1.ZodEnum<{
+                      fork: "fork";
+                    }>
+                  >;
+                  originPluginId: z$1.ZodNullable<z$1.ZodString>;
+                  visibility: z$1.ZodEnum<{
+                    visible: "visible";
+                    hidden: "hidden";
+                  }>;
+                  archivedAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  pinnedAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  deletedAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  lastReadAt: z$1.ZodNullable<z$1.ZodNumber>;
+                  latestAttentionAt: z$1.ZodNumber;
+                  createdAt: z$1.ZodNumber;
+                  updatedAt: z$1.ZodNumber;
+                  runtime: z$1.ZodObject<
+                    {
+                      displayStatus: z$1.ZodEnum<{
+                        error: "error";
+                        provisioning: "provisioning";
+                        stopping: "stopping";
+                        idle: "idle";
+                        starting: "starting";
+                        active: "active";
+                        "host-reconnecting": "host-reconnecting";
+                        "waiting-for-host": "waiting-for-host";
+                      }>;
+                      hostReconnectGraceExpiresAt: z$1.ZodNullable<z$1.ZodNumber>;
+                    },
+                    z$1.core.$strip
+                  >;
+                  activity: z$1.ZodObject<
+                    {
+                      activeWorkflowCount: z$1.ZodNumber;
+                      activeBackgroundAgentCount: z$1.ZodNumber;
+                      activeBackgroundCommandCount: z$1.ZodNumber;
+                      activePlanModeCount: z$1.ZodNumber;
+                      activeGoalCount: z$1.ZodNumber;
+                    },
+                    z$1.core.$strip
+                  >;
+                  pinSortKey: z$1.ZodNullable<z$1.ZodString>;
+                  hasPendingInteraction: z$1.ZodBoolean;
+                  environmentHostId: z$1.ZodNullable<z$1.ZodString>;
+                  environmentName: z$1.ZodNullable<z$1.ZodString>;
+                  environmentBranchName: z$1.ZodNullable<z$1.ZodString>;
+                  environmentWorkspaceDisplayKind: z$1.ZodEnum<{
+                    "managed-worktree": "managed-worktree";
+                    "unmanaged-worktree": "unmanaged-worktree";
+                    other: "other";
+                  }>;
+                },
+                z$1.core.$strip
+              >;
+              matches: z$1.ZodArray<
+                z$1.ZodObject<
+                  {
+                    sourceKind: z$1.ZodEnum<{
+                      title: "title";
+                      title_fallback: "title_fallback";
+                      user_message: "user_message";
+                      assistant_message: "assistant_message";
+                      system_message: "system_message";
+                    }>;
+                    text: z$1.ZodString;
+                    highlightRanges: z$1.ZodArray<
+                      z$1.ZodObject<
+                        {
+                          start: z$1.ZodNumber;
+                          end: z$1.ZodNumber;
+                        },
+                        z$1.core.$strict
+                      >
+                    >;
+                    sourceSeq: z$1.ZodNullable<z$1.ZodNumber>;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >;
+  },
+  z$1.core.$strict
+>;
+type ThreadSearchResponse = z$1.infer<typeof threadSearchResponseSchema>;
+declare const threadResponseSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    projectId: z$1.ZodString;
+    environmentId: z$1.ZodNullable<z$1.ZodString>;
+    providerId: z$1.ZodString;
+    title: z$1.ZodNullable<z$1.ZodString>;
+    titleFallback: z$1.ZodNullable<z$1.ZodString>;
+    sectionId: z$1.ZodNullable<z$1.ZodString>;
+    status: z$1.ZodEnum<{
+      error: "error";
+      stopping: "stopping";
+      idle: "idle";
+      starting: "starting";
+      active: "active";
+    }>;
+    parentThreadId: z$1.ZodNullable<z$1.ZodString>;
+    sourceThreadId: z$1.ZodNullable<z$1.ZodString>;
+    originKind: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        fork: "fork";
+      }>
+    >;
+    childOrigin: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        fork: "fork";
+      }>
+    >;
+    originPluginId: z$1.ZodNullable<z$1.ZodString>;
+    visibility: z$1.ZodEnum<{
+      visible: "visible";
+      hidden: "hidden";
+    }>;
+    archivedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    pinnedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    deletedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    lastReadAt: z$1.ZodNullable<z$1.ZodNumber>;
+    latestAttentionAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    runtime: z$1.ZodObject<
+      {
+        displayStatus: z$1.ZodEnum<{
+          error: "error";
+          provisioning: "provisioning";
+          stopping: "stopping";
+          idle: "idle";
+          starting: "starting";
+          active: "active";
+          "host-reconnecting": "host-reconnecting";
+          "waiting-for-host": "waiting-for-host";
+        }>;
+        hostReconnectGraceExpiresAt: z$1.ZodNullable<z$1.ZodNumber>;
+      },
+      z$1.core.$strip
+    >;
+    canSpawnChild: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type ThreadResponse = z$1.infer<typeof threadResponseSchema>;
+declare const threadGetQuerySchema: z$1.ZodObject<
+  {
+    include: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ThreadGetQuery = z$1.infer<typeof threadGetQuerySchema>;
+declare const threadWithIncludesResponseSchema: z$1.ZodObject<
+  {
+    id: z$1.ZodString;
+    projectId: z$1.ZodString;
+    environmentId: z$1.ZodNullable<z$1.ZodString>;
+    providerId: z$1.ZodString;
+    title: z$1.ZodNullable<z$1.ZodString>;
+    titleFallback: z$1.ZodNullable<z$1.ZodString>;
+    sectionId: z$1.ZodNullable<z$1.ZodString>;
+    status: z$1.ZodEnum<{
+      error: "error";
+      stopping: "stopping";
+      idle: "idle";
+      starting: "starting";
+      active: "active";
+    }>;
+    parentThreadId: z$1.ZodNullable<z$1.ZodString>;
+    sourceThreadId: z$1.ZodNullable<z$1.ZodString>;
+    originKind: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        fork: "fork";
+      }>
+    >;
+    childOrigin: z$1.ZodNullable<
+      z$1.ZodEnum<{
+        fork: "fork";
+      }>
+    >;
+    originPluginId: z$1.ZodNullable<z$1.ZodString>;
+    visibility: z$1.ZodEnum<{
+      visible: "visible";
+      hidden: "hidden";
+    }>;
+    archivedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    pinnedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    deletedAt: z$1.ZodNullable<z$1.ZodNumber>;
+    lastReadAt: z$1.ZodNullable<z$1.ZodNumber>;
+    latestAttentionAt: z$1.ZodNumber;
+    createdAt: z$1.ZodNumber;
+    updatedAt: z$1.ZodNumber;
+    runtime: z$1.ZodObject<
+      {
+        displayStatus: z$1.ZodEnum<{
+          error: "error";
+          provisioning: "provisioning";
+          stopping: "stopping";
+          idle: "idle";
+          starting: "starting";
+          active: "active";
+          "host-reconnecting": "host-reconnecting";
+          "waiting-for-host": "waiting-for-host";
+        }>;
+        hostReconnectGraceExpiresAt: z$1.ZodNullable<z$1.ZodNumber>;
+      },
+      z$1.core.$strip
+    >;
+    canSpawnChild: z$1.ZodBoolean;
+    environment: z$1.ZodOptional<
+      z$1.ZodNullable<
+        z$1.ZodObject<
+          {
+            id: z$1.ZodString;
+            name: z$1.ZodNullable<z$1.ZodString>;
+            projectId: z$1.ZodString;
+            hostId: z$1.ZodString;
+            path: z$1.ZodNullable<z$1.ZodString>;
+            managed: z$1.ZodBoolean;
+            isGitRepo: z$1.ZodBoolean;
+            isWorktree: z$1.ZodBoolean;
+            workspaceProvisionType: z$1.ZodEnum<{
+              unmanaged: "unmanaged";
+              "managed-worktree": "managed-worktree";
+              personal: "personal";
+            }>;
+            branchName: z$1.ZodNullable<z$1.ZodString>;
+            baseBranch: z$1.ZodNullable<z$1.ZodString>;
+            defaultBranch: z$1.ZodNullable<z$1.ZodString>;
+            mergeBaseBranch: z$1.ZodNullable<z$1.ZodString>;
+            status: z$1.ZodEnum<{
+              error: "error";
+              provisioning: "provisioning";
+              ready: "ready";
+              retiring: "retiring";
+              destroying: "destroying";
+              destroyed: "destroyed";
+            }>;
+            createdAt: z$1.ZodNumber;
+            updatedAt: z$1.ZodNumber;
+          },
+          z$1.core.$strip
+        >
+      >
+    >;
+    host: z$1.ZodOptional<
+      z$1.ZodNullable<
+        z$1.ZodObject<
+          {
+            id: z$1.ZodString;
+            name: z$1.ZodString;
+            type: z$1.ZodEnum<{
+              persistent: "persistent";
+            }>;
+            status: z$1.ZodEnum<{
+              disconnected: "disconnected";
+              connected: "connected";
+            }>;
+            maxPermissionMode: z$1.ZodEnum<{
+              auto: "auto";
+              "accept-edits": "accept-edits";
+              full: "full";
+            }>;
+            lastSeenAt: z$1.ZodNullable<z$1.ZodNumber>;
+            lastRejectedProtocolVersion: z$1.ZodNullable<z$1.ZodNumber>;
+            createdAt: z$1.ZodNumber;
+            updatedAt: z$1.ZodNumber;
+          },
+          z$1.core.$strip
+        >
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ThreadWithIncludesResponse = z$1.infer<
+  typeof threadWithIncludesResponseSchema
+>;
+declare const threadPendingInteractionsResponseSchema: z$1.ZodArray<
+  z$1.ZodUnion<
+    readonly [
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          threadId: z$1.ZodString;
+          status: z$1.ZodEnum<{
+            pending: "pending";
+            interrupted: "interrupted";
+            resolving: "resolving";
+            resolved: "resolved";
+          }>;
+          statusReason: z$1.ZodNullable<z$1.ZodString>;
+          createdAt: z$1.ZodNumber;
+          expiresAt: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodNumber>>;
+          resolvedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          turnId: z$1.ZodString;
+          providerId: z$1.ZodString;
+          providerThreadId: z$1.ZodString;
+          providerRequestId: z$1.ZodString;
+          origin: z$1.ZodOptional<
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"provider">;
+                providerId: z$1.ZodString;
+                providerThreadId: z$1.ZodString;
+                providerRequestId: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >
+          >;
+          payload: z$1.ZodUnion<
+            readonly [
+              z$1.ZodObject<
+                {
+                  kind: z$1.ZodLiteral<"approval">;
+                  subject: z$1.ZodDiscriminatedUnion<
+                    [
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"command">;
+                          itemId: z$1.ZodString;
+                          command: z$1.ZodString;
+                          cwd: z$1.ZodNullable<z$1.ZodString>;
+                          actions: z$1.ZodArray<
+                            z$1.ZodDiscriminatedUnion<
+                              [
+                                z$1.ZodObject<
+                                  {
+                                    type: z$1.ZodLiteral<"read">;
+                                    command: z$1.ZodString;
+                                    name: z$1.ZodString;
+                                    path: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    type: z$1.ZodLiteral<"listFiles">;
+                                    command: z$1.ZodString;
+                                    path: z$1.ZodNullable<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    type: z$1.ZodLiteral<"search">;
+                                    command: z$1.ZodString;
+                                    query: z$1.ZodNullable<z$1.ZodString>;
+                                    path: z$1.ZodNullable<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                                z$1.ZodObject<
+                                  {
+                                    type: z$1.ZodLiteral<"unknown">;
+                                    command: z$1.ZodString;
+                                  },
+                                  z$1.core.$strip
+                                >,
+                              ],
+                              "type"
+                            >
+                          >;
+                          sessionGrant: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                network: z$1.ZodNullable<
+                                  z$1.ZodObject<
+                                    {
+                                      enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                    },
+                                    z$1.core.$strip
+                                  >
+                                >;
+                                fileSystem: z$1.ZodNullable<
+                                  z$1.ZodObject<
+                                    {
+                                      read: z$1.ZodArray<z$1.ZodString>;
+                                      write: z$1.ZodArray<z$1.ZodString>;
+                                    },
+                                    z$1.core.$strip
+                                  >
+                                >;
+                              },
+                              z$1.core.$strict
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"file_change">;
+                          itemId: z$1.ZodString;
+                          writeScope: z$1.ZodNullable<z$1.ZodString>;
+                          sessionGrant: z$1.ZodNullable<
+                            z$1.ZodObject<
+                              {
+                                network: z$1.ZodNullable<
+                                  z$1.ZodObject<
+                                    {
+                                      enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                    },
+                                    z$1.core.$strip
+                                  >
+                                >;
+                                fileSystem: z$1.ZodNullable<
+                                  z$1.ZodObject<
+                                    {
+                                      read: z$1.ZodArray<z$1.ZodString>;
+                                      write: z$1.ZodArray<z$1.ZodString>;
+                                    },
+                                    z$1.core.$strip
+                                  >
+                                >;
+                              },
+                              z$1.core.$strict
+                            >
+                          >;
+                        },
+                        z$1.core.$strip
+                      >,
+                      z$1.ZodObject<
+                        {
+                          kind: z$1.ZodLiteral<"permission_grant">;
+                          itemId: z$1.ZodString;
+                          toolName: z$1.ZodNullable<z$1.ZodString>;
+                          permissions: z$1.ZodObject<
+                            {
+                              network: z$1.ZodNullable<
+                                z$1.ZodObject<
+                                  {
+                                    enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              fileSystem: z$1.ZodNullable<
+                                z$1.ZodObject<
+                                  {
+                                    read: z$1.ZodArray<z$1.ZodString>;
+                                    write: z$1.ZodArray<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strict
+                          >;
+                        },
+                        z$1.core.$strip
+                      >,
+                    ],
+                    "kind"
+                  >;
+                  reason: z$1.ZodNullable<z$1.ZodString>;
+                  availableDecisions: z$1.ZodArray<
+                    z$1.ZodEnum<{
+                      allow_once: "allow_once";
+                      allow_for_session: "allow_for_session";
+                      deny: "deny";
+                    }>
+                  >;
+                },
+                z$1.core.$strip
+              >,
+              z$1.ZodObject<
+                {
+                  kind: z$1.ZodLiteral<"user_question">;
+                  questions: z$1.ZodArray<
+                    z$1.ZodObject<
+                      {
+                        id: z$1.ZodString;
+                        prompt: z$1.ZodString;
+                        shortLabel: z$1.ZodOptional<z$1.ZodString>;
+                        multiSelect: z$1.ZodBoolean;
+                        options: z$1.ZodOptional<
+                          z$1.ZodArray<
+                            z$1.ZodObject<
+                              {
+                                value: z$1.ZodString;
+                                label: z$1.ZodString;
+                                description: z$1.ZodOptional<z$1.ZodString>;
+                              },
+                              z$1.core.$strip
+                            >
+                          >
+                        >;
+                        allowFreeText: z$1.ZodBoolean;
+                      },
+                      z$1.core.$strip
+                    >
+                  >;
+                },
+                z$1.core.$strip
+              >,
+            ]
+          >;
+          resolution: z$1.ZodNullable<
+            z$1.ZodUnion<
+              readonly [
+                z$1.ZodDiscriminatedUnion<
+                  [
+                    z$1.ZodObject<
+                      {
+                        decision: z$1.ZodLiteral<"allow_once">;
+                        grantedPermissions: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              network: z$1.ZodNullable<
+                                z$1.ZodObject<
+                                  {
+                                    enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              fileSystem: z$1.ZodNullable<
+                                z$1.ZodObject<
+                                  {
+                                    read: z$1.ZodArray<z$1.ZodString>;
+                                    write: z$1.ZodArray<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strict
+                          >
+                        >;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        decision: z$1.ZodLiteral<"allow_for_session">;
+                        grantedPermissions: z$1.ZodNullable<
+                          z$1.ZodObject<
+                            {
+                              network: z$1.ZodNullable<
+                                z$1.ZodObject<
+                                  {
+                                    enabled: z$1.ZodNullable<z$1.ZodBoolean>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                              fileSystem: z$1.ZodNullable<
+                                z$1.ZodObject<
+                                  {
+                                    read: z$1.ZodArray<z$1.ZodString>;
+                                    write: z$1.ZodArray<z$1.ZodString>;
+                                  },
+                                  z$1.core.$strip
+                                >
+                              >;
+                            },
+                            z$1.core.$strict
+                          >
+                        >;
+                      },
+                      z$1.core.$strip
+                    >,
+                    z$1.ZodObject<
+                      {
+                        decision: z$1.ZodLiteral<"deny">;
+                      },
+                      z$1.core.$strip
+                    >,
+                  ],
+                  "decision"
+                >,
+                z$1.ZodObject<
+                  {
+                    kind: z$1.ZodLiteral<"user_answer">;
+                    answers: z$1.ZodRecord<
+                      z$1.ZodString,
+                      z$1.ZodObject<
+                        {
+                          selected: z$1.ZodArray<z$1.ZodString>;
+                          freeText: z$1.ZodOptional<z$1.ZodString>;
+                        },
+                        z$1.core.$strip
+                      >
+                    >;
+                  },
+                  z$1.core.$strip
+                >,
+              ]
+            >
+          >;
+        },
+        z$1.core.$strip
+      >,
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          threadId: z$1.ZodString;
+          status: z$1.ZodEnum<{
+            pending: "pending";
+            interrupted: "interrupted";
+            resolving: "resolving";
+            resolved: "resolved";
+          }>;
+          statusReason: z$1.ZodNullable<z$1.ZodString>;
+          createdAt: z$1.ZodNumber;
+          expiresAt: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodNumber>>;
+          resolvedAt: z$1.ZodNullable<z$1.ZodNumber>;
+          turnId: z$1.ZodNullable<z$1.ZodString>;
+          origin: z$1.ZodObject<
+            {
+              kind: z$1.ZodLiteral<"plugin">;
+              pluginId: z$1.ZodString;
+              rendererId: z$1.ZodString;
+            },
+            z$1.core.$strip
+          >;
+          payload: z$1.ZodObject<
+            {
+              kind: z$1.ZodLiteral<"plugin">;
+              title: z$1.ZodString;
+              data: z$1.ZodType<
+                JsonValue$1,
+                unknown,
+                z$1.core.$ZodTypeInternals<JsonValue$1, unknown>
+              >;
+            },
+            z$1.core.$strip
+          >;
+          resolution: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                kind: z$1.ZodLiteral<"plugin_submitted">;
+              },
+              z$1.core.$strip
+            >
+          >;
+        },
+        z$1.core.$strip
+      >,
+    ]
+  >
+>;
+type ThreadPendingInteractionsResponse = z$1.infer<
+  typeof threadPendingInteractionsResponseSchema
+>;
+declare const threadQueuedMessageListResponseSchema: z$1.ZodArray<
+  z$1.ZodObject<
+    {
+      id: z$1.ZodString;
+      content: z$1.ZodArray<
+        z$1.ZodDiscriminatedUnion<
+          [
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"text">;
+                text: z$1.ZodString;
+                mentions: z$1.ZodDefault<
+                  z$1.ZodArray<
+                    z$1.ZodObject<
+                      {
+                        start: z$1.ZodNumber;
+                        end: z$1.ZodNumber;
+                        resource: z$1.ZodPipe<
+                          z$1.ZodTransform<unknown, unknown>,
+                          z$1.ZodDiscriminatedUnion<
+                            [
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"thread">;
+                                  threadId: z$1.ZodString;
+                                  projectId: z$1.ZodOptional<z$1.ZodString>;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"project">;
+                                  projectId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"section">;
+                                  sectionId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"path">;
+                                  source: z$1.ZodEnum<{
+                                    workspace: "workspace";
+                                    "thread-storage": "thread-storage";
+                                  }>;
+                                  entryKind: z$1.ZodEnum<{
+                                    file: "file";
+                                    directory: "directory";
+                                  }>;
+                                  path: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"command">;
+                                  trigger: z$1.ZodEnum<{
+                                    "/": "/";
+                                  }>;
+                                  name: z$1.ZodString;
+                                  source: z$1.ZodEnum<{
+                                    command: "command";
+                                    skill: "skill";
+                                  }>;
+                                  origin: z$1.ZodEnum<{
+                                    user: "user";
+                                    project: "project";
+                                    builtin: "builtin";
+                                  }>;
+                                  label: z$1.ZodString;
+                                  argumentHint: z$1.ZodNullable<z$1.ZodString>;
+                                },
+                                z$1.core.$strip
+                              >,
+                              z$1.ZodObject<
+                                {
+                                  kind: z$1.ZodLiteral<"plugin">;
+                                  pluginId: z$1.ZodString;
+                                  icon: z$1.ZodOptional<
+                                    z$1.ZodNullable<z$1.ZodString>
+                                  >;
+                                  itemId: z$1.ZodString;
+                                  label: z$1.ZodString;
+                                },
+                                z$1.core.$strip
+                              >,
+                            ],
+                            "kind"
+                          >
+                        >;
+                      },
+                      z$1.core.$strip
+                    >
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"image">;
+                url: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"localImage">;
+                path: z$1.ZodString;
+              },
+              z$1.core.$strip
+            >,
+            z$1.ZodObject<
+              {
+                visibility: z$1.ZodOptional<
+                  z$1.ZodEnum<{
+                    "agent-only": "agent-only";
+                  }>
+                >;
+                type: z$1.ZodLiteral<"localFile">;
+                path: z$1.ZodString;
+                name: z$1.ZodOptional<z$1.ZodString>;
+                sizeBytes: z$1.ZodOptional<z$1.ZodNumber>;
+                mimeType: z$1.ZodOptional<z$1.ZodString>;
+              },
+              z$1.core.$strip
+            >,
+          ],
+          "type"
+        >
+      >;
+      model: z$1.ZodString;
+      reasoningLevel: z$1.ZodEnum<{
+        none: "none";
+        low: "low";
+        medium: "medium";
+        high: "high";
+        xhigh: "xhigh";
+        ultracode: "ultracode";
+        max: "max";
+        ultra: "ultra";
+      }>;
+      permissionMode: z$1.ZodEnum<{
+        auto: "auto";
+        "accept-edits": "accept-edits";
+        full: "full";
+      }>;
+      serviceTier: z$1.ZodEnum<{
+        default: "default";
+        fast: "fast";
+      }>;
+      groupWithNext: z$1.ZodBoolean;
+      createdAt: z$1.ZodNumber;
+      updatedAt: z$1.ZodNumber;
+    },
+    z$1.core.$strip
+  >
+>;
+type ThreadQueuedMessageListResponse = z$1.infer<
+  typeof threadQueuedMessageListResponseSchema
+>;
+declare const threadChildSummaryResponseSchema: z$1.ZodObject<
+  {
+    nonDeletedChildCount: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type ThreadChildSummaryResponse = z$1.infer<
+  typeof threadChildSummaryResponseSchema
+>;
+declare const deleteThreadRequestSchema: z$1.ZodObject<
+  {
+    childThreadsConfirmed: z$1.ZodBoolean;
+  },
+  z$1.core.$strip
+>;
+type DeleteThreadRequest = z$1.infer<typeof deleteThreadRequestSchema>;
+declare const updateThreadRequestSchema: z$1.ZodObject<
+  {
+    title: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+    sectionId: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+    parentThreadId: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+    model: z$1.ZodOptional<z$1.ZodNullable<z$1.ZodString>>;
+    reasoningLevel: z$1.ZodOptional<
+      z$1.ZodNullable<
+        z$1.ZodEnum<{
+          none: "none";
+          low: "low";
+          medium: "medium";
+          high: "high";
+          xhigh: "xhigh";
+          ultracode: "ultracode";
+          max: "max";
+          ultra: "ultra";
+        }>
+      >
+    >;
+    visibility: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        visible: "visible";
+        hidden: "hidden";
+      }>
+    >;
+  },
+  z$1.core.$strip
+>;
+type UpdateThreadRequest = z$1.infer<typeof updateThreadRequestSchema>;
+declare const reorderPinnedThreadRequestSchema: z$1.ZodObject<
+  {
+    previousThreadId: z$1.ZodNullable<z$1.ZodString>;
+    nextThreadId: z$1.ZodNullable<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ReorderPinnedThreadRequest = z$1.infer<
+  typeof reorderPinnedThreadRequestSchema
+>;
+/**
+ * Requested placement for a thread opened in the app's split layout. Edge
+ * placements add panes through the eighth pane; at the cap they replace the
+ * focused pane. `replace` always replaces the focused pane.
+ */
+declare const threadOpenSplitSchema: z$1.ZodEnum<{
+  right: "right";
+  down: "down";
+  left: "left";
+  top: "top";
+  replace: "replace";
+}>;
+type ThreadOpenSplit = z$1.infer<typeof threadOpenSplitSchema>;
+/** Optional secondary-panel file to open with a thread. */
+declare const threadOpenFileSchema: z$1.ZodObject<
+  {
+    source: z$1.ZodEnum<{
+      workspace: "workspace";
+      "thread-storage": "thread-storage";
+    }>;
+    path: z$1.ZodString;
+    lineNumber: z$1.ZodNullable<z$1.ZodNumber>;
+  },
+  z$1.core.$strict
+>;
+type ThreadOpenFile = z$1.infer<typeof threadOpenFileSchema>;
+/** Response for POST /threads/:id/open: how many connected clients received it. */
+declare const threadOpenResponseSchema: z$1.ZodObject<
+  {
+    delivered: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type ThreadOpenResponse = z$1.infer<typeof threadOpenResponseSchema>;
+/** Presentation action for one thread pane in each connected app window. */
+declare const threadPaneActionSchema: z$1.ZodEnum<{
+  maximize: "maximize";
+  restore: "restore";
+  toggle: "toggle";
+}>;
+type ThreadPaneAction = z$1.infer<typeof threadPaneActionSchema>;
+/** Number of connected app clients that received the pane action. */
+declare const threadPaneActionResponseSchema: z$1.ZodObject<
+  {
+    delivered: z$1.ZodNumber;
+  },
+  z$1.core.$strip
+>;
+type ThreadPaneActionResponse = z$1.infer<
+  typeof threadPaneActionResponseSchema
+>;
+declare const threadArchiveAllResponseSchema: z$1.ZodObject<
+  {
+    ok: z$1.ZodLiteral<true>;
+    archivedThreadIds: z$1.ZodArray<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ThreadArchiveAllResponse = z$1.infer<
+  typeof threadArchiveAllResponseSchema
+>;
+declare const threadListQuerySchema: z$1.ZodObject<
+  {
+    projectId: z$1.ZodOptional<z$1.ZodString>;
+    parentThreadId: z$1.ZodOptional<z$1.ZodString>;
+    sourceThreadId: z$1.ZodOptional<z$1.ZodString>;
+    archived: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+    sectionId: z$1.ZodOptional<z$1.ZodString>;
+    unsectioned: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+    hasParent: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+    originKind: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        fork: "fork";
+      }>
+    >;
+    originPluginId: z$1.ZodOptional<z$1.ZodString>;
+    childOrigin: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        fork: "fork";
+      }>
+    >;
+    includeHidden: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+    limit: z$1.ZodOptional<z$1.ZodString>;
+    offset: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ThreadListQuery = z$1.infer<typeof threadListQuerySchema>;
+declare const threadSearchQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodString;
+    limitPerGroup: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ThreadSearchQuery = z$1.infer<typeof threadSearchQuerySchema>;
+declare const threadTimelineQuerySchema: z$1.ZodObject<
+  {
+    includeNestedRows: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+    segmentLimit: z$1.ZodOptional<z$1.ZodString>;
+    beforeAnchorSeq: z$1.ZodOptional<z$1.ZodString>;
+    beforeAnchorId: z$1.ZodOptional<z$1.ZodString>;
+    summaryOnly: z$1.ZodOptional<
+      z$1.ZodEnum<{
+        true: "true";
+        false: "false";
+      }>
+    >;
+    afterSequence: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ThreadTimelineQuery = z$1.infer<typeof threadTimelineQuerySchema>;
+declare const timelineTurnSummaryDetailsQuerySchema: z$1.ZodObject<
+  {
+    turnId: z$1.ZodString;
+    sourceSeqStart: z$1.ZodString;
+    sourceSeqEnd: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type TimelineTurnSummaryDetailsQuery = z$1.infer<
+  typeof timelineTurnSummaryDetailsQuerySchema
+>;
+declare const threadStorageFilesQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodString>;
+    limit: z$1.ZodOptional<z$1.ZodString>;
+  },
+  z$1.core.$strip
+>;
+type ThreadStorageFilesQuery = z$1.infer<typeof threadStorageFilesQuerySchema>;
+declare const threadStoragePathsQuerySchema: z$1.ZodObject<
+  {
+    query: z$1.ZodOptional<z$1.ZodString>;
+    limit: z$1.ZodOptional<z$1.ZodString>;
+    includeFiles: z$1.ZodEnum<{
+      true: "true";
+      false: "false";
+    }>;
+    includeDirectories: z$1.ZodEnum<{
+      true: "true";
+      false: "false";
+    }>;
+  },
+  z$1.core.$strip
+>;
+type ThreadStoragePathsQuery = z$1.infer<typeof threadStoragePathsQuerySchema>;
+declare const timelineTurnSummaryDetailsResponseSchema: z$1.ZodObject<
+  {
+    rows: z$1.ZodArray<
+      z$1.ZodType<
+        TimelineRow,
+        unknown,
+        z$1.core.$ZodTypeInternals<TimelineRow, unknown>
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type TimelineTurnSummaryDetailsResponse = z$1.infer<
+  typeof timelineTurnSummaryDetailsResponseSchema
+>;
+declare const threadTimelineResponseSchema: z$1.ZodObject<
+  {
+    rows: z$1.ZodArray<
+      z$1.ZodType<
+        TimelineRow,
+        unknown,
+        z$1.core.$ZodTypeInternals<TimelineRow, unknown>
+      >
+    >;
+    activePromptMode: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          mode: z$1.ZodLiteral<"plan">;
+          providerId: z$1.ZodEnum<{
+            "claude-code": "claude-code";
+            codex: "codex";
+          }>;
+          prompt: z$1.ZodString;
+        },
+        z$1.core.$strict
+      >
+    >;
+    activeThinking: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          text: z$1.ZodString;
+          startedAt: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+        },
+        z$1.core.$strip
+      >
+    >;
+    activeWorkflows: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          threadId: z$1.ZodString;
+          turnId: z$1.ZodNullable<z$1.ZodString>;
+          sourceSeqStart: z$1.ZodNumber;
+          sourceSeqEnd: z$1.ZodNumber;
+          startedAt: z$1.ZodNumber;
+          createdAt: z$1.ZodNumber;
+          kind: z$1.ZodLiteral<"work">;
+          status: z$1.ZodEnum<{
+            error: "error";
+            pending: "pending";
+            completed: "completed";
+            interrupted: "interrupted";
+          }>;
+          workKind: z$1.ZodLiteral<"workflow">;
+          itemId: z$1.ZodString;
+          taskType: z$1.ZodString;
+          workflowName: z$1.ZodNullable<z$1.ZodString>;
+          description: z$1.ZodString;
+          taskStatus: z$1.ZodEnum<{
+            pending: "pending";
+            completed: "completed";
+            running: "running";
+            paused: "paused";
+            failed: "failed";
+            killed: "killed";
+            stopped: "stopped";
+          }>;
+          workflow: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                phases: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      index: z$1.ZodNumber;
+                      title: z$1.ZodString;
+                      kind: z$1.ZodOptional<z$1.ZodString>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+                agents: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      index: z$1.ZodNumber;
+                      label: z$1.ZodString;
+                      state: z$1.ZodEnum<{
+                        running: "running";
+                        failed: "failed";
+                        queued: "queued";
+                        done: "done";
+                        skipped: "skipped";
+                      }>;
+                      model: z$1.ZodString;
+                      attempt: z$1.ZodNumber;
+                      cached: z$1.ZodBoolean;
+                      lastProgressAt: z$1.ZodNumber;
+                      phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                      phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                      agentType: z$1.ZodOptional<z$1.ZodString>;
+                      isolation: z$1.ZodOptional<z$1.ZodString>;
+                      queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                      startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                      lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                      lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                      promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                      resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                      error: z$1.ZodOptional<z$1.ZodString>;
+                      tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                      toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                      durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >
+          >;
+          usage: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                totalTokens: z$1.ZodNumber;
+                toolUses: z$1.ZodNumber;
+                durationMs: z$1.ZodNumber;
+              },
+              z$1.core.$strip
+            >
+          >;
+          summary: z$1.ZodNullable<z$1.ZodString>;
+          error: z$1.ZodNullable<z$1.ZodString>;
+          completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    activeBackgroundCommands: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          threadId: z$1.ZodString;
+          turnId: z$1.ZodNullable<z$1.ZodString>;
+          sourceSeqStart: z$1.ZodNumber;
+          sourceSeqEnd: z$1.ZodNumber;
+          startedAt: z$1.ZodNumber;
+          createdAt: z$1.ZodNumber;
+          kind: z$1.ZodLiteral<"work">;
+          status: z$1.ZodEnum<{
+            error: "error";
+            pending: "pending";
+            completed: "completed";
+            interrupted: "interrupted";
+          }>;
+          workKind: z$1.ZodLiteral<"workflow">;
+          itemId: z$1.ZodString;
+          taskType: z$1.ZodString;
+          workflowName: z$1.ZodNullable<z$1.ZodString>;
+          description: z$1.ZodString;
+          taskStatus: z$1.ZodEnum<{
+            pending: "pending";
+            completed: "completed";
+            running: "running";
+            paused: "paused";
+            failed: "failed";
+            killed: "killed";
+            stopped: "stopped";
+          }>;
+          workflow: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                phases: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      index: z$1.ZodNumber;
+                      title: z$1.ZodString;
+                      kind: z$1.ZodOptional<z$1.ZodString>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+                agents: z$1.ZodArray<
+                  z$1.ZodObject<
+                    {
+                      index: z$1.ZodNumber;
+                      label: z$1.ZodString;
+                      state: z$1.ZodEnum<{
+                        running: "running";
+                        failed: "failed";
+                        queued: "queued";
+                        done: "done";
+                        skipped: "skipped";
+                      }>;
+                      model: z$1.ZodString;
+                      attempt: z$1.ZodNumber;
+                      cached: z$1.ZodBoolean;
+                      lastProgressAt: z$1.ZodNumber;
+                      phaseIndex: z$1.ZodOptional<z$1.ZodNumber>;
+                      phaseTitle: z$1.ZodOptional<z$1.ZodString>;
+                      agentType: z$1.ZodOptional<z$1.ZodString>;
+                      isolation: z$1.ZodOptional<z$1.ZodString>;
+                      queuedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                      startedAt: z$1.ZodOptional<z$1.ZodNumber>;
+                      lastToolName: z$1.ZodOptional<z$1.ZodString>;
+                      lastToolSummary: z$1.ZodOptional<z$1.ZodString>;
+                      promptPreview: z$1.ZodOptional<z$1.ZodString>;
+                      resultPreview: z$1.ZodOptional<z$1.ZodString>;
+                      error: z$1.ZodOptional<z$1.ZodString>;
+                      tokens: z$1.ZodOptional<z$1.ZodNumber>;
+                      toolCalls: z$1.ZodOptional<z$1.ZodNumber>;
+                      durationMs: z$1.ZodOptional<z$1.ZodNumber>;
+                    },
+                    z$1.core.$strip
+                  >
+                >;
+              },
+              z$1.core.$strip
+            >
+          >;
+          usage: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                totalTokens: z$1.ZodNumber;
+                toolUses: z$1.ZodNumber;
+                durationMs: z$1.ZodNumber;
+              },
+              z$1.core.$strip
+            >
+          >;
+          summary: z$1.ZodNullable<z$1.ZodString>;
+          error: z$1.ZodNullable<z$1.ZodString>;
+          completedAt: z$1.ZodNullable<z$1.ZodNumber>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    pendingTodos: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          sourceSeq: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+          items: z$1.ZodArray<
+            z$1.ZodObject<
+              {
+                id: z$1.ZodString;
+                text: z$1.ZodString;
+                status: z$1.ZodEnum<{
+                  pending: "pending";
+                  completed: "completed";
+                  in_progress: "in_progress";
+                }>;
+              },
+              z$1.core.$strip
+            >
+          >;
+        },
+        z$1.core.$strip
+      >
+    >;
+    goal: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          sourceSeq: z$1.ZodNumber;
+          updatedAt: z$1.ZodNumber;
+          objective: z$1.ZodString;
+          status: z$1.ZodEnum<{
+            active: "active";
+            paused: "paused";
+            budgetLimited: "budgetLimited";
+            complete: "complete";
+          }>;
+          tokenBudget: z$1.ZodNullable<z$1.ZodNumber>;
+          tokensUsed: z$1.ZodNumber;
+          timeUsedSeconds: z$1.ZodNumber;
+        },
+        z$1.core.$strip
+      >
+    >;
+    modelFallback: z$1.ZodNullable<
+      z$1.ZodObject<
+        {
+          sourceSeq: z$1.ZodNumber;
+          detectedAt: z$1.ZodNumber;
+          originalModel: z$1.ZodString;
+          fallbackModel: z$1.ZodString;
+          reason: z$1.ZodEnum<{
+            refusal: "refusal";
+            provider: "provider";
+          }>;
+          message: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    contextWindowUsage: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          usedTokens: z$1.ZodNumber;
+          modelContextWindow: z$1.ZodNumber;
+          estimated: z$1.ZodBoolean;
+        },
+        z$1.core.$strip
+      >
+    >;
+    timelinePage: z$1.ZodObject<
+      {
+        kind: z$1.ZodEnum<{
+          latest: "latest";
+          older: "older";
+        }>;
+        segmentLimit: z$1.ZodNumber;
+        returnedSegmentCount: z$1.ZodNumber;
+        hasOlderRows: z$1.ZodBoolean;
+        olderCursor: z$1.ZodNullable<
+          z$1.ZodObject<
+            {
+              anchorSeq: z$1.ZodNumber;
+              anchorId: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >
+        >;
+      },
+      z$1.core.$strict
+    >;
+    maxSeq: z$1.ZodNumber;
+    delta: z$1.ZodOptional<
+      z$1.ZodObject<
+        {
+          upsertRows: z$1.ZodArray<
+            z$1.ZodType<
+              TimelineRow,
+              unknown,
+              z$1.core.$ZodTypeInternals<TimelineRow, unknown>
+            >
+          >;
+          rowOrder: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+        },
+        z$1.core.$strip
+      >
+    >;
+  },
+  z$1.core.$strip
+>;
+type ThreadTimelineResponse = z$1.infer<typeof threadTimelineResponseSchema>;
+declare const threadConversationOutlineResponseSchema: z$1.ZodObject<
+  {
+    items: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          id: z$1.ZodString;
+          role: z$1.ZodEnum<{
+            user: "user";
+            assistant: "assistant";
+          }>;
+          preview: z$1.ZodString;
+          attachmentSummary: z$1.ZodNullable<
+            z$1.ZodObject<
+              {
+                imageCount: z$1.ZodNumber;
+                fileCount: z$1.ZodNumber;
+              },
+              z$1.core.$strict
+            >
+          >;
+        },
+        z$1.core.$strict
+      >
+    >;
+    maxSeq: z$1.ZodNumber;
+  },
+  z$1.core.$strict
+>;
+type ThreadConversationOutlineResponse = z$1.infer<
+  typeof threadConversationOutlineResponseSchema
+>;
+declare const threadStorageFileListResponseSchema: z$1.ZodObject<
+  {
+    files: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          path: z$1.ZodString;
+          name: z$1.ZodString;
+        },
+        z$1.core.$strip
+      >
+    >;
+    truncated: z$1.ZodBoolean;
+    storageRootPath: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type ThreadStorageFileListResponse = z$1.infer<
+  typeof threadStorageFileListResponseSchema
+>;
+declare const threadStoragePathListResponseSchema: z$1.ZodObject<
+  {
+    paths: z$1.ZodArray<
+      z$1.ZodObject<
+        {
+          kind: z$1.ZodEnum<{
+            file: "file";
+            directory: "directory";
+          }>;
+          path: z$1.ZodString;
+          name: z$1.ZodString;
+          score: z$1.ZodNumber;
+          positions: z$1.ZodArray<z$1.ZodNumber>;
+        },
+        z$1.core.$strip
+      >
+    >;
+    truncated: z$1.ZodBoolean;
+    storageRootPath: z$1.ZodString;
+  },
+  z$1.core.$strip
+>;
+type ThreadStoragePathListResponse = z$1.infer<
+  typeof threadStoragePathListResponseSchema
+>;
+
+declare const threadTabsResponseSchema: z$1.ZodObject<
+  {
+    revision: z$1.ZodNumber;
+    tabs: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"thread-info">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"git-diff">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              actionId: z$1.ZodString;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"plugin-panel">;
+              paramsJson: z$1.ZodNullable<z$1.ZodString>;
+              pluginId: z$1.ZodString;
+              title: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"workspace-file-preview">;
+              lineRange: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    endLineNumber: z$1.ZodNumber;
+                    startLineNumber: z$1.ZodNumber;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              path: z$1.ZodString;
+              projectId: z$1.ZodNullable<z$1.ZodString>;
+              source: z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"working-tree">;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"head">;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"merge-base">;
+                      ref: z$1.ZodString;
+                    },
+                    z$1.core.$strict
+                  >,
+                ],
+                "kind"
+              >;
+              statusLabel: z$1.ZodNullable<z$1.ZodLiteral<"deleted">>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"host-file-preview">;
+              lineRange: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    endLineNumber: z$1.ZodNumber;
+                    startLineNumber: z$1.ZodNumber;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              path: z$1.ZodString;
+              threadId: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              isPinned: z$1.ZodBoolean;
+              kind: z$1.ZodLiteral<"thread-storage-file-preview">;
+              lineRange: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    endLineNumber: z$1.ZodNumber;
+                    startLineNumber: z$1.ZodNumber;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              path: z$1.ZodString;
+              threadId: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"browser">;
+              title: z$1.ZodNullable<z$1.ZodString>;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"new-tab">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"side-chat">;
+              sourceMessageText: z$1.ZodString;
+              sourceSeqEnd: z$1.ZodNullable<z$1.ZodNumber>;
+              threadId: z$1.ZodNullable<z$1.ZodString>;
+              title: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"terminal">;
+              terminalId: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+        ],
+        "kind"
+      >
+    >;
+  },
+  z$1.core.$strict
+>;
+type ThreadTabsResponse = z$1.infer<typeof threadTabsResponseSchema>;
+declare const updateThreadTabsRequestSchema: z$1.ZodObject<
+  {
+    expectedRevision: z$1.ZodNumber;
+    tabs: z$1.ZodArray<
+      z$1.ZodDiscriminatedUnion<
+        [
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"thread-info">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"git-diff">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              actionId: z$1.ZodString;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"plugin-panel">;
+              paramsJson: z$1.ZodNullable<z$1.ZodString>;
+              pluginId: z$1.ZodString;
+              title: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"workspace-file-preview">;
+              lineRange: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    endLineNumber: z$1.ZodNumber;
+                    startLineNumber: z$1.ZodNumber;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              path: z$1.ZodString;
+              projectId: z$1.ZodNullable<z$1.ZodString>;
+              source: z$1.ZodDiscriminatedUnion<
+                [
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"working-tree">;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"head">;
+                    },
+                    z$1.core.$strict
+                  >,
+                  z$1.ZodObject<
+                    {
+                      kind: z$1.ZodLiteral<"merge-base">;
+                      ref: z$1.ZodString;
+                    },
+                    z$1.core.$strict
+                  >,
+                ],
+                "kind"
+              >;
+              statusLabel: z$1.ZodNullable<z$1.ZodLiteral<"deleted">>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"host-file-preview">;
+              lineRange: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    endLineNumber: z$1.ZodNumber;
+                    startLineNumber: z$1.ZodNumber;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              path: z$1.ZodString;
+              threadId: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              isPinned: z$1.ZodBoolean;
+              kind: z$1.ZodLiteral<"thread-storage-file-preview">;
+              lineRange: z$1.ZodNullable<
+                z$1.ZodObject<
+                  {
+                    endLineNumber: z$1.ZodNumber;
+                    startLineNumber: z$1.ZodNumber;
+                  },
+                  z$1.core.$strict
+                >
+              >;
+              path: z$1.ZodString;
+              threadId: z$1.ZodNullable<z$1.ZodString>;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              environmentId: z$1.ZodNullable<z$1.ZodString>;
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"browser">;
+              title: z$1.ZodNullable<z$1.ZodString>;
+              url: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"new-tab">;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"side-chat">;
+              sourceMessageText: z$1.ZodString;
+              sourceSeqEnd: z$1.ZodNullable<z$1.ZodNumber>;
+              threadId: z$1.ZodNullable<z$1.ZodString>;
+              title: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+          z$1.ZodObject<
+            {
+              id: z$1.ZodString;
+              kind: z$1.ZodLiteral<"terminal">;
+              terminalId: z$1.ZodString;
+            },
+            z$1.core.$strict
+          >,
+        ],
+        "kind"
+      >
+    >;
+  },
+  z$1.core.$strict
+>;
+type UpdateThreadTabsRequest = z$1.infer<typeof updateThreadTabsRequestSchema>;
+
+/**
+ * A value that survives a JSON round trip without coercion or data loss.
+ *
+ * Host boundaries still validate values at runtime because TypeScript cannot
+ * exclude non-finite numbers and plugin bundles can bypass static types.
+ */
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | {
+      [key: string]: JsonValue;
+    };
+
+/** A JSON-safe path segment reported by a Standard Schema validation issue. */
+type PluginRpcIssuePathSegment = string | number;
+/** Validator-neutral validation detail carried by an RPC error envelope. */
+interface PluginRpcValidationIssue {
+  message: string;
+  path?: PluginRpcIssuePathSegment[];
+}
+/** Stable wire error categories for plugin RPC. */
+type PluginRpcErrorCode =
+  | "invalid_json"
+  | "invalid_input"
+  | "handler_error"
+  | "invalid_output"
+  | "non_json_result"
+  | "unknown_method";
+/** Structured RPC failure returned as `{ ok: false, error }`. */
+interface PluginRpcError {
+  code: PluginRpcErrorCode;
+  message: string;
+  issues?: PluginRpcValidationIssue[];
+}
+/**
+ * The validator-neutral subset of Standard Schema v1 used by plugin RPC.
+ * Zod 4 schemas implement this interface directly; other validators can do
+ * the same without becoming part of BB's public protocol.
+ */
+interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: unknown
+    ) =>
+      | StandardSchemaV1Result<Output>
+      | Promise<StandardSchemaV1Result<Output>>;
+    readonly types?: {
+      readonly input: Input;
+      readonly output: Output;
+    };
+  };
+}
+type StandardSchemaV1Result<Output> =
+  | {
+      readonly value: Output;
+      readonly issues?: undefined;
+    }
+  | {
+      readonly issues: readonly StandardSchemaV1Issue[];
+    };
+interface StandardSchemaV1Issue {
+  readonly message: string;
+  readonly path?:
+    | PropertyKey
+    | readonly (
+        | PropertyKey
+        | {
+            readonly key: PropertyKey;
+          }
+      )[];
+}
+type StandardSchemaV1InferInput<Schema extends StandardSchemaV1> = NonNullable<
+  Schema["~standard"]["types"]
+>["input"];
+type StandardSchemaV1InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+  Schema["~standard"]["types"]
+>["output"];
+interface PluginRpcMethodContract<
+  InputSchema extends StandardSchemaV1 = StandardSchemaV1,
+  OutputSchema extends StandardSchemaV1 = StandardSchemaV1,
+> {
+  readonly input: InputSchema;
+  readonly output: OutputSchema;
+}
+type PluginRpcContract = Readonly<Record<string, PluginRpcMethodContract>>;
+/** Define a shared RPC contract while preserving exact method/schema types. */
+declare function defineRpcContract<const Contract extends PluginRpcContract>(
+  contract: Contract
+): Contract;
+type PluginRpcHandlers<Contract extends PluginRpcContract> = {
+  [Method in keyof Contract]: (
+    input: StandardSchemaV1InferOutput<Contract[Method]["input"]>
+  ) =>
+    | StandardSchemaV1InferInput<Contract[Method]["output"]>
+    | Promise<StandardSchemaV1InferInput<Contract[Method]["output"]>>;
+};
+type PluginRpcCallInput<Method extends PluginRpcMethodContract> =
+  StandardSchemaV1InferInput<Method["input"]>;
+type PluginRpcCallArgs<Method extends PluginRpcMethodContract> =
+  null extends PluginRpcCallInput<Method>
+    ? [input?: PluginRpcCallInput<Method>]
+    : [input: PluginRpcCallInput<Method>];
+type PluginRpcResult<Method extends PluginRpcMethodContract> =
+  StandardSchemaV1InferOutput<Method["output"]>;
+
+/**
+ * The `@bb/plugin-sdk/app` contract (plugin design §5.2) — pure types with no
+ * side effects. The BB app imports these to keep its real implementation in
+ * sync (`satisfies PluginSdkApp`). Plugin authors import the same shapes through
+ * `@bb/plugin-sdk/app`.
+ *
+ * Per-slot props are versioned contracts: additive-only within an SDK major.
+ */
+/** Props passed to a `homepageSection` component. */
+interface PluginHomepageSectionProps {
+  /** Project in view on the compose surface; null when none is selected. */
+  projectId: string | null;
+}
+/**
+ * Props passed to a `settingsSection` component.
+ *
+ * Deliberately empty in V1; versioned additive like the other slot props.
+ */
+interface PluginSettingsSectionProps {}
+/** Props passed to a `navPanel` component (it owns its whole route). */
+interface PluginNavPanelProps {
+  /**
+   * The route remainder after the panel root, "" at the root. The panel's
+   * route is `/plugins/<pluginId>/<path>/*`, so a deep link like
+   * `/plugins/notes/notes/work/ideas.md` renders the panel with
+   * `subPath: "work/ideas.md"`. Navigate within the panel via
+   * `useBbNavigate().toPluginPanel(path, { subPath })` — browser
+   * back/forward then walks panel-internal history.
+   */
+  subPath: string;
+}
+/** Props passed to a panel tab opened by a `threadPanelAction`. */
+interface PluginThreadPanelProps {
+  threadId: string;
+  /**
+   * The JSON value the action's `openPanel` call passed (round-tripped
+   * through persistence, so the tab restores across reloads); null when the
+   * action opened the panel without params.
+   */
+  params: JsonValue | null;
+}
+interface PluginPendingInteractionView {
+  id: string;
+  threadId: string;
+  title: string;
+  payload: JsonValue;
+  createdAt: number;
+  expiresAt: number | null;
+}
+interface PluginPendingInteractionProps {
+  interaction: PluginPendingInteractionView;
+  submit(value: JsonValue): Promise<void>;
+  cancel(): Promise<void>;
+}
+/**
+ * Props for a `sidebarFooterAction` — host-rendered (no plugin component).
+ * Deliberately empty; the registration's `run` carries the behavior.
+ */
+interface PluginSidebarFooterActionProps {}
+/**
+ * Props passed to an `experimental_threadList` component — the sidebar's
+ * scrolling thread area, replaced wholesale by one plugin.
+ */
+interface PluginThreadListProps {
+  /** The thread the route currently shows; null on non-thread routes. */
+  activeThreadId: string | null;
+  /** The project the route currently shows; null when none is selected. */
+  activeProjectId: string | null;
+  /** True on phone-width viewports and coarse pointers. */
+  isCompactViewport: boolean;
+  /**
+   * Call after the user opens a thread. Closes the mobile sidebar drawer and
+   * is a no-op on desktop, so always call it.
+   */
+  onNavigate: () => void;
+  /**
+   * The host search field's current text, or "" when the field is closed.
+   * The host owns that field, so a plugin list filters by this rather than
+   * shipping a second search box.
+   */
+  searchQuery: string;
+}
+/**
+ * Props passed to an `experimental_threadHeaderAction` component, rendered in
+ * the thread header's action row.
+ */
+interface PluginThreadHeaderActionProps {
+  /**
+   * The thread this header belongs to. Never null: the slot is not rendered
+   * on the compose screen or other non-thread routes. A split layout renders
+   * one header per pane, so the component mounts once per visible thread,
+   * each with its own id — keep per-thread state in the component, never in a
+   * module-level singleton.
+   */
+  threadId: string;
+  projectId: string;
+  /**
+   * True on phone-width viewports and coarse pointers. Collapse to an
+   * icon-sized control when it is true — the row is short.
+   */
+  isCompactViewport: boolean;
+}
+/**
+ * Where a file being opened by a `fileOpener` lives. `path` semantics follow
+ * the source: workspace paths are relative to the environment's worktree,
+ * thread-storage paths are relative to the thread's storage root, host paths
+ * are absolute on the thread's host.
+ */
+interface PluginFileOpenerSource {
+  kind: "workspace" | "host" | "thread-storage";
+  threadId: string | null;
+  environmentId: string | null;
+  projectId: string | null;
+}
+/** Props passed to a `fileOpener` component (rendered as a panel file tab). */
+interface PluginFileOpenerProps {
+  path: string;
+  source: PluginFileOpenerSource;
+}
+/**
+ * Message context passed to a `messageDirective` component — the assistant
+ * (or nested agent) message that contained the directive.
+ */
+interface PluginMessageDirectiveMessage {
+  id: string;
+  threadId: string;
+  turnId: string | null;
+  projectId: string | null;
+}
+/**
+ * Open a worktree-relative file in the host's workspace file viewer. Returns
+ * true when the host accepted the path; false when the path is invalid or the
+ * viewer declined it.
+ */
+type PluginMessageDirectiveOpenWorkspaceFile = (path: string) => boolean;
+/**
+ * Props passed to a `messageDirective` component. Attributes are untrusted
+ * strings parsed from the directive; the plugin validates its own fields.
+ */
+interface PluginMessageDirectiveProps {
+  /** Parsed, untrusted directive attributes (e.g. `{ file: "demo.html" }`). */
+  attributes: Readonly<Record<string, string>>;
+  /** Original directive source text (useful for diagnostics / crash fallback). */
+  source: string;
+  message: PluginMessageDirectiveMessage;
+  /**
+   * Opens a worktree-relative file in the host's workspace file viewer. Null
+   * when the message surface has no workspace viewer available.
+   */
+  openWorkspaceFile: PluginMessageDirectiveOpenWorkspaceFile | null;
+}
+interface PluginHomepageSectionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  title: string;
+  component: ComponentType<PluginHomepageSectionProps>;
+}
+interface PluginSettingsSectionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Optional host-rendered section heading. */
+  title?: string;
+  /**
+   * Optional one-line host-rendered subheading under `title`, in the built-in
+   * SettingsSection idiom (ignored when `title` is absent).
+   */
+  description?: string;
+  component: ComponentType<PluginSettingsSectionProps>;
+}
+interface PluginNavPanelRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  title: string;
+  /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
+  icon: string;
+  /** URL segment under `/plugins/<pluginId>/`; letters, digits, `-`, `_`. */
+  path: string;
+  component: ComponentType<PluginNavPanelProps>;
+  /**
+   * Optional component rendered on the right side of the shared title bar
+   * (e.g. a sync button or a count). Contained separately from the body: a
+   * throwing headerContent is hidden without breaking the title bar.
+   */
+  headerContent?: ComponentType<PluginNavPanelProps>;
+}
+/** Context handed to a `threadPanelAction`'s `run`. */
+interface PluginThreadPanelActionContext {
+  /** The thread whose panel launcher invoked the action. */
+  threadId: string;
+  /**
+   * Open a tab in the thread's side panel rendering this action's
+   * `component`. `title` labels the tab (default: the action's `title`);
+   * `params` must be JSON-serializable — it is persisted with the tab and
+   * reaches the component as its `params` prop. Opening with params
+   * identical to an already-open tab of this action focuses that tab
+   * (updating its title) instead of duplicating it. May be called more than
+   * once (different params ⇒ multiple tabs) or not at all.
+   */
+  openPanel(options?: { title?: string; params?: JsonValue }): void;
+}
+interface PluginThreadPanelActionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Label of the action row in the panel's new-tab launcher. */
+  title: string;
+  /**
+   * Icon hint (BB icon name) used when the plugin ships no logo; the
+   * launcher row and opened tabs prefer the plugin's logo.
+   */
+  icon?: string;
+  /** Rendered inside every panel tab this action opens. */
+  component: ComponentType<PluginThreadPanelProps>;
+  /**
+   * How the host frames the tab content. "padded" (default) wraps the
+   * component in the panel's scroll container with standard padding —
+   * right for document-like content. "flush" gives the component the full
+   * tab area (no padding, definite height, no host scrolling) — right for
+   * app-like content that manages its own layout, such as
+   * `ThreadChat`.
+   */
+  layout?: "padded" | "flush";
+  /**
+   * Runs when the user activates the action: call your RPC methods, show a
+   * toast, and/or open panel tabs via `context.openPanel`. Omitted =
+   * immediately open a panel tab with defaults. Errors (sync or async) are
+   * contained and logged; they never break the launcher.
+   */
+  run?(context: PluginThreadPanelActionContext): void | Promise<void>;
+}
+interface PluginPendingInteractionRegistration {
+  /** Matches `rendererId` passed to `bb.ui.requestInput`. */
+  id: string;
+  component: ComponentType<PluginPendingInteractionProps>;
+}
+/** Context handed to a `sidebarFooterAction`'s `run`. */
+interface PluginSidebarFooterActionContext {
+  /**
+   * Navigate to this plugin's detail page in Tools, where declarative settings
+   * and `settingsSection` slots render.
+   */
+  openSettings(): void;
+}
+/**
+ * An icon button in the app sidebar footer (next to Settings / bug report).
+ * Host-rendered for consistent chrome — plugins supply icon, label, and
+ * `run` behavior only.
+ */
+interface PluginSidebarFooterActionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Tooltip and accessible label for the icon button. */
+  title: string;
+  /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
+  icon: string;
+  /**
+   * Runs when the user activates the action (e.g. call `openSettings()`,
+   * open a panel via other surfaces, toast). Errors (sync or async) are
+   * contained and logged; they never break the sidebar.
+   */
+  run(context: PluginSidebarFooterActionContext): void | Promise<void>;
+}
+/**
+ * The one status bb would paint for a thread, already resolved through the
+ * host's precedence (attention before work; plan and goal before the generic
+ * spinner). Draw your own glyph for it — the SDK ships no status component.
+ *
+ * Treat an unrecognized value as "none": bb adds kinds over time, and an
+ * older plugin must degrade to drawing nothing rather than throwing.
+ *
+ * "draft" and "working-draft" are never reported here: an unsubmitted composer
+ * draft is per-client state the host reads per row, which an array-wide view
+ * cannot. A thread holding a draft reports whatever it would report without
+ * one.
+ */
+type PluginSidebarThreadIndicator =
+  | "unread-error"
+  | "waiting-for-input"
+  | "working-draft"
+  | "workflow"
+  | "background-agent"
+  | "background-command"
+  | "plan-mode"
+  | "goal"
+  | "runtime"
+  | "draft"
+  | "unread-success"
+  | "none";
+/**
+ * How a thread's environment presents its workspace: a worktree bb manages,
+ * a worktree the user manages, or anything else (a plain checkout).
+ */
+type PluginSidebarWorkspaceKind =
+  | "managed-worktree"
+  | "unmanaged-worktree"
+  | "other";
+/** Live work counts on a thread. All zero means nothing is running. */
+interface PluginSidebarThreadActivity {
+  workflows: number;
+  backgroundAgents: number;
+  backgroundCommands: number;
+  planMode: number;
+  goals: number;
+}
+/**
+ * One thread in the sidebar's live view.
+ *
+ * A deliberate copy of the fields a sidebar needs — not a re-export of the
+ * host's internal thread row type, which changes whenever the app needs a
+ * field. Timestamps are epoch milliseconds.
+ */
+interface PluginSidebarThread {
+  id: string;
+  projectId: string;
+  /** Null while a thread is still unnamed; pair with `titleFallback`. */
+  title: string | null;
+  titleFallback: string | null;
+  /** The thread this one was forked from or spawned under; null at the root. */
+  parentThreadId: string | null;
+  sectionId: string | null;
+  /** How this thread came to exist under its parent; null for root threads. */
+  originKind: "fork" | "side-chat" | null;
+  /** The plugin that spawned it, or null for non-plugin origins. */
+  originPluginId: string | null;
+  /** The agent provider this thread runs on, e.g. "codex", "claude-code". */
+  providerId: string;
+  /** The agent is blocked on the user: an approval or a question. */
+  hasPendingInteraction: boolean;
+  activity: PluginSidebarThreadActivity;
+  indicator: PluginSidebarThreadIndicator;
+  /**
+   * The host's accessible label for `indicator`, e.g. "Thread needs user
+   * input"; null when the indicator is "none". Use it for `aria-label` so
+   * screen-reader text stays consistent across sidebars.
+   */
+  indicatorLabel: string | null;
+  isUnread: boolean;
+  isPinned: boolean;
+  isArchived: boolean;
+  environment: {
+    id: string | null;
+    name: string | null;
+    branchName: string | null;
+    workspaceDisplayKind: PluginSidebarWorkspaceKind;
+  } | null;
+  /**
+   * The machine this thread's work runs on, with the name resolved for you.
+   * Null when the thread has no environment yet, or when its host is not in
+   * the known-hosts list. Useful where a thread has no branch to show — a
+   * personal-project thread has a machine but no worktree.
+   */
+  host: {
+    id: string;
+    name: string;
+  } | null;
+  createdAt: number;
+  updatedAt: number;
+  lastReadAt: number | null;
+  latestAttentionAt: number;
+}
+/**
+ * The pull request for a thread's branch, narrowed to what a sidebar row
+ * needs. `attention` is bb's rolled-up "does this need you" signal, so a row
+ * can colour a badge without reading checks, review, and mergeability itself.
+ */
+interface PluginSidebarPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  state: "draft" | "open" | "merged" | "closed";
+  attention:
+    | "checks_failed"
+    | "checks_pending"
+    | "changes_requested"
+    | "review_requested"
+    | "conflicts"
+    | "blocked"
+    | "draft"
+    | "ready_to_merge"
+    | "merged"
+    | "closed"
+    | "none";
+}
+interface PluginSidebarThreadPullRequestState {
+  /** True while the first lookup for this thread's environment is in flight. */
+  isLoading: boolean;
+  /**
+   * The pull request, or null when the branch has none, the thread has no
+   * environment, or the lookup could not run (a git-host hiccup). A row should
+   * treat null as "nothing to show", never as an error.
+   */
+  pullRequest: PluginSidebarPullRequest | null;
+}
+/** One project in the sidebar's live view. */
+interface PluginSidebarProject {
+  id: string;
+  name: string;
+  /** True for the implicit personal project. */
+  isPersonal: boolean;
+}
+interface PluginSidebarThreadsState {
+  status: "loading" | "ready" | "error";
+  threads: readonly PluginSidebarThread[];
+  projects: readonly PluginSidebarProject[];
+}
+/**
+ * Act on threads from a plugin surface. Every method routes to the host's own
+ * flow, so optimistic updates, toasts, dialogs, pane closing, and route repair
+ * behave exactly as they do in the built-in sidebar. Unknown thread ids are
+ * ignored by `open` and rejected by the rest.
+ */
+interface PluginSidebarThreadActions {
+  /**
+   * Navigate to a thread. `split: true` applies bb's split placement rules —
+   * a right split by default, focus when the thread is already open, replace
+   * at the pane cap — and falls back to plain navigation where splits are off.
+   */
+  open(
+    threadId: string,
+    options?: {
+      split?: boolean;
+    }
+  ): void;
+  /**
+   * Go to the new-thread screen. Passing `projectId` also makes that project
+   * the composer's selection, so the thread is created where you asked.
+   */
+  openNewThread(options?: { projectId?: string; focusPrompt?: boolean }): void;
+  setPinned(threadId: string, pinned: boolean): Promise<void>;
+  setRead(threadId: string, read: boolean): Promise<void>;
+  /** Silent rename — no dialog. For inline editing in your own row. */
+  rename(threadId: string, title: string): Promise<void>;
+  /** Archives the thread AND its children, closing any panes showing them. */
+  archive(threadId: string): void;
+  /**
+   * Opens bb's delete confirmation, which counts child threads first. Deletion
+   * is destructive and recursive, so the host owns the confirmation: there is
+   * deliberately no silent `delete`.
+   */
+  requestDelete(threadId: string): void;
+}
+/**
+ * Render a plugin component in the thread header's action row.
+ *
+ * The frontend sibling of the backend `bb.ui.registerThreadAction`, which
+ * renders a host-owned button and runs server-side. Use that one for "do a
+ * thing"; use this one when the control must draw live state.
+ *
+ * The host places it at the left end of the action row, before the workspace
+ * button, git actions, the panel toggle, maximize, and close. That row is a
+ * 48px chrome row with 28px controls: render one inline control that fits, and
+ * put anything taller in a portalled popover.
+ */
+interface PluginThreadHeaderActionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /**
+   * Names the region the host wraps around your component (a labelled group).
+   * It does NOT label your control: an icon-only button still needs its own
+   * accessible name.
+   */
+  title: string;
+  component: ComponentType<PluginThreadHeaderActionProps>;
+}
+/** One pane's place in the split layout, as fractions of the split area. */
+interface PluginSidebarSplitPane {
+  paneId: string;
+  rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  /** This pane holds the thread the row represents. */
+  isMe: boolean;
+  isFocused: boolean;
+}
+/**
+ * Drag-to-split support for one row, plus where that thread currently sits in
+ * the split layout.
+ */
+interface PluginSidebarThreadSplit {
+  /**
+   * Spread onto the row's interactive element. Carries the pointer handler
+   * that starts a split drag; empty when splits are unavailable, so spreading
+   * it is always safe.
+   *
+   * The host owns every rule: the gesture engages only once the pointer leaves
+   * the sidebar toward the main area (so a list with its own drag-to-reorder
+   * keeps working), an edge drop splits, a center drop replaces, an
+   * already-open thread focuses its pane, and the pane cap coerces a split
+   * into a replace.
+   */
+  splitProps: {
+    onPointerDown?: (event: react.PointerEvent<HTMLElement>) => void;
+  };
+  /**
+   * False on compact viewports, when the user disabled splits, and for an
+   * unknown thread id. Gate any "open in split" affordance you draw on it.
+   */
+  isAvailable: boolean;
+  /**
+   * Where this thread sits in the split layout, or null when it is not open in
+   * one (including single-pane layouts). Draw a mini-map, a tint, or nothing.
+   */
+  layout: {
+    panes: readonly PluginSidebarSplitPane[];
+  } | null;
+}
+/**
+ * Replace the sidebar's thread list with a plugin component.
+ *
+ * Unlike every other slot, this one is EXCLUSIVE: two lists cannot share one
+ * scroll area. The built-in list stays the default; the user picks a provider
+ * in Settings → Appearance, stored per client. A provider that is uninstalled,
+ * disabled, or crashing falls back to the built-in list rather than leaving
+ * the user with no sidebar.
+ *
+ * The plugin gets the scrolling list and nothing else. The New-thread button,
+ * the search field, the plugin nav rows, and the footer stay host-rendered in
+ * every sidebar — they are shared surfaces (other plugins live in two of
+ * them), and a replaced list must not be able to remove them.
+ */
+interface PluginThreadListRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Label in the Settings → Appearance → Sidebar picker. */
+  title: string;
+  /** Optional one-line description under the title in that picker. */
+  description?: string;
+  component: ComponentType<PluginThreadListProps>;
+}
+/**
+ * Register this plugin as a viewer/editor for file extensions. The user
+ * picks (and can set as default) an opener per extension via the file tab's
+ * "Open with" menu; matching files opened in the panel then render
+ * `component` in a plugin tab instead of the built-in preview. Applies to
+ * working-tree, host, and thread-storage files — never to git-ref snapshots
+ * (diff views always use the built-in preview). The built-in preview stays
+ * one menu click away, and a missing/disabled opener falls back to it.
+ */
+interface PluginFileOpenerRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Label in the "Open with" menu (e.g. "Notes editor"). */
+  title: string;
+  /** Lowercase extensions without the dot (e.g. ["md", "mdx"]). */
+  extensions: readonly string[];
+  component: ComponentType<PluginFileOpenerProps>;
+}
+/**
+ * Register a leaf message directive rendered inside assistant (and nested
+ * agent) message Markdown. `id` is the directive name: `inline-vis` matches
+ * `::inline-vis{file="demo.html"}`.
+ */
+interface PluginMessageDirectiveRegistration {
+  /**
+   * The directive name. Lowercase kebab-case beginning with a letter.
+   */
+  id: string;
+  component: ComponentType<PluginMessageDirectiveProps>;
+}
+/**
+ * A narrow, stable reference to one rendered chat message — NOT an internal
+ * timeline row. `sourceSeqEnd` is the last source event sequence the message
+ * covers, the anchor the server accepts for provider-history forks.
+ */
+interface ThreadChatMessageReference {
+  id: string;
+  threadId: string;
+  role: "user" | "assistant";
+  /** Visible text of the message. */
+  text: string;
+  sourceSeqEnd: number;
+}
+interface PluginMessageActionThreadPanelOptions {
+  /** A `threadPanelAction` id registered by this same plugin. */
+  actionId: string;
+  title?: string;
+  params?: JsonValue;
+}
+/** Context handed to a `messageAction`'s `run`. */
+interface PluginMessageActionContext {
+  /** The thread whose timeline surfaced the action. */
+  threadId: string;
+  message: ThreadChatMessageReference;
+  /**
+   * Present only when the action was invoked from the text-selection menu;
+   * the exact text the user highlighted inside `message`.
+   */
+  selectedText?: string;
+  /**
+   * Open one of this plugin's `threadPanelAction` components in the current
+   * thread's side panel — the registration-callback equivalent of
+   * `useBbNavigate().openThreadPanel`. Returns true when the host
+   * accepted (the action id exists and the surface has a panel); false
+   * otherwise.
+   */
+  openPanel(options: PluginMessageActionThreadPanelOptions): boolean;
+}
+/**
+ * An action on chat messages: an icon button in the per-message action bar
+ * (user and assistant messages) and an entry in the assistant-message
+ * text-selection menu. Host-rendered chrome — the plugin supplies title,
+ * icon hint, and `run` behavior only.
+ */
+interface PluginMessageActionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Tooltip / menu label for the action. */
+  title: string;
+  /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
+  icon?: string;
+  /**
+   * Runs when the user activates the action. Errors (sync or async) are
+   * contained and logged; they never break the timeline.
+   */
+  run(context: PluginMessageActionContext): void | Promise<void>;
+}
+interface PluginAppSlots {
+  homepageSection(registration: PluginHomepageSectionRegistration): void;
+  settingsSection(registration: PluginSettingsSectionRegistration): void;
+  navPanel(registration: PluginNavPanelRegistration): void;
+  threadPanelAction(registration: PluginThreadPanelActionRegistration): void;
+  pendingInteraction(registration: PluginPendingInteractionRegistration): void;
+  sidebarFooterAction(
+    registration: PluginSidebarFooterActionRegistration
+  ): void;
+  /**
+   * Replace the sidebar's thread list (see
+   * {@link PluginThreadListRegistration}). Experimental: see
+   * docs/api_to_audit.md for what to audit before the prefix drops.
+   */
+  experimental_threadList(registration: PluginThreadListRegistration): void;
+  /**
+   * Render a component in the thread header's action row (see
+   * {@link PluginThreadHeaderActionRegistration}). Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_threadHeaderAction(
+    registration: PluginThreadHeaderActionRegistration
+  ): void;
+  fileOpener(registration: PluginFileOpenerRegistration): void;
+  messageDirective(registration: PluginMessageDirectiveRegistration): void;
+  messageAction(registration: PluginMessageActionRegistration): void;
+}
+interface PluginAppComposer {
+  customize(registration: ComposerCustomization): void;
+}
+/** Stable lifecycle values for one content-script instance in one bb client. */
+interface PluginContentScriptContext {
+  /** The id of the plugin that owns this script. */
+  readonly pluginId: string;
+  /** Monotonic per-client generation, starting at 1. */
+  readonly generation: number;
+  /** Aborted before cleanup begins on replacement, deactivation, or teardown. */
+  readonly signal: AbortSignal;
+  /**
+   * Persistently decorate any thread row for this plugin generation.
+   *
+   * The status is owned by the frontend generation and therefore survives
+   * route changes. Passing `null` clears the plugin's status for that thread.
+   * The host clears every remaining status when the frontend generation
+   * deactivates.
+   *
+   * Optional so bundles can feature-detect support while this experimental
+   * surface rolls out across 0.x clients.
+   */
+  readonly experimental_setThreadRowStatus?: (
+    threadId: string,
+    status: PluginComposerThreadRowStatus | null
+  ) => void;
+}
+/** Cleanup returned by a frontend content script. */
+type PluginContentScriptDisposer = () => void | Promise<void>;
+/**
+ * Trusted same-origin JavaScript/TypeScript mounted once per active frontend
+ * generation in each bb app window or browser tab.
+ */
+interface PluginContentScriptRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /**
+   * Install behavior into the bb app shell. The host awaits a returned
+   * promise, contains failures, and calls the returned disposer exactly once.
+   */
+  mount(
+    context: PluginContentScriptContext
+  ):
+    | void
+    | PluginContentScriptDisposer
+    | Promise<void | PluginContentScriptDisposer>;
+}
+/** Lifecycle surface for trusted frontend content scripts. */
+interface PluginAppContentScripts {
+  register(registration: PluginContentScriptRegistration): void;
+}
+interface PluginAppBuilder {
+  slots: PluginAppSlots;
+  composer: PluginAppComposer;
+  contentScripts: PluginAppContentScripts;
+}
+type PluginAppSetup = (app: PluginAppBuilder) => void;
+/**
+ * The opaque product of `definePluginApp` — a plugin's `app.tsx` default
+ * export. The host re-runs `setup` against a fresh collector on every
+ * (re)interpretation, replacing that plugin's registrations wholesale.
+ */
+interface PluginAppDefinition {
+  /** Brand the host checks before interpreting a bundle's default export. */
+  readonly __bbPluginApp: true;
+  readonly setup: PluginAppSetup;
+}
+interface PluginRpcClient<
+  Contract extends PluginRpcContract = PluginRpcContract,
+> {
+  /**
+   * Invoke one of the plugin's `bb.rpc` methods (POST
+   * /api/v1/plugins/&lt;id&gt;/rpc/&lt;method&gt;). Resolves with the method's
+   * inferred output; rejects with an `Error` carrying the server's message,
+   * stable `code`, and validation `issues` when present.
+   */
+  call<Method extends Extract<keyof Contract, string>>(
+    method: Method,
+    ...args: PluginRpcCallArgs<Contract[Method]>
+  ): Promise<PluginRpcResult<Contract[Method]>>;
+}
+interface PluginSettingsState {
+  /**
+   * Effective non-secret setting values (secret settings are excluded —
+   * read them server-side). Undefined while loading or unavailable.
+   */
+  values: Record<string, string | boolean> | undefined;
+  isLoading: boolean;
+}
+/** State of the app's shared realtime connection to the bb server. */
+type PluginRealtimeConnectionState =
+  | "connecting"
+  | "connected"
+  | "reconnecting";
+/** Where `useComposer()` writes. */
+type PluginComposerScope =
+  | {
+      kind: "thread";
+      threadId: string;
+    }
+  | {
+      kind: "queued-message";
+      threadId: string;
+      queuedMessageId: string;
+    }
+  | {
+      kind: "side-chat";
+      projectId: string;
+      parentThreadId: string;
+      tabId: string;
+      childThreadId: string | null;
+    }
+  | {
+      kind: "new-thread";
+      /** Root compose's effective selected project; null only while unresolved. */
+      projectId: string | null;
+    };
+/** One plugin-owned composer customization registration. */
+interface ComposerCustomization {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Composer kinds where this customization is active; omit for all kinds. */
+  scopes?: readonly PluginComposerScope["kind"][];
+  actions?: readonly {
+    id: string;
+    component: ComponentType;
+  }[];
+  banners?: readonly {
+    id: string;
+    /** Host chrome around the banner. Defaults to `"card"`. */
+    chrome?: "card" | "bare";
+    component: ComponentType;
+  }[];
+  plusMenu?: readonly ComposerPlusMenuItem[];
+  richText?: ComposerRichTextSpec;
+}
+/** Host-rendered menu row in the composer's `+` menu. */
+interface ComposerPlusMenuItem {
+  id: string;
+  label: string;
+  /** BB icon name; unknown names fall back to the generic plugin icon. */
+  icon?: string;
+  /** Accessible description for the host-rendered row. */
+  description?: string;
+  disabled?: boolean | ((view: ComposerView) => boolean);
+  run(context: {
+    composer: PluginComposerApi;
+    view: ComposerView;
+  }): void | Promise<void>;
+}
+/** Reactive read-side of the composer a plugin surface is mounted in. */
+interface ComposerView {
+  scope: PluginComposerScope;
+  layout: "expanded" | "compact" | "zen";
+  draft: {
+    text: string;
+    isEmpty: boolean;
+    attachmentCount: number;
+  };
+  run: {
+    isRunning: boolean;
+    isSubmitting: boolean;
+  };
+}
+interface ComposerRichTextSpec {
+  /** Content-derived paint: match ranges receive `className`; text is never mutated. */
+  effects?: readonly {
+    id: string;
+    /** Plain-text offsets into the current structured draft. */
+    match(text: string): readonly {
+      from: number;
+      to: number;
+    }[];
+    className: string;
+  }[];
+  /** Debounced, read-only observation of the structured draft. */
+  onDraftChange?(draft: ComposerStructuredDraft, view: ComposerView): void;
+}
+interface ComposerStructuredDraft {
+  text: string;
+  mentions: readonly {
+    from: number;
+    to: number;
+    provider: string;
+    id: string;
+    label: string;
+  }[];
+}
+/** Host-rendered paint applied to the editable composer text. */
+interface PluginComposerTextEffect {
+  className: string;
+}
+/** Host-rendered status that temporarily replaces a thread's draft glyph. */
+interface PluginComposerThreadRowStatus {
+  /** BB icon-name hint; unknown names fall back to the generic plugin icon. */
+  icon: string;
+  /** Accessible label for the status glyph. */
+  label: string;
+  /**
+   * Semantic host treatment for the status glyph. `running` automatically
+   * shimmers; terminal `success` and `error` tones are static. Defaults to the
+   * neutral tone.
+   */
+  tone?: "default" | "running" | "success" | "error";
+}
+/** An @-mention pill bound to one of the calling plugin's mention providers. */
+interface PluginComposerMention {
+  /** Mention provider id registered by THIS plugin via `bb.ui.registerMentionProvider`. */
+  provider: string;
+  /** Item id your provider's `resolve` will receive at send time. */
+  id: string;
+  /** Pill text shown in the composer. */
+  label: string;
+}
+/**
+ * Programmatic access to the chat composer draft — the same shared draft the
+ * built-in "Add to chat" affordances (file preview, diff, terminal selections)
+ * write to. While a queued message is being edited, writes land in that
+ * message's inline editor. In a side chat, writes land in the visible side-chat
+ * draft. Otherwise, inside a thread context writes land in that thread's draft;
+ * anywhere else (nav panel, homepage section) they seed the new-thread composer
+ * draft, which persists until the user sends or clears it.
+ */
+interface PluginComposerApi {
+  scope: PluginComposerScope;
+  /** Current plain text for this composer scope. */
+  readonly text: string;
+  /**
+   * Replace the draft's plain text. Attachments are preserved. Inline mentions
+   * outside the changed range are preserved and rebased; mentions overlapped
+   * by the replacement are removed because their text representation changed.
+   */
+  setText(next: string): void;
+  /**
+   * Replace the draft's plain text from the latest committed value. Uses the
+   * same structured-state reconciliation as `setText`.
+   */
+  updateText(updater: (current: string) => string): void;
+  /** Clear plain text without clearing independently attached files. */
+  clear(): void;
+  /**
+   * Apply a host-rendered effect to this composer's editable text, or clear it.
+   * Effects are scoped to the calling plugin and automatically clear when the
+   * slot unmounts or its composer scope changes.
+   */
+  setTextEffect(effect: PluginComposerTextEffect | null): void;
+  /**
+   * Lock or unlock editing for this composer. Locks are scoped to the calling
+   * plugin and automatically release when the slot unmounts or its composer
+   * scope changes.
+   */
+  setInputLock(locked: boolean): void;
+  /**
+   * Append text to the draft as a `> ` blockquote block and focus the
+   * composer. Blank text is a no-op. This is the "reference this selection
+   * in chat" primitive.
+   */
+  addQuote(text: string): void;
+  /**
+   * Insert an @-mention pill that resolves through this plugin's mention
+   * provider at send time — the durable way to reference an entity whose
+   * content should be fetched fresh when the message is sent.
+   */
+  insertMention(mention: PluginComposerMention): void;
+  /** Focus the composer caret at the end of the draft. */
+  focus(): void;
+}
+/**
+ * A consumer-supplied action on the messages of one `ThreadChat` instance,
+ * rendered in the embedded timeline's per-message action bar alongside the
+ * native and slot-registered actions. Unlike the `messageAction` slot this is
+ * scoped to the rendering component, not registered globally.
+ */
+interface ThreadChatMessageAction {
+  /** Unique within this ThreadChat instance; letters, digits, `-`, `_`. */
+  id: string;
+  /** Tooltip / menu label for the action. */
+  title: string;
+  /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
+  icon?: string;
+  /**
+   * Message roles the action applies to. Omitted = both user and assistant
+   * messages.
+   */
+  roles?: readonly ("user" | "assistant")[];
+  /**
+   * Runs when the user activates the action. Errors (sync or async) are
+   * contained and logged; they never break the timeline.
+   */
+  run(message: ThreadChatMessageReference): void | Promise<void>;
+}
+/**
+ * Props of the host-owned `ThreadChat` component — one thread's chat
+ * (timeline, and for the composer variants the full send/queue/draft
+ * engine), rendered by the BB app inside a plugin slot. This is the
+ * deliberate exception to the no-host-components rule (§5.5): a stable
+ * product capability, not a UI kit. Versioned additive like slot props;
+ * internal timeline rows, query hooks, and prompt-box configuration are
+ * deliberately not exposed.
+ */
+interface ThreadChatProps {
+  threadId: string;
+  /**
+   * "full" (default) is the page presentation (centered reading width);
+   * "compact" is the side-panel presentation; "timeline" renders the
+   * transcript without a composer.
+   */
+  variant?: "full" | "compact" | "timeline";
+  /**
+   * "contained" (default) fills and scrolls inside a bounded parent;
+   * "document" grows with its content and defers scrolling to the page.
+   */
+  layout?: "contained" | "document";
+  /** Bump to focus the composer (ignored by `variant: "timeline"`). */
+  focusRequest?: number;
+  /**
+   * Who controls the permission mode sends run with. "inherit" (default)
+   * pins every send to the thread's own resolved default and renders the
+   * picker as a dimmed label — a plugin surface can never widen it.
+   * "editable" gives this chat its own picker, so the user can raise or
+   * lower permissions for this thread independently of the thread it was
+   * forked from. Ignored by `variant: "timeline"` (no composer).
+   */
+  permissionPolicy?: "inherit" | "editable";
+  className?: string;
+  /** Rendered above the conversation, scrolling with it. */
+  leadingContent?: ReactNode;
+  /**
+   * Actions rendered in this instance's per-message action bar (see
+   * {@link ThreadChatMessageAction}).
+   */
+  messageActions?: readonly ThreadChatMessageAction[];
+}
+/**
+ * Every selection the composer resolved, JSON-serializable so a plugin can
+ * forward it to its own backend rpc verbatim and hand it straight to
+ * `bb.sdk.threads.spawn`.
+ *
+ * The split is deliberate: the composer owns *user selections*, the plugin
+ * owns *filing and attribution*. `bb.sdk.threads.spawn` auto-fills
+ * `origin: "plugin"` and `originPluginId`, so a thread created this way stays
+ * attributed to the plugin — which it would not be if the component created
+ * the thread itself. The plugin adds `sectionId`, `parentThreadId`, `title`,
+ * and `visibility` to the request on its own; they are deliberately not
+ * composer props.
+ */
+interface NewThreadRequest {
+  projectId: string;
+  providerId: string;
+  model: string;
+  reasoningLevel: ReasoningLevel;
+  permissionMode: PermissionMode;
+  /** Omitted when the selected provider has no service tiers. */
+  serviceTier?: ServiceTier;
+  /**
+   * Per-field provenance (caller-explicit vs. default) for the execution
+   * options above, forwarded to `spawn` so the server records what the user
+   * actually chose.
+   */
+  executionInputSources: CreateExecutionInputSources;
+  environment: CreateThreadEnvironmentArgs;
+  input: PromptInput[];
+}
+/**
+ * Props of the host-owned `experimental_NewThreadComposer` component — bb's
+ * full new-thread compose surface (prompt editor with @-mentions and expand,
+ * attachments, provider/model/reasoning picker, voice, submit, and the row
+ * beneath with project, environment, branch-from, and permission mode),
+ * rendered by the BB app inside a plugin slot.
+ *
+ * It is the create-side counterpart to `ThreadChat`: same deliberate
+ * exception to the no-host-components rule (§5.5), same additive versioning.
+ */
+interface NewThreadComposerProps {
+  /** Seeds the project picker. The user can change it. */
+  defaultProjectId?: string;
+  /**
+   * Seeds the provider picker. Like every `default*` prop this is a SEED, not
+   * a controlled value: the composer stays uncontrolled, the user can change
+   * it, and when omitted the composer falls back to the project's remembered
+   * execution defaults exactly as before. When provided it takes precedence
+   * over those project defaults.
+   *
+   * Re-seeding: the `default*` props are value-compared each render. When any
+   * of them changes after mount, the composer re-seeds EVERY execution and
+   * environment selection from the new props — including selections the user
+   * had already touched — so switching between two saved records in the same
+   * mounted composer reloads that record's values (the same rule
+   * `defaultProjectId` already follows).
+   *
+   * Every seeded field is reported as caller-explicit in the submitted
+   * request's `executionInputSources`. That is what makes the seed survive
+   * `threads.spawn`: the server drops a requested `providerId`/`model` that
+   * carries no provenance source and re-derives it from the project's stored
+   * defaults, which would silently undo the seed.
+   */
+  defaultProviderId?: string;
+  /** Seeds the model picker. Same seed semantics as {@link defaultProviderId}. */
+  defaultModel?: string;
+  /**
+   * Seeds the reasoning-level picker. Same seed semantics as
+   * {@link defaultProviderId}. If the seeded model does not support this
+   * level, the composer reconciles to the closest supported one.
+   */
+  defaultReasoningLevel?: ReasoningLevel;
+  /**
+   * Seeds the service-tier picker. Same seed semantics as
+   * {@link defaultProviderId}. Ignored (and omitted from the submitted
+   * request) when the selected provider has no service tiers.
+   */
+  defaultServiceTier?: ServiceTier;
+  /** Seeds the permission-mode picker. Same seed semantics as {@link defaultProviderId}. */
+  defaultPermissionMode?: PermissionMode;
+  /**
+   * Seeds the environment and branch pickers from a previously submitted
+   * `NewThreadRequest.environment`. Same seed semantics as
+   * {@link defaultProviderId}: a seed the user can change, taking precedence
+   * over the composer's own environment default when provided.
+   *
+   * Round trip: feeding a submitted request's `environment` back in and
+   * resubmitting untouched reproduces an equivalent environment, with these
+   * documented limits — the composer cannot represent every args variant:
+   *
+   * - `{ type: "project-default" }` seeds nothing; the composer resolves its
+   *   own default and submits that concrete environment instead.
+   * - A `host` environment whose host no longer exists (or whose project has
+   *   no source on it) falls back to the composer's default host, exactly as
+   *   the primary compose surface would.
+   * - A `reuse` environment whose worktree no longer has unarchived threads
+   *   falls back the same way.
+   * - An `unmanaged` workspace's `path` has no composer control; the seeded
+   *   selection submits `path: null` (the host's configured checkout). The
+   *   composer itself never produces a non-null `path`, so real round trips
+   *   are unaffected.
+   * - A `managed-worktree` with `baseBranch: { kind: "default" }` leaves the
+   *   branch picker on its default, which may resolve to a named base branch
+   *   when the project configures a dedicated worktree base — the same branch
+   *   the original `default` submission would have created from.
+   */
+  defaultEnvironment?: CreateThreadEnvironmentArgs;
+  /** Seeds the draft, only while the draft is still empty. */
+  initialPrompt?: string;
+  placeholder?: string;
+  /**
+   * "contained" (default) fills and scrolls inside a bounded parent;
+   * "document" grows with its content and defers scrolling to the page.
+   */
+  layout?: "contained" | "document";
+  /** Bump to focus the editor. */
+  focusRequest?: number;
+  className?: string;
+  /**
+   * Where the draft persists. Drafts survive reloads and are shared by every
+   * composer using the same key; defaults to a key scoped to this plugin.
+   */
+  draftKey?: string;
+  /**
+   * Fires on submit with every selection resolved. The draft clears when this
+   * resolves and is KEPT if it throws, so a failed create never loses what the
+   * user typed.
+   */
+  onSubmit: (request: NewThreadRequest) => void | Promise<void>;
+}
+/**
+ * Props of the host-owned `Markdown` component — bb's chat message renderer
+ * (the same typography, spacing, and code styling as timeline messages).
+ * Use it wherever plugin UI quotes or previews message content so it reads
+ * like the rest of the chat. Like `ThreadChat`, this is a stable product
+ * capability, not a UI kit; renderer internals stay private.
+ */
+interface MarkdownProps {
+  /** Markdown source, rendered exactly like a chat message body. */
+  content: string;
+  className?: string;
+}
+/** Current app selection, derived from the route. */
+interface BbContext {
+  projectId: string | null;
+  threadId: string | null;
+}
+interface BbNavigate {
+  toThread(threadId: string): void;
+  toProject(projectId: string): void;
+  /**
+   * Navigate to one of this plugin's own nav panels by its `path`.
+   * `subPath` targets a location inside the panel (the component's
+   * `subPath` prop); `replace` swaps the current history entry instead of
+   * pushing — use it for redirects so back does not bounce.
+   */
+  toPluginPanel(
+    path: string,
+    options?: {
+      subPath?: string;
+      replace?: boolean;
+    }
+  ): void;
+  /**
+   * Navigate to the root compose surface (the new-thread screen). Pass
+   * `initialPrompt` to seed the composer draft and `focusPrompt` to focus the
+   * composer on arrival — the pairing behind "Create via chat" style entry
+   * points that drop the user into chat with a prefilled prompt.
+   */
+  toCompose(options?: { initialPrompt?: string; focusPrompt?: boolean }): void;
+  /**
+   * Open one of this plugin's registered thread-panel actions in the current
+   * thread surface. Returns false when the surface has no thread side panel or
+   * the action is unavailable.
+   */
+  openThreadPanel(options: {
+    actionId: string;
+    title?: string;
+    params?: JsonValue;
+  }): boolean;
+}
+/**
+ * Everything `@bb/plugin-sdk/app` resolves to at runtime. The BB app builds
+ * the real implementation and `satisfies` this interface; `bb plugin build`
+ * shims the specifier to that object on `globalThis.__bbPluginRuntime`.
+ */
+interface PluginSdkApp {
+  definePluginApp(setup: PluginAppSetup): PluginAppDefinition;
+  useRpc<
+    Contract extends PluginRpcContract = PluginRpcContract,
+  >(): PluginRpcClient<Contract>;
+  useRealtime(channel: string, handler: (payload: unknown) => void): void;
+  /**
+   * Observe the same shared connection that delivers `useRealtime` signals.
+   * Use a subsequent transition to `connected` to reconcile server state that
+   * may have changed while ephemeral signals could not be delivered. The first
+   * connection can transition from `connecting` and is not a reconnection.
+   */
+  useRealtimeConnectionState(): PluginRealtimeConnectionState;
+  useSettings(): PluginSettingsState;
+  useBbContext(): BbContext;
+  useBbNavigate(): BbNavigate;
+  useComposer(): PluginComposerApi;
+  /**
+   * The sidebar's live thread view (see {@link PluginSidebarThreadsState}).
+   * Reads the host's own cache and realtime subscriptions, so it costs no
+   * extra request and updates exactly when the built-in sidebar does.
+   * Experimental: see docs/api_to_audit.md.
+   */
+  experimental_useSidebarThreads(): PluginSidebarThreadsState;
+  /**
+   * Thread actions bound to the host's mutations (see
+   * {@link PluginSidebarThreadActions}). Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_useSidebarThreadActions(): PluginSidebarThreadActions;
+  /**
+   * The pull request for one thread's branch (see
+   * {@link PluginSidebarThreadPullRequestState}).
+   *
+   * Per row and opt-in, because it costs a git-host lookup: it is NOT on the
+   * thread payload every sidebar loads. Threads sharing an environment share
+   * one query, and the host owns the polling and staleness rules — an open PR
+   * with pending checks refreshes, a merged one does not.
+   *
+   * Experimental: see docs/api_to_audit.md.
+   */
+  experimental_useSidebarThreadPullRequest(
+    threadId: string
+  ): PluginSidebarThreadPullRequestState;
+  /**
+   * Per-row drag-to-split support (see {@link PluginSidebarThreadSplit}).
+   * Call it once per rendered row, like the built-in sidebar does.
+   * Experimental: see docs/api_to_audit.md.
+   */
+  experimental_useSidebarThreadSplit(
+    threadId: string
+  ): PluginSidebarThreadSplit;
+  /**
+   * The host-owned chat component (see {@link ThreadChatProps}). Together
+   * with `Markdown`, the only components the SDK ships — everything else
+   * stays vendored per §5.5.
+   */
+  ThreadChat: ComponentType<ThreadChatProps>;
+  /**
+   * The host-owned chat-message markdown renderer (see
+   * {@link MarkdownProps}).
+   */
+  Markdown: ComponentType<MarkdownProps>;
+  /**
+   * The host-owned new-thread compose surface (see
+   * {@link NewThreadComposerProps}). Experimental: see
+   * docs/api_to_audit.md for what to audit before the prefix drops.
+   */
+  experimental_NewThreadComposer: ComponentType<NewThreadComposerProps>;
+  useComposerView(): ComposerView;
+}
+
+interface EnvironmentActionArgs {
+  environmentId: string;
+}
+interface EnvironmentGetArgs extends EnvironmentActionArgs {
+  signal?: AbortSignal;
+}
+type EnvironmentMergeBaseBranchUpdateValue = Exclude<
+  UpdateEnvironmentRequest["mergeBaseBranch"],
+  undefined
+>;
+type EnvironmentNameUpdateValue = Exclude<
+  UpdateEnvironmentRequest["name"],
+  undefined
+>;
+interface EnvironmentMergeBaseBranchUpdate {
+  mergeBaseBranch: EnvironmentMergeBaseBranchUpdateValue;
+  name?: EnvironmentNameUpdateValue;
+}
+interface EnvironmentNameUpdate {
+  mergeBaseBranch?: EnvironmentMergeBaseBranchUpdateValue;
+  name: EnvironmentNameUpdateValue;
+}
+type EnvironmentUpdateFields =
+  | EnvironmentMergeBaseBranchUpdate
+  | EnvironmentNameUpdate;
+type EnvironmentUpdateArgs = EnvironmentUpdateFields & {
+  environmentId: string;
+};
+interface EnvironmentStatusArgs extends EnvironmentStatusQuery {
+  environmentId: string;
+  signal?: AbortSignal;
+}
+type EnvironmentDiffArgs = EnvironmentDiffQuery & {
+  environmentId: string;
+  signal?: AbortSignal;
+};
+type EnvironmentDiffFileArgs = EnvironmentDiffFileQuery & {
+  environmentId: string;
+  signal?: AbortSignal;
+};
+interface EnvironmentDiffBranchesArgs extends EnvironmentDiffBranchesQuery {
+  environmentId: string;
+  signal?: AbortSignal;
+}
+interface EnvironmentCommitArgs {
+  environmentId: string;
+}
+interface EnvironmentSquashMergeArgs {
+  environmentId: string;
+  mergeBaseBranch: string;
+}
+interface EnvironmentPullRequestMergeArgs {
+  environmentId: string;
+  method: PullRequestMergeMethod;
+}
+type EnvironmentDiffPatchArgs = EnvironmentDiffPatchRequest & {
+  environmentId: string;
+  signal?: AbortSignal;
+};
+interface EnvironmentPathsArgs extends EnvironmentPathsQuery {
+  environmentId: string;
+  signal?: AbortSignal;
+}
+type EnvironmentArchiveThreadsResult = EnvironmentArchiveThreadsResponse;
+type EnvironmentCommitResult = CommitActionResponse;
+type EnvironmentDiffResult = EnvironmentDiffResponse;
+type EnvironmentDiffBranchesResult = EnvironmentDiffBranchesResponse;
+type EnvironmentDiffFileResult = EnvironmentDiffFileResponse;
+type EnvironmentDiffFilesResult = EnvironmentDiffFilesResponse;
+type EnvironmentDiffPatchResult = EnvironmentDiffPatchResponse;
+type EnvironmentGetResult = Environment;
+type EnvironmentMarkPullRequestDraftResult = PullRequestDraftActionResponse;
+type EnvironmentMarkPullRequestReadyResult = PullRequestReadyActionResponse;
+type EnvironmentMergePullRequestResult = PullRequestMergeActionResponse;
+type EnvironmentPathsResult = WorkspacePathListResponse;
+type EnvironmentPullRequestResult = EnvironmentPullRequestResponse;
+type EnvironmentSquashMergeResult = SquashMergeActionResponse;
+type EnvironmentStatusResult = EnvironmentStatusResponse;
+type EnvironmentUpdateResult = Environment;
+interface EnvironmentsArea {
+  archiveThreads(
+    args: EnvironmentActionArgs
+  ): Promise<EnvironmentArchiveThreadsResult>;
+  commit(args: EnvironmentCommitArgs): Promise<EnvironmentCommitResult>;
+  diff(args: EnvironmentDiffArgs): Promise<EnvironmentDiffResult>;
+  diffBranches(
+    args: EnvironmentDiffBranchesArgs
+  ): Promise<EnvironmentDiffBranchesResult>;
+  diffFile(args: EnvironmentDiffFileArgs): Promise<EnvironmentDiffFileResult>;
+  diffFiles(args: EnvironmentDiffArgs): Promise<EnvironmentDiffFilesResult>;
+  diffPatch(
+    args: EnvironmentDiffPatchArgs
+  ): Promise<EnvironmentDiffPatchResult>;
+  get(args: EnvironmentGetArgs): Promise<EnvironmentGetResult>;
+  pullRequest(args: EnvironmentGetArgs): Promise<EnvironmentPullRequestResult>;
+  markPullRequestDraft(
+    args: EnvironmentActionArgs
+  ): Promise<EnvironmentMarkPullRequestDraftResult>;
+  markPullRequestReady(
+    args: EnvironmentActionArgs
+  ): Promise<EnvironmentMarkPullRequestReadyResult>;
+  mergePullRequest(
+    args: EnvironmentPullRequestMergeArgs
+  ): Promise<EnvironmentMergePullRequestResult>;
+  paths(args: EnvironmentPathsArgs): Promise<EnvironmentPathsResult>;
+  squashMerge(
+    args: EnvironmentSquashMergeArgs
+  ): Promise<EnvironmentSquashMergeResult>;
+  status(args: EnvironmentStatusArgs): Promise<EnvironmentStatusResult>;
+  update(args: EnvironmentUpdateArgs): Promise<EnvironmentUpdateResult>;
+}
+
+/**
+ * Host file primitives. `hostId` may be omitted to target the server's
+ * primary (local) host. `rootPath`, when set, confines the target beneath
+ * that absolute root on the host (symlink-safe).
+ */
+interface FileReadArgs {
+  hostId?: string;
+  path: string;
+  rootPath?: string;
+  signal?: AbortSignal;
+}
+interface FileWriteArgs {
+  hostId?: string;
+  path: string;
+  rootPath?: string;
+  content: string;
+  /** Defaults to "utf8". */
+  contentEncoding?: "utf8" | "base64";
+  /** Defaults to false. */
+  createParents?: boolean;
+  /**
+   * Optimistic-concurrency guard: omitted → unconditional write; a hash →
+   * write only when the current content hashes to it (use `read().sha256`);
+   * null → create-only. A failed guard resolves to the `conflict` outcome.
+   */
+  expectedSha256?: string | null;
+  /** POSIX permission bits used when creating a file (for example 0o600). */
+  mode?: number;
+}
+interface FileListArgs {
+  hostId?: string;
+  path: string;
+  query?: string;
+  limit?: number;
+  signal?: AbortSignal;
+}
+interface PathListArgs extends FileListArgs {
+  includeFiles: boolean;
+  includeDirectories: boolean;
+}
+interface FileMkdirArgs {
+  hostId?: string;
+  path: string;
+  rootPath?: string;
+  recursive?: boolean;
+}
+interface FileMoveArgs {
+  hostId?: string;
+  sourcePath: string;
+  destinationPath: string;
+  rootPath?: string;
+}
+interface FileRemoveArgs {
+  hostId?: string;
+  path: string;
+  rootPath?: string;
+  recursive?: boolean;
+}
+interface FilePreviewArgs {
+  hostId?: string;
+  rootPath: string;
+  signal?: AbortSignal;
+  ttlMs?: number;
+}
+type FileReadResult = HostFileReadResponse;
+type FileWriteResult = HostFileWriteResponse;
+type FileListResult = HostFileListResponse;
+type PathListResult = HostPathListResponse;
+type FileMkdirResult = HostMkdirResponse;
+type FileMoveResult = HostMovePathResponse;
+type FileRemoveResult = HostRemovePathResponse;
+type FilePreviewResult = CreateFilePreviewResponse;
+interface FilesArea {
+  read(args: FileReadArgs): Promise<FileReadResult>;
+  write(args: FileWriteArgs): Promise<FileWriteResult>;
+  list(args: FileListArgs): Promise<FileListResult>;
+  listPaths(args: PathListArgs): Promise<PathListResult>;
+  mkdir(args: FileMkdirArgs): Promise<FileMkdirResult>;
+  move(args: FileMoveArgs): Promise<FileMoveResult>;
+  remove(args: FileRemoveArgs): Promise<FileRemoveResult>;
+  createPreview(args: FilePreviewArgs): Promise<FilePreviewResult>;
+}
+
+interface GuideRenderArgs {
+  chapter?: string;
+}
+interface GuideRenderResult {
+  chapter?: string;
+  content: string;
+}
+interface GuideArea {
+  render(args?: GuideRenderArgs): GuideRenderResult;
+}
+
+interface HostGetArgs {
+  hostId: string;
+  signal?: AbortSignal;
+}
+interface HostDeleteArgs {
+  hostId: string;
+}
+interface HostUpdateArgs extends UpdateHostRequest {
+  hostId: string;
+}
+interface HostRetryUpdateArgs {
+  hostId: string;
+}
+interface HostDirectoryArgs extends HostDirectoryQuery {
+  hostId: string;
+  signal?: AbortSignal;
+}
+interface HostCloneDefaultPathArgs extends HostCloneDefaultPathQuery {
+  hostId: string;
+  signal?: AbortSignal;
+}
+interface HostPathsExistArgs extends HostPathsExistRequest {
+  hostId: string;
+  signal?: AbortSignal;
+}
+interface HostPickFolderArgs extends HostPickFolderRequest {
+  hostId: string;
+  signal?: AbortSignal;
+}
+interface HostProviderCliInstallArgs extends HostProviderCliInstallRequest {
+  hostId: string;
+}
+interface HostListArgs {
+  signal?: AbortSignal;
+}
+type HostCreateJoinCodeResult = CreateHostJoinCodeResponse;
+type HostDeleteResult = {
+  ok: true;
+};
+type HostDirectoryResult = HostDirectoryListing;
+type HostGetResult = Host;
+type HostCloneDefaultPathResult = HostCloneDefaultPathResponse;
+type HostProviderCliInstallResult = HostProviderCliInstallEvent[];
+type HostListResult = Host[];
+type HostPathsExistResult = HostPathsExistResponse;
+type HostPickFolderResult = HostPickFolderResponse;
+type HostProviderCliStatusResult = HostProviderCliStatusResponse;
+type HostRetryUpdateResult = HostRetryUpdateResponse;
+type HostUpdateResult = Host;
+interface HostsArea {
+  createJoinCode(): Promise<HostCreateJoinCodeResult>;
+  delete(args: HostDeleteArgs): Promise<HostDeleteResult>;
+  directory(args: HostDirectoryArgs): Promise<HostDirectoryResult>;
+  get(args: HostGetArgs): Promise<HostGetResult>;
+  cloneDefaultPath(
+    args: HostCloneDefaultPathArgs
+  ): Promise<HostCloneDefaultPathResult>;
+  installProviderCli(
+    args: HostProviderCliInstallArgs
+  ): Promise<HostProviderCliInstallResult>;
+  list(args?: HostListArgs): Promise<HostListResult>;
+  pathsExist(args: HostPathsExistArgs): Promise<HostPathsExistResult>;
+  pickFolder(args: HostPickFolderArgs): Promise<HostPickFolderResult>;
+  providerCliStatus(args: HostGetArgs): Promise<HostProviderCliStatusResult>;
+  retryUpdate(args: HostRetryUpdateArgs): Promise<HostRetryUpdateResult>;
+  update(args: HostUpdateArgs): Promise<HostUpdateResult>;
+}
+
+interface ProjectListArgs {
+  include?: ProjectListQuery["include"];
+  /** Include the singleton personal project. Defaults to false for compatibility. */
+  includePersonal?: boolean;
+  signal?: AbortSignal;
+}
+interface ProjectCreateArgs extends CreateProjectRequest {}
+interface ProjectGetArgs {
+  projectId: string;
+  signal?: AbortSignal;
+}
+interface ProjectUpdateArgs extends UpdateProjectRequest {
+  projectId: string;
+}
+interface ProjectDeleteArgs {
+  projectId: string;
+}
+interface ProjectReorderArgs extends ReorderProjectRequest {
+  projectId: string;
+}
+interface ProjectPromptHistoryArgs extends PromptHistoryQuery {
+  projectId: string;
+  signal?: AbortSignal;
+}
+/** Select one project workspace source, or omit both for the primary host. */
+type ProjectWorkspaceRoutingArgs =
+  | {
+      environmentId: string;
+      hostId?: never;
+    }
+  | {
+      environmentId?: never;
+      hostId: string;
+    }
+  | {
+      environmentId?: never;
+      hostId?: never;
+    };
+type ProjectFilesArgs = ProjectWorkspaceRoutingArgs &
+  Omit<ProjectFilesQuery, "environmentId" | "hostId"> & {
+    projectId: string;
+    signal?: AbortSignal;
+  };
+type ProjectPathsArgs = ProjectWorkspaceRoutingArgs &
+  Omit<ProjectPathsQuery, "environmentId" | "hostId"> & {
+    projectId: string;
+    signal?: AbortSignal;
+  };
+type ProjectCommandsArgs = ProjectWorkspaceRoutingArgs &
+  Omit<ProjectCommandsQuery, "environmentId" | "hostId"> & {
+    projectId: string;
+    signal?: AbortSignal;
+  };
+type ProjectFileContentArgs = ProjectWorkspaceRoutingArgs &
+  Omit<ProjectFileContentQuery, "environmentId" | "hostId"> & {
+    projectId: string;
+    signal?: AbortSignal;
+  };
+interface ProjectBranchesArgs extends ProjectBranchesQuery {
+  projectId: string;
+  signal?: AbortSignal;
+}
+interface ProjectDefaultExecutionOptionsArgs {
+  projectId: string;
+  signal?: AbortSignal;
+}
+interface ProjectAttachmentFileLike {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  readonly name: string;
+  readonly type?: string;
+}
+interface ProjectAttachmentUploadArgsBase {
+  /** MIME override. Omit to use the File/Blob type, when available. */
+  mimeType?: string;
+  projectId: string;
+}
+/**
+ * Upload bytes owned by this SDK client. A bare Blob/byte buffer needs an
+ * explicit filename; File-like values can supply their own name.
+ */
+type ProjectAttachmentUploadArgs = ProjectAttachmentUploadArgsBase &
+  (
+    | {
+        clientFile: ProjectAttachmentFileLike;
+        filename?: string;
+      }
+    | {
+        clientFile: ArrayBuffer | Blob | Uint8Array;
+        filename: string;
+      }
+  );
+interface ProjectAttachmentReadArgs {
+  path: string;
+  projectId: string;
+  signal?: AbortSignal;
+}
+interface ProjectAttachmentCopyArgs extends CopyProjectAttachmentsRequest {
+  projectId: string;
+}
+type ProjectSourceAddArgs = CreateProjectSourceRequest & {
+  projectId: string;
+};
+interface ProjectSourceUpdateArgs extends UpdateProjectSourceRequest {
+  projectId: string;
+  sourceId: string;
+}
+interface ProjectSourceDeleteArgs {
+  projectId: string;
+  sourceId: string;
+}
+type ProjectBranchesResult = ProjectBranchesResponse;
+interface ProjectAttachmentReadResult {
+  bytes: Uint8Array;
+  mimeType: string;
+  sizeBytes: number;
+}
+type ProjectAttachmentUploadResult = UploadedPromptAttachment;
+type ProjectCommandsResult = CommandListResponse;
+type ProjectCreateResult = ProjectResponse;
+type ProjectDefaultExecutionOptionsResult = ProjectExecutionDefaults | null;
+type ProjectDeleteResult = {
+  ok: true;
+};
+interface ProjectFileContentResult {
+  /** UTF-8 text or base64, as selected by `contentEncoding`. */
+  content: string;
+  contentEncoding: "utf8" | "base64";
+  mimeType: string;
+  sizeBytes: number;
+}
+type ProjectFilesResult = WorkspaceFileListResponse;
+type ProjectGetResult = ProjectResponse;
+type ProjectListResult = ProjectResponse[] | ProjectWithThreadsResponse[];
+type ProjectPathsResult = WorkspacePathListResponse;
+type ProjectPromptHistoryResult = PromptHistoryResponse;
+type ProjectReorderResult = ProjectResponse[];
+type ProjectSourceAddResult = ProjectSource;
+type ProjectSourceDeleteResult = {
+  ok: true;
+};
+type ProjectSourceUpdateResult = ProjectSource;
+type ProjectUpdateResult = ProjectResponse;
+interface ProjectSourcesArea {
+  add(args: ProjectSourceAddArgs): Promise<ProjectSourceAddResult>;
+  delete(args: ProjectSourceDeleteArgs): Promise<ProjectSourceDeleteResult>;
+  update(args: ProjectSourceUpdateArgs): Promise<ProjectSourceUpdateResult>;
+}
+interface ProjectAttachmentsArea {
+  copy(args: ProjectAttachmentCopyArgs): Promise<void>;
+  read(args: ProjectAttachmentReadArgs): Promise<ProjectAttachmentReadResult>;
+  upload(
+    args: ProjectAttachmentUploadArgs
+  ): Promise<ProjectAttachmentUploadResult>;
+}
+interface ProjectsArea {
+  attachments: ProjectAttachmentsArea;
+  branches(args: ProjectBranchesArgs): Promise<ProjectBranchesResult>;
+  commands(args: ProjectCommandsArgs): Promise<ProjectCommandsResult>;
+  create(args: ProjectCreateArgs): Promise<ProjectCreateResult>;
+  defaultExecutionOptions(
+    args: ProjectDefaultExecutionOptionsArgs
+  ): Promise<ProjectDefaultExecutionOptionsResult>;
+  delete(args: ProjectDeleteArgs): Promise<ProjectDeleteResult>;
+  fileContent(args: ProjectFileContentArgs): Promise<ProjectFileContentResult>;
+  files(args: ProjectFilesArgs): Promise<ProjectFilesResult>;
+  get(args: ProjectGetArgs): Promise<ProjectGetResult>;
+  list(args?: ProjectListArgs): Promise<ProjectListResult>;
+  paths(args: ProjectPathsArgs): Promise<ProjectPathsResult>;
+  promptHistory(
+    args: ProjectPromptHistoryArgs
+  ): Promise<ProjectPromptHistoryResult>;
+  reorder(args: ProjectReorderArgs): Promise<ProjectReorderResult>;
+  sources: ProjectSourcesArea;
+  update(args: ProjectUpdateArgs): Promise<ProjectUpdateResult>;
+}
+
+/** Select exactly one provider-discovery host source, or omit both for primary. */
+type ProviderHostRoutingArgs =
+  | {
+      environmentId: string;
+      hostId?: never;
+    }
+  | {
+      environmentId?: never;
+      hostId: string;
+    }
+  | {
+      environmentId?: never;
+      hostId?: never;
+    };
+type ProviderListArgs = ProviderHostRoutingArgs & {
+  signal?: AbortSignal;
+};
+type ProviderModelsArgs = ProviderHostRoutingArgs & {
+  providerId?: string;
+  signal?: AbortSignal;
+};
+type ProviderListResult = ProviderInfo[];
+type ProviderModelsResult = SystemExecutionOptionsResponse;
+interface ProvidersArea {
+  /** List providers on the environment host, explicit host, or primary host. */
+  list(args?: ProviderListArgs): Promise<ProviderListResult>;
+  /** List models on the environment host, explicit host, or primary host. */
+  models(args?: ProviderModelsArgs): Promise<ProviderModelsResult>;
+}
+
+interface PluginIdArgs {
+  pluginId: string;
+}
+/** Install directly from a path:, git:, npm:, or builtin: source spec. */
+interface PluginInstallArgs {
+  source: string;
+}
+/** Install an entry from BB's official catalog. */
+interface PluginCatalogInstallArgs {
+  entryId: string;
+}
+interface PluginReloadArgs {
+  pluginId?: string;
+}
+interface PluginSettingsUpdateArgs extends PluginIdArgs {
+  values: Record<string, JsonValue$1>;
+}
+interface PluginTokenArgs extends PluginIdArgs {
+  rotate?: boolean;
+}
+interface PluginCheckUpdatesArgs {
+  pluginId?: string;
+  signal?: AbortSignal;
+}
+interface PluginRpcArgs<TOutput> extends PluginIdArgs {
+  input?: JsonValue$1;
+  method: string;
+  outputSchema: z$1.ZodType<TOutput>;
+}
+interface PluginCatalogSearchArgs {
+  query: string;
+  signal?: AbortSignal;
+}
+interface PluginCatalogStatusArgs {
+  signal?: AbortSignal;
+}
+interface PluginGetSettingsArgs extends PluginIdArgs {
+  signal?: AbortSignal;
+}
+interface PluginGetSourceArgs extends PluginIdArgs {
+  signal?: AbortSignal;
+}
+interface PluginListArgs {
+  signal?: AbortSignal;
+}
+interface PluginListUpdateResultsArgs {
+  signal?: AbortSignal;
+}
+type PluginDisableResult = InstalledPlugin;
+type PluginEnableResult = InstalledPlugin;
+type PluginGetSettingsResult = PluginSettingsResponse;
+type PluginInstallResult = InstalledPlugin;
+type PluginListResult = PluginListResponse;
+type PluginReloadResult = PluginReloadResponse;
+type PluginRemoveResult = PluginRemoveResponse;
+type PluginTokenResult = PluginTokenResponse;
+type PluginUpdateSettingsResult = PluginSettingsResponse;
+type PluginGetSourceResult = PluginSourceDetail;
+type PluginCheckUpdatesResult = PluginUpdateCheckEntry[];
+type PluginApplyUpdateResult = PluginApplyUpdateResult$1;
+type PluginCatalogStatusResult = PluginCatalogStatus;
+type PluginCatalogSearchResult = PluginCatalogSearchResult$1[];
+interface PluginCatalogArea {
+  install(args: PluginCatalogInstallArgs): Promise<PluginInstallResult>;
+  search(args: PluginCatalogSearchArgs): Promise<PluginCatalogSearchResult>;
+  status(args?: PluginCatalogStatusArgs): Promise<PluginCatalogStatusResult>;
+}
+interface PluginsArea {
+  applyUpdate(args: PluginIdArgs): Promise<PluginApplyUpdateResult>;
+  callRpc<TOutput>(args: PluginRpcArgs<TOutput>): Promise<TOutput>;
+  checkUpdates(
+    args?: PluginCheckUpdatesArgs
+  ): Promise<PluginCheckUpdatesResult>;
+  catalog: PluginCatalogArea;
+  disable(args: PluginIdArgs): Promise<PluginDisableResult>;
+  enable(args: PluginIdArgs): Promise<PluginEnableResult>;
+  getSettings(args: PluginGetSettingsArgs): Promise<PluginGetSettingsResult>;
+  getSource(args: PluginGetSourceArgs): Promise<PluginGetSourceResult>;
+  install(args: PluginInstallArgs): Promise<PluginInstallResult>;
+  list(args?: PluginListArgs): Promise<PluginListResult>;
+  listUpdateResults(
+    args?: PluginListUpdateResultsArgs
+  ): Promise<PluginCheckUpdatesResult>;
+  reload(args?: PluginReloadArgs): Promise<PluginReloadResult>;
+  remove(args: PluginIdArgs): Promise<PluginRemoveResult>;
+  token(args: PluginTokenArgs): Promise<PluginTokenResult>;
+  updateSettings(
+    args: PluginSettingsUpdateArgs
+  ): Promise<PluginUpdateSettingsResult>;
+}
+
+type BbRealtimeUnsubscribe = () => void;
+type BbRealtimeEventName =
+  | "thread:changed"
+  | "project:changed"
+  | "environment:changed"
+  | "host:changed"
+  | "system:changed"
+  | "system:config-changed"
+  | "realtime:connection";
+type ThreadRealtimeEvent = Extract<
+  ChangedMessage,
+  {
+    entity: "thread";
+  }
+>;
+type ProjectRealtimeEvent = Extract<
+  ChangedMessage,
+  {
+    entity: "project";
+  }
+>;
+type EnvironmentRealtimeEvent = Extract<
+  ChangedMessage,
+  {
+    entity: "environment";
+  }
+>;
+type HostRealtimeEvent = Extract<
+  ChangedMessage,
+  {
+    entity: "host";
+  }
+>;
+type SystemRealtimeEvent = Extract<
+  ChangedMessage,
+  {
+    entity: "system";
+  }
+>;
+type BbRealtimeConnectionState = "connecting" | "connected" | "disconnected";
+interface BbRealtimeConnectionEvent {
+  reconnectDelayMs: number | null;
+  reconnected: boolean;
+  state: BbRealtimeConnectionState;
+}
+/**
+ * Entity-changed events are delivered as one shared object to every matching
+ * listener; their payload types are readonly so a listener cannot mutate what
+ * the next listener receives.
+ */
+interface BbRealtimeEventMap {
+  "thread:changed": ThreadRealtimeEvent;
+  "project:changed": ProjectRealtimeEvent;
+  "environment:changed": EnvironmentRealtimeEvent;
+  "host:changed": HostRealtimeEvent;
+  "system:changed": SystemRealtimeEvent;
+  "system:config-changed": SystemRealtimeEvent;
+  "realtime:connection": BbRealtimeConnectionEvent;
+}
+type BbRealtimeCallback<TEventName extends BbRealtimeEventName> = (
+  event: BbRealtimeEventMap[TEventName]
+) => void;
+interface ThreadRealtimeSubscribeArgs {
+  callback: BbRealtimeCallback<"thread:changed">;
+  event: "thread:changed";
+  threadId?: string;
+}
+interface ProjectRealtimeSubscribeArgs {
+  callback: BbRealtimeCallback<"project:changed">;
+  event: "project:changed";
+  projectId?: string;
+}
+interface EnvironmentRealtimeSubscribeArgs {
+  callback: BbRealtimeCallback<"environment:changed">;
+  environmentId?: string;
+  event: "environment:changed";
+}
+interface HostRealtimeSubscribeArgs {
+  callback: BbRealtimeCallback<"host:changed">;
+  event: "host:changed";
+  hostId?: string;
+}
+interface SystemRealtimeSubscribeArgs {
+  callback: BbRealtimeCallback<"system:changed">;
+  event: "system:changed";
+}
+interface SystemConfigRealtimeSubscribeArgs {
+  callback: BbRealtimeCallback<"system:config-changed">;
+  event: "system:config-changed";
+}
+/**
+ * Connection listeners are pure observers — they never open or hold the
+ * socket. A listener registered while a socket already exists receives the
+ * latest connection event as a snapshot on the next microtask, so a status
+ * UI mounted after connect still learns the current state.
+ */
+interface RealtimeConnectionSubscribeArgs {
+  callback: BbRealtimeCallback<"realtime:connection">;
+  event: "realtime:connection";
+}
+type BbRealtimeSubscribeArgsUnion =
+  | ThreadRealtimeSubscribeArgs
+  | ProjectRealtimeSubscribeArgs
+  | EnvironmentRealtimeSubscribeArgs
+  | HostRealtimeSubscribeArgs
+  | SystemRealtimeSubscribeArgs
+  | SystemConfigRealtimeSubscribeArgs
+  | RealtimeConnectionSubscribeArgs;
+type BbRealtimeSubscribeArgs<
+  TEventName extends BbRealtimeEventName = BbRealtimeEventName,
+> = Extract<
+  BbRealtimeSubscribeArgsUnion,
+  {
+    event: TEventName;
+  }
+>;
+interface BbRealtime {
+  subscribe<TEventName extends BbRealtimeEventName>(
+    args: BbRealtimeSubscribeArgs<TEventName>
+  ): BbRealtimeUnsubscribe;
+}
+
+interface StatusGetArgs {
+  projectId?: string;
+  signal?: AbortSignal;
+  threadId?: string;
+}
+interface StatusThreadSummary {
+  environmentId: string | null;
+  id: string;
+  parentThreadId: string | null;
+  pinnedAt: number | null;
+  projectId: string;
+  status: ThreadStatus;
+  title: string | null;
+}
+type StatusProject = ProjectResponse;
+type StatusChildThreads = ThreadListResponse;
+interface StatusResult {
+  childThreads: StatusChildThreads | null;
+  pendingTodos: ThreadTimelinePendingTodos | null;
+  project: StatusProject | null;
+  thread: StatusThreadSummary | null;
+}
+interface StatusArea {
+  get(args?: StatusGetArgs): Promise<StatusResult>;
+}
+
+interface SkillWorkspaceArgs {
+  projectId: string;
+  environmentId: string | null;
+}
+interface SkillListArgs extends SkillWorkspaceArgs {
+  signal?: AbortSignal;
+}
+interface SkillIdentityArgs extends SkillListArgs {
+  skillId: string;
+}
+interface SkillContentArgs extends SkillIdentityArgs {
+  path: string;
+}
+interface SkillUpdateArgs extends SkillWorkspaceArgs {
+  skillId: string;
+  content: string;
+  revision: string;
+}
+interface SkillDeleteArgs extends SkillWorkspaceArgs {
+  skillId: string;
+}
+/**
+ * Registry calls proxy out to skills.sh and GitHub, and the browse grid fans
+ * out one per card. Callers pass their query's AbortSignal so abandoning a
+ * page cancels its requests instead of leaving them in flight.
+ */
+interface AbortableArgs {
+  signal?: AbortSignal;
+}
+interface RegistrySkillsSearchArgs extends AbortableArgs {
+  query?: string;
+  page?: number;
+  perPage?: number;
+}
+interface RegistrySkillIdArgs extends AbortableArgs {
+  registrySkillId: string;
+}
+interface RegistrySkillSourceArgs extends AbortableArgs {
+  source: string;
+  skillId: string;
+}
+interface RegistryRepositoryArgs extends AbortableArgs {
+  source: string;
+}
+/**
+ * Install is a mutation and deliberately takes no signal: its body is parsed
+ * with a strict schema, so an extra key would throw at runtime.
+ */
+interface RegistrySkillInstallArgs {
+  registrySkillId: string;
+}
+interface SkillsRegistryArea {
+  detail(args: RegistrySkillSourceArgs): Promise<RegistrySkillDetail>;
+  get(args: RegistrySkillIdArgs): Promise<RegistrySkill>;
+  install(
+    args: RegistrySkillInstallArgs
+  ): Promise<RegistrySkillInstallResponse>;
+  repositoryStars(
+    args: RegistryRepositoryArgs
+  ): Promise<RegistryRepositoryStars>;
+  search(args?: RegistrySkillsSearchArgs): Promise<RegistrySkillsPage>;
+}
+interface SkillsArea {
+  getContent(args: SkillContentArgs): Promise<SkillContentResponse>;
+  list(args: SkillListArgs): Promise<SkillListResponse>;
+  listFiles(args: SkillIdentityArgs): Promise<SkillFilesResponse>;
+  registry: SkillsRegistryArea;
+  remove(args: SkillDeleteArgs): Promise<{
+    deletedPath: string;
+  }>;
+  update(args: SkillUpdateArgs): Promise<{
+    filePath: string;
+    revision: string;
+  }>;
+}
+
+type ThemeGetResult = AppTheme;
+type ThemeCatalogResult = ThemeCatalogResponse;
+type ThemeSetInput = AppThemeSelection;
+type ThemeSetResult = AppTheme;
+interface ThemeCatalogArgs {
+  signal?: AbortSignal;
+}
+interface ThemeGetArgs {
+  signal?: AbortSignal;
+}
+interface ThemeArea {
+  /** The active app palette, resolved server-side (built-in id or custom CSS). */
+  get(args?: ThemeGetArgs): Promise<ThemeGetResult>;
+  /** The custom-theme directory plus discovered themes and the active palette. */
+  catalog(args?: ThemeCatalogArgs): Promise<ThemeCatalogResult>;
+  /** Set the complete app appearance selection in one request. */
+  set(selection: ThemeSetInput): Promise<ThemeSetResult>;
+  /**
+   * Activate a palette by id while preserving the active favicon color. This
+   * compatibility shorthand reads the active appearance before writing the
+   * complete selection; prefer the object form when both values are known.
+   */
+  set(themeId: string): Promise<ThemeSetResult>;
+}
+
+interface SystemAttentionArgs {
+  signal?: AbortSignal;
+}
+interface SystemConfigArgs {
+  signal?: AbortSignal;
+}
+interface SystemExecutionOptionsArgs extends SystemExecutionOptionsQuery {
+  signal?: AbortSignal;
+}
+interface SystemUsageLimitsArgs extends SystemUsageLimitsQuery {
+  signal?: AbortSignal;
+}
+interface SystemVersionArgs {
+  force?: boolean;
+  signal?: AbortSignal;
+}
+interface SystemVoiceTranscriptionArgs {
+  file: Blob;
+  prompt?: string;
+  signal?: AbortSignal;
+}
+type SystemAttentionResult = SystemAttentionResponse;
+type SystemConfigResult = SystemConfigResponse;
+type SystemExecutionOptionsResult = SystemExecutionOptionsResponse;
+type SystemReloadConfigResult = SystemConfigReloadResponse;
+type SystemInstallCliSkillsArgs = SystemInstallCliSkillsRequest;
+interface SystemCliSkillsStatusArgs {
+  /** Omit for every enrolled machine. */
+  hostIds?: readonly string[];
+  signal?: AbortSignal;
+}
+type SystemCliSkillsStatusResult = SystemCliSkillsStatusResponse;
+type SystemInstallCliSkillsResult = SystemInstallCliSkillsResponse;
+type SystemVoiceTranscriptionResult = SystemVoiceTranscriptionResponse;
+type SystemUpdateExperimentsResult = Experiments;
+type SystemUpdateGeneralSettingsResult = AppSettings;
+type SystemUpdateKeyboardSettingsResult = AppKeybindingOverrides;
+type SystemUsageLimitsResult = ProviderUsageResponse;
+type SystemVersionResult = SystemVersionResponse;
+interface SystemArea {
+  attention(args?: SystemAttentionArgs): Promise<SystemAttentionResult>;
+  config(args?: SystemConfigArgs): Promise<SystemConfigResult>;
+  executionOptions(
+    args?: SystemExecutionOptionsArgs
+  ): Promise<SystemExecutionOptionsResult>;
+  /**
+   * Copy bb's built-in CLI skills into each named machine's global agent skill
+   * roots (`~/.agents/skills` and `~/.claude/skills`). Machines install
+   * independently; the result reports each machine's outcome.
+   */
+  /** Per-machine install state of bb's built-in CLI skills. */
+  cliSkillsStatus(
+    args?: SystemCliSkillsStatusArgs
+  ): Promise<SystemCliSkillsStatusResult>;
+  installCliSkills(
+    args: SystemInstallCliSkillsArgs
+  ): Promise<SystemInstallCliSkillsResult>;
+  reloadConfig(): Promise<SystemReloadConfigResult>;
+  transcribeVoice(
+    args: SystemVoiceTranscriptionArgs
+  ): Promise<SystemVoiceTranscriptionResult>;
+  updateExperiments(args: Experiments): Promise<SystemUpdateExperimentsResult>;
+  updateGeneralSettings(
+    args: AppSettings
+  ): Promise<SystemUpdateGeneralSettingsResult>;
+  updateKeyboardSettings(
+    args: AppKeybindingOverrides
+  ): Promise<SystemUpdateKeyboardSettingsResult>;
+  usageLimits(args?: SystemUsageLimitsArgs): Promise<SystemUsageLimitsResult>;
+  version(args?: SystemVersionArgs): Promise<SystemVersionResult>;
+}
+
+interface TerminalThreadScope {
+  cwd?: never;
+  environmentId?: never;
+  hostId?: never;
+  kind: "thread";
+  threadId: string;
+}
+interface TerminalEnvironmentScope {
+  environmentId: string;
+  cwd?: never;
+  hostId?: never;
+  kind: "environment";
+  threadId?: never;
+}
+interface TerminalHostPathListScope {
+  /** Optional exact initial working-directory filter on the selected host. */
+  cwd?: string;
+  environmentId?: never;
+  hostId: string;
+  kind: "host_path";
+  threadId?: never;
+}
+interface TerminalHostPathCreateScope {
+  /** Null starts in the selected host's home directory. */
+  cwd: string | null;
+  environmentId?: never;
+  hostId: string;
+  kind: "host_path";
+  threadId?: never;
+}
+type TerminalListScope =
+  | TerminalThreadScope
+  | TerminalEnvironmentScope
+  | TerminalHostPathListScope;
+type TerminalCreateScope =
+  | TerminalThreadScope
+  | TerminalEnvironmentScope
+  | TerminalHostPathCreateScope;
+interface TerminalListArgs {
+  signal?: AbortSignal;
+  scope: TerminalListScope;
+}
+interface TerminalCreateArgs {
+  cols: number;
+  rows: number;
+  scope: TerminalCreateScope;
+  start?: CreateTerminalRequest["start"];
+  title?: string;
+}
+interface TerminalTargetArgs {
+  terminalId: string;
+}
+interface TerminalGetArgs extends TerminalTargetArgs {
+  signal?: AbortSignal;
+}
+interface TerminalRenameArgs extends TerminalTargetArgs {
+  title: UpdateTerminalRequest["title"];
+}
+interface TerminalCloseArgs extends TerminalTargetArgs {
+  mode: "force" | "if-clean";
+}
+interface TerminalInputArgs extends TerminalTargetArgs {
+  dataBase64: TerminalInputRequest["dataBase64"];
+}
+interface TerminalResizeArgs extends TerminalTargetArgs {
+  cols: TerminalResizeRequest["cols"];
+  rows: TerminalResizeRequest["rows"];
+}
+interface TerminalOutputArgs extends TerminalTargetArgs {
+  limitChunks?: TerminalOutputQuery["limitChunks"];
+  signal?: AbortSignal;
+  sinceSeq?: TerminalOutputQuery["sinceSeq"];
+  tailBytes?: TerminalOutputQuery["tailBytes"];
+}
+type TerminalRestartArgs = TerminalTargetArgs;
+type TerminalListResult = TerminalListResponse;
+type TerminalCreateResult = TerminalSession;
+type TerminalGetResult = TerminalSession;
+type TerminalRenameResult = TerminalSession;
+type TerminalCloseResult = TerminalSession;
+type TerminalInputResult = TerminalSession;
+type TerminalResizeResult = TerminalSession;
+type TerminalOutputResult = TerminalOutputResponse;
+type TerminalRestartResult = TerminalSession;
+interface TerminalsArea {
+  close(args: TerminalCloseArgs): Promise<TerminalCloseResult>;
+  create(args: TerminalCreateArgs): Promise<TerminalCreateResult>;
+  get(args: TerminalGetArgs): Promise<TerminalGetResult>;
+  input(args: TerminalInputArgs): Promise<TerminalInputResult>;
+  list(args: TerminalListArgs): Promise<TerminalListResult>;
+  output(args: TerminalOutputArgs): Promise<TerminalOutputResult>;
+  rename(args: TerminalRenameArgs): Promise<TerminalRenameResult>;
+  /**
+   * Replace a terminal with a shell at the same scope, size, and title.
+   * The original command is not replayed because terminal sessions do not
+   * persist launch commands. The replacement has a new terminal ID.
+   */
+  restart(args: TerminalRestartArgs): Promise<TerminalRestartResult>;
+  resize(args: TerminalResizeArgs): Promise<TerminalResizeResult>;
+}
+
+interface ThreadListArgs {
+  archived?: boolean;
+  sectionId?: string;
+  hasParent?: boolean;
+  includeHidden?: boolean;
+  limit?: number;
+  offset?: number;
+  originKind?: ThreadListQuery["originKind"];
+  originPluginId?: string;
+  parentThreadId?: string;
+  projectId?: string;
+  signal?: AbortSignal;
+  sourceThreadId?: string;
+  unsectioned?: boolean;
+}
+interface ThreadSearchArgs extends ThreadSearchQuery {
+  signal?: AbortSignal;
+}
+interface ThreadGetArgs {
+  include?: ThreadGetQuery["include"];
+  signal?: AbortSignal;
+  threadId: string;
+}
+type ThreadGetResult = ThreadResponse | ThreadWithIncludesResponse;
+type ThreadListResult = ThreadListResponse;
+type ThreadSearchResult = ThreadSearchResponse;
+interface ThreadOutputResponse {
+  output: string | null;
+}
+type ThreadMutationResult = ThreadResponse;
+type ThreadSpawnResult = ThreadResponse;
+type ThreadForkResult = ThreadResponse;
+type ThreadInteractionGetResult = PendingInteraction;
+type ThreadInteractionListResult = ThreadPendingInteractionsResponse;
+type ThreadInteractionResolveResult = PendingInteraction;
+type ThreadInteractionRespondResult = PendingInteraction;
+type ThreadInteractionCancelResult = PendingInteraction;
+type ThreadEventsListResult = ThreadEventRow[];
+type ThreadEventWaitResult = ThreadEventRow | null;
+type ThreadTimelineResult = ThreadTimelineResponse;
+type ThreadArchiveResult = ThreadArchiveAllResponse;
+type ThreadOpenResult = ThreadOpenResponse;
+type ThreadPaneActionResult = ThreadPaneActionResponse;
+type ThreadDeleteResult = {
+  ok: true;
+};
+type ThreadSendResult = {
+  ok: true;
+};
+type ThreadStopResult = {
+  ok: true;
+};
+type ThreadBannerActionResult = {
+  ok: true;
+};
+type ThreadUnarchiveResult = {
+  ok: true;
+};
+type ThreadArchiveAllResult = ThreadArchiveAllResponse;
+type ThreadReadStateResult = ThreadResponse;
+type ThreadPinOrderResult = ThreadListResponse;
+type ThreadPromptHistoryResult = PromptHistoryResponse;
+type ThreadQueuedMessagesResult = ThreadQueuedMessageListResponse;
+type ThreadQueuedMessageCreateResult = ThreadQueuedMessage;
+type ThreadQueuedMessageUpdateResult = ThreadQueuedMessage;
+type ThreadQueuedMessageDeleteResult = {
+  ok: true;
+};
+type ThreadQueuedMessageReorderResult = ThreadQueuedMessageListResponse;
+type ThreadQueuedMessageSendResult = SendQueuedMessageResponse;
+type ThreadQueuedMessageGroupBoundaryResult = ThreadQueuedMessageListResponse;
+type ThreadTabsResult = ThreadTabsResponse;
+type ThreadTabsUpdateResult = ThreadTabsResponse;
+type ThreadStorageFilesResult = ThreadStorageFileListResponse;
+type ThreadStoragePathsResult = ThreadStoragePathListResponse;
+type ThreadChildSummaryResult = ThreadChildSummaryResponse;
+type ThreadDefaultExecutionOptionsResult =
+  ResolvedThreadExecutionOptions | null;
+type ThreadConversationOutlineResult = ThreadConversationOutlineResponse;
+type ThreadTimelineTurnSummaryDetailsResult =
+  TimelineTurnSummaryDetailsResponse;
+interface ThreadSpawnBaseArgs extends Omit<
+  CreateThreadRequest,
+  "childOrigin" | "input" | "origin" | "originKind" | "startedOnBehalfOf"
+> {
+  childOrigin?: CreateThreadRequest["childOrigin"];
+  origin?: CreateThreadRequest["origin"];
+  originKind?: CreateThreadRequest["originKind"];
+  startedOnBehalfOf?: CreateThreadRequest["startedOnBehalfOf"];
+}
+type ThreadSpawnArgs = ThreadSpawnBaseArgs &
+  (
+    | {
+        input: CreateThreadRequest["input"];
+        prompt?: never;
+      }
+    | {
+        input?: never;
+        prompt: string;
+      }
+  );
+interface ThreadForkArgs extends Omit<
+  ForkThreadRequest,
+  "origin" | "visibility" | "workspace"
+> {
+  origin?: ForkThreadRequest["origin"];
+  visibility?: ForkThreadRequest["visibility"];
+  workspace?: ForkThreadRequest["workspace"];
+}
+interface ThreadUpdateArgs extends UpdateThreadRequest {
+  threadId: string;
+}
+interface ThreadDeleteArgs extends DeleteThreadRequest {
+  threadId: string;
+}
+interface ThreadSendArgs extends SendMessageRequest {
+  threadId: string;
+}
+interface ThreadActionArgs {
+  threadId: string;
+}
+interface ThreadStatusArgs extends ThreadActionArgs {
+  signal?: AbortSignal;
+}
+interface ThreadPromptHistoryArgs extends PromptHistoryQuery {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadPinOrderArgs extends ReorderPinnedThreadRequest {
+  threadId: string;
+}
+interface ThreadQueuedMessageArgs {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadQueuedMessageCreateArgs extends CreateQueuedMessageRequest {
+  threadId: string;
+}
+interface ThreadQueuedMessageUpdateArgs
+  extends ThreadQueuedMessageTargetArgs, UpdateQueuedMessageRequest {}
+interface ThreadQueuedMessageTargetArgs {
+  queuedMessageId: string;
+  threadId: string;
+}
+interface ThreadQueuedMessageSendArgs
+  extends ThreadQueuedMessageTargetArgs, SendQueuedMessageRequest {}
+interface ThreadQueuedMessageReorderArgs
+  extends ThreadQueuedMessageTargetArgs, ReorderQueuedMessageRequest {}
+interface ThreadQueuedMessageGroupBoundaryArgs extends SetQueuedMessageGroupBoundaryRequest {
+  threadId: string;
+}
+interface ThreadStorageFilesArgs extends ThreadStorageFilesQuery {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadStoragePathsArgs extends ThreadStoragePathsQuery {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadTimelineTurnSummaryDetailsArgs extends TimelineTurnSummaryDetailsQuery {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadTabsUpdateArgs extends UpdateThreadTabsRequest {
+  threadId: string;
+}
+interface ThreadOpenArgs {
+  threadId: string;
+  split?: ThreadOpenSplit;
+  file: ThreadOpenFile | null;
+}
+interface ThreadPaneActionArgs {
+  action: ThreadPaneAction;
+  threadId: string;
+}
+interface ThreadEventsListArgs {
+  afterSeq?: string;
+  limit?: string;
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadEventWaitArgs {
+  afterSeq?: string;
+  signal?: AbortSignal;
+  threadId: string;
+  type: string;
+  waitMs: string;
+}
+interface ThreadTimelineArgs extends ThreadTimelineQuery {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadOutputArgs {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadInteractionListArgs {
+  signal?: AbortSignal;
+  threadId: string;
+}
+interface ThreadInteractionTargetArgs {
+  interactionId: string;
+  threadId: string;
+}
+interface ThreadInteractionGetArgs extends ThreadInteractionTargetArgs {
+  signal?: AbortSignal;
+}
+interface ThreadInteractionResolveArgs extends ThreadInteractionTargetArgs {
+  resolution: PendingInteractionResolution;
+}
+interface ThreadInteractionRespondArgs extends ThreadInteractionTargetArgs {
+  value: JsonValue$1;
+}
+type ThreadWaitTarget =
+  | {
+      kind: "status";
+      status: ThreadStatus;
+    }
+  | {
+      kind: "event";
+      eventType: string;
+    };
+interface ThreadWaitArgs {
+  event?: string;
+  pollIntervalMs?: number;
+  signal?: AbortSignal;
+  status?: ThreadStatus;
+  threadId: string;
+  timeoutMs?: number;
+}
+type ThreadWaitResult =
+  | {
+      event: NonNullable<ThreadEventWaitResult>;
+      matched: true;
+      target: Extract<
+        ThreadWaitTarget,
+        {
+          kind: "event";
+        }
+      >;
+      threadId: string;
+    }
+  | {
+      matched: true;
+      target: Extract<
+        ThreadWaitTarget,
+        {
+          kind: "status";
+        }
+      >;
+      thread: ThreadGetResult;
+      threadId: string;
+    };
+interface ThreadInteractionsArea {
+  cancel(
+    args: ThreadInteractionTargetArgs
+  ): Promise<ThreadInteractionCancelResult>;
+  get(args: ThreadInteractionGetArgs): Promise<ThreadInteractionGetResult>;
+  list(args: ThreadInteractionListArgs): Promise<ThreadInteractionListResult>;
+  resolve(
+    args: ThreadInteractionResolveArgs
+  ): Promise<ThreadInteractionResolveResult>;
+  respond(
+    args: ThreadInteractionRespondArgs
+  ): Promise<ThreadInteractionRespondResult>;
+}
+interface ThreadEventsArea {
+  list(args: ThreadEventsListArgs): Promise<ThreadEventsListResult>;
+  wait(args: ThreadEventWaitArgs): Promise<ThreadEventWaitResult>;
+}
+interface ThreadQueuedMessagesArea {
+  create(
+    args: ThreadQueuedMessageCreateArgs
+  ): Promise<ThreadQueuedMessageCreateResult>;
+  delete(
+    args: ThreadQueuedMessageTargetArgs
+  ): Promise<ThreadQueuedMessageDeleteResult>;
+  list(args: ThreadQueuedMessageArgs): Promise<ThreadQueuedMessagesResult>;
+  reorder(
+    args: ThreadQueuedMessageReorderArgs
+  ): Promise<ThreadQueuedMessageReorderResult>;
+  send(
+    args: ThreadQueuedMessageSendArgs
+  ): Promise<ThreadQueuedMessageSendResult>;
+  setGroupBoundary(
+    args: ThreadQueuedMessageGroupBoundaryArgs
+  ): Promise<ThreadQueuedMessageGroupBoundaryResult>;
+  update(
+    args: ThreadQueuedMessageUpdateArgs
+  ): Promise<ThreadQueuedMessageUpdateResult>;
+}
+interface ThreadTabsArea {
+  get(args: ThreadStatusArgs): Promise<ThreadTabsResult>;
+  update(args: ThreadTabsUpdateArgs): Promise<ThreadTabsUpdateResult>;
+}
+interface ThreadsArea {
+  archive(args: ThreadActionArgs): Promise<ThreadArchiveResult>;
+  archiveAll(args: ThreadActionArgs): Promise<ThreadArchiveAllResult>;
+  childSummary(args: ThreadStatusArgs): Promise<ThreadChildSummaryResult>;
+  cancelPlan(args: ThreadActionArgs): Promise<ThreadBannerActionResult>;
+  clearGoal(args: ThreadActionArgs): Promise<ThreadBannerActionResult>;
+  conversationOutline(
+    args: ThreadStatusArgs
+  ): Promise<ThreadConversationOutlineResult>;
+  defaultExecutionOptions(
+    args: ThreadStatusArgs
+  ): Promise<ThreadDefaultExecutionOptionsResult>;
+  delete(args: ThreadDeleteArgs): Promise<ThreadDeleteResult>;
+  events: ThreadEventsArea;
+  fork(args: ThreadForkArgs): Promise<ThreadForkResult>;
+  get(args: ThreadGetArgs): Promise<ThreadGetResult>;
+  interactions: ThreadInteractionsArea;
+  list(args?: ThreadListArgs): Promise<ThreadListResult>;
+  markRead(args: ThreadActionArgs): Promise<ThreadReadStateResult>;
+  markUnread(args: ThreadActionArgs): Promise<ThreadReadStateResult>;
+  open(args: ThreadOpenArgs): Promise<ThreadOpenResult>;
+  paneAction(args: ThreadPaneActionArgs): Promise<ThreadPaneActionResult>;
+  output(args: ThreadOutputArgs): Promise<ThreadOutputResponse>;
+  pin(args: ThreadActionArgs): Promise<ThreadMutationResult>;
+  promptHistory(
+    args: ThreadPromptHistoryArgs
+  ): Promise<ThreadPromptHistoryResult>;
+  queuedMessages: ThreadQueuedMessagesArea;
+  reorderPinned(args: ThreadPinOrderArgs): Promise<ThreadPinOrderResult>;
+  search(args: ThreadSearchArgs): Promise<ThreadSearchResult>;
+  send(args: ThreadSendArgs): Promise<ThreadSendResult>;
+  spawn(args: ThreadSpawnArgs): Promise<ThreadSpawnResult>;
+  stop(args: ThreadActionArgs): Promise<ThreadStopResult>;
+  tabs: ThreadTabsArea;
+  timeline(args: ThreadTimelineArgs): Promise<ThreadTimelineResult>;
+  timelineTurnSummaryDetails(
+    args: ThreadTimelineTurnSummaryDetailsArgs
+  ): Promise<ThreadTimelineTurnSummaryDetailsResult>;
+  storageFiles(args: ThreadStorageFilesArgs): Promise<ThreadStorageFilesResult>;
+  storagePaths(args: ThreadStoragePathsArgs): Promise<ThreadStoragePathsResult>;
+  unarchive(args: ThreadActionArgs): Promise<ThreadUnarchiveResult>;
+  unpin(args: ThreadActionArgs): Promise<ThreadMutationResult>;
+  update(args: ThreadUpdateArgs): Promise<ThreadMutationResult>;
+  wait(args: ThreadWaitArgs): Promise<ThreadWaitResult>;
+}
+
+type ThreadSectionCreateResult = ThreadSectionResponse;
+type ThreadSectionUpdateResult = ThreadSectionMutationResponse;
+type ThreadSectionDeleteResult = ThreadSectionMutationResponse;
+type ThreadSectionListResult = ThreadSectionResponse[];
+interface ThreadSectionListArgs {
+  signal?: AbortSignal;
+}
+interface ThreadSectionsArea {
+  create(args: CreateThreadSectionRequest): Promise<ThreadSectionCreateResult>;
+  delete(args: DeleteThreadSectionRequest): Promise<ThreadSectionDeleteResult>;
+  list(args?: ThreadSectionListArgs): Promise<ThreadSectionListResult>;
+  update(args: UpdateThreadSectionRequest): Promise<ThreadSectionUpdateResult>;
+}
+
+interface BbSdk extends BbRealtime {
+  environments: EnvironmentsArea;
+  files: FilesArea;
+  guide: GuideArea;
+  hosts: HostsArea;
+  projects: ProjectsArea;
+  plugins: PluginsArea;
+  providers: ProvidersArea;
+  skills: SkillsArea;
+  status: StatusArea;
+  system: SystemArea;
+  terminals: TerminalsArea;
+  theme: ThemeArea;
+  threadSections: ThreadSectionsArea;
+  threads: ThreadsArea;
+}
+
+/**
+ * The backend plugin API contract — the `bb` object handed to a plugin's
+ * `server.ts` factory (`export default function plugin(bb: BbPluginApi)`).
+ *
+ * Types only: the implementation lives in the BB server
+ * (apps/server/src/services/plugins/plugin-api.ts), which imports these
+ * shapes so the contract and the implementation cannot drift. Plugin authors
+ * import them type-only (`import type { BbPluginApi } from
+ * "@bb/plugin-sdk"`); the import is erased when BB loads the file.
+ *
+ * Runtime classes stay host-side. NeedsConfigurationError in particular is
+ * matched by NAME, so plugin code needs no runtime import:
+ * `throw Object.assign(new Error(msg), { name: "NeedsConfigurationError" })`.
+ */
+interface PluginLogger {
+  debug(message: string): void;
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+/**
+ * Declarative settings descriptors (`bb.settings.define`). Deliberately plain
+ * data — not zod — so the host can render settings forms and the CLI can
+ * parse values without executing plugin code.
+ */
+type PluginSettingDescriptor =
+  | {
+      type: "string";
+      label: string;
+      description?: string;
+      /** Stored in a 0600 file under <dataDir>/plugins/<id>/secrets/, never in the db or sent to the frontend. */
+      secret?: true;
+      default?: string;
+    }
+  | {
+      type: "boolean";
+      label: string;
+      description?: string;
+      default?: boolean;
+    }
+  | {
+      type: "select";
+      label: string;
+      description?: string;
+      options: string[];
+      default?: string;
+    }
+  | {
+      type: "project";
+      label: string;
+      description?: string;
+      default?: string;
+    };
+type PluginSettingDescriptors = Record<string, PluginSettingDescriptor>;
+type PluginSettingValue = string | boolean;
+/** `default` present → non-optional value; absent → `T | undefined`. */
+type PluginSettingsValues<Ds extends Record<string, PluginSettingDescriptor>> =
+  {
+    [K in keyof Ds]: Ds[K] extends {
+      default: string | boolean;
+    }
+      ? PluginSettingValueOf<Ds[K]>
+      : PluginSettingValueOf<Ds[K]> | undefined;
+  };
+type PluginSettingValueOf<D extends PluginSettingDescriptor> = D extends {
+  type: "boolean";
+}
+  ? boolean
+  : string;
+interface PluginSettingsHandle<
+  Ds extends Record<string, PluginSettingDescriptor>,
+> {
+  /** Load-safe: callable inside the factory. */
+  get(): Promise<PluginSettingsValues<Ds>>;
+  /** Fires after values change through the settings route/CLI. */
+  onChange(
+    listener: (
+      next: PluginSettingsValues<Ds>,
+      prev: PluginSettingsValues<Ds>
+    ) => void
+  ): void;
+}
+interface PluginSettings {
+  define<Ds extends Record<string, PluginSettingDescriptor>>(
+    descriptors: Ds
+  ): PluginSettingsHandle<Ds>;
+}
+interface PluginKvStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(prefix?: string): Promise<string[]>;
+}
+interface PluginStorage {
+  /** Namespaced JSON key-value rows in bb.db; values ≤256KB each. */
+  kv: PluginKvStorage;
+  /**
+   * Open (or reuse the path of) the plugin's own SQLite database at
+   * <dataDir>/plugins/<id>/data.db — the server's better-sqlite3, WAL mode,
+   * busy_timeout 5000. Handles are host-tracked and closed on
+   * dispose/reload; a closed handle throws on use.
+   */
+  database(): Database.Database;
+  /**
+   * Ordered-statement migration helper: statement index = migration id in a
+   * `_bb_migrations` table; unapplied statements run in one transaction.
+   * Append-only — never reorder or edit shipped statements.
+   */
+  migrate(db: Database.Database, statements: string[]): void;
+}
+/**
+ * Thread lifecycle events a plugin can observe (design §4.5). Observe-only:
+ * handlers run fire-and-forget after the transition is applied and can never
+ * block or veto it. `thread` is the same public DTO GET /threads/:id serves.
+ */
+interface PluginThreadEventPayloads {
+  /** Fired after a thread row is created. */
+  "thread.created": {
+    thread: ThreadResponse;
+  };
+  /** Fired when a thread transitions into `active`. */
+  "thread.active": {
+    thread: ThreadResponse;
+  };
+  /** Fired when a thread transitions into `idle`. `lastAssistantText` is
+   * assembled the same way GET /threads/:id/output is. */
+  "thread.idle": {
+    thread: ThreadResponse;
+    lastAssistantText: string | null;
+  };
+  /** Fired when a thread transitions into `error`. `error` is the latest
+   * system/error event message, when one exists. */
+  "thread.failed": {
+    thread: ThreadResponse;
+    error: string | null;
+  };
+  /** Fired after a thread is archived (including cascade archives). */
+  "thread.archived": {
+    thread: ThreadResponse;
+  };
+  /** Fired after a thread is soft-deleted. */
+  "thread.deleted": {
+    thread: ThreadResponse;
+  };
+}
+type PluginThreadEventName = keyof PluginThreadEventPayloads;
+type PluginThreadEventHandler<E extends PluginThreadEventName> = (
+  payload: PluginThreadEventPayloads[E]
+) => void | Promise<void>;
+type PluginHttpAuthMode = "local" | "token" | "none";
+type PluginHttpHandler = (context: Context) => Response | Promise<Response>;
+interface PluginHttp {
+  /**
+   * Register an HTTP route, mounted at
+   * `/api/v1/plugins/<id>/http/<path>`. Auth modes (default "local"):
+   * - "local": Origin/Host must be a local BB app origin; non-GET requires
+   *   content-type application/json (forces a CORS preflight).
+   * - "token": requires the per-plugin token (`bb plugin token <id>`) via
+   *   the x-bb-plugin-token header or ?token=.
+   * - "none": no checks — only for signature-verified webhooks.
+   */
+  route(
+    method: string,
+    path: string,
+    handler: PluginHttpHandler,
+    opts?: {
+      auth?: PluginHttpAuthMode;
+    }
+  ): void;
+}
+interface PluginRpc {
+  /**
+   * Register a Standard Schema-driven rpc contract and its inferred handlers,
+   * served at POST
+   * `/api/v1/plugins/<id>/rpc/<method>` with "local" auth semantics. The
+   * host validates input before invocation and output before strict JSON
+   * serialization. The response is `{ ok: true, result }` or
+   * `{ ok: false, error: { code, message, issues? } }`.
+   */
+  register<Contract extends PluginRpcContract>(
+    contract: Contract,
+    handlers: PluginRpcHandlers<Contract>
+  ): void;
+}
+interface PluginRealtime {
+  /**
+   * Broadcast an ephemeral `plugin-signal` WS message
+   * `{ pluginId, channel, payload }` to every connected client (V1 has no
+   * per-channel subscriptions). `payload` must be JSON-serializable;
+   * `undefined` is normalized to `null`. Nothing is persisted.
+   */
+  publish(channel: string, payload: unknown): void;
+}
+interface PluginBackground {
+  /**
+   * Register a long-lived background service. `start` runs after the
+   * factory completes and should resolve when `signal` aborts
+   * (dispose/reload/disable/shutdown). A crash restarts it with capped
+   * exponential backoff; throwing NeedsConfigurationError marks the plugin
+   * `needs-configuration` and stops restarting until the next load.
+   */
+  service(
+    name: string,
+    service: {
+      start(signal: AbortSignal): void | Promise<void>;
+    }
+  ): void;
+  /**
+   * Register a cron schedule (5-field expression, server-local time). The
+   * durable row keyed (pluginId, name) is upserted at load; the periodic
+   * sweep claims due rows with a CAS on next_run_at, but only while this
+   * plugin is loaded. Failures land in last_status/last_error, visible in
+   * `bb plugin list`.
+   */
+  schedule(name: string, cron: string, fn: () => void | Promise<void>): void;
+}
+interface PluginCliCommandInfo {
+  name: string;
+  summary: string;
+  usage: string;
+}
+/** Context forwarded from the invoking CLI when known; all fields optional. */
+interface PluginCliContext {
+  cwd?: string;
+  threadId?: string;
+  projectId?: string;
+  /** Aborted when the invoking CLI HTTP request disconnects. */
+  signal?: AbortSignal;
+}
+type PluginInteractionCancelReason =
+  | "user"
+  | "request-aborted"
+  | "thread-stopped"
+  | "thread-deleted"
+  | "plugin-disposed"
+  | "server-restarted"
+  | "timeout";
+type PluginInteractionResult =
+  | {
+      outcome: "submitted";
+      value: JsonValue;
+    }
+  | {
+      outcome: "cancelled";
+      reason: PluginInteractionCancelReason;
+    };
+interface PluginInteractionRequest {
+  threadId: string;
+  rendererId: string;
+  title: string;
+  payload: JsonValue;
+  /** Defaults to ten minutes; capped at one hour. */
+  timeoutMs?: number;
+}
+interface PluginCliResult {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+}
+/**
+ * Maximum combined UTF-8 bytes accepted from plugin CLI stdout and stderr.
+ * This is the shared source of truth for production and the testing harness.
+ */
+declare const PLUGIN_CLI_OUTPUT_MAX_BYTES: number;
+interface PluginCliOutputLimitError {
+  code: "plugin_cli_output_too_large";
+  message: string;
+  maxBytes: number;
+  stdoutBytes: number;
+  stderrBytes: number;
+  totalBytes: number;
+}
+/** Normalized host result returned by the plugin CLI HTTP/testing boundary. */
+interface PluginCliExecutionResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error?: PluginCliOutputLimitError;
+}
+interface PluginCliRegistration {
+  /** Top-level command name (`bb <name> …`): lowercase [a-z0-9-]+, and not
+   * a core bb command (see RESERVED_BB_CLI_COMMANDS in the server). */
+  name: string;
+  summary: string;
+  /** Subcommand metadata rendered in help and the plugin-commands skill
+   * without executing plugin code. Parsing argv is plugin-owned. */
+  commands?: PluginCliCommandInfo[];
+  run(
+    argv: string[],
+    ctx: PluginCliContext
+  ): PluginCliResult | Promise<PluginCliResult>;
+}
+interface PluginCli {
+  /**
+   * Register this plugin's `bb` subcommand. One registration per factory
+   * execution; a repeated call is rejected. Core bb commands always win
+   * name collisions; reserved names are rejected at registration.
+   */
+  register(registration: PluginCliRegistration): void;
+}
+/** Per-turn context handed to bb.agents context providers (design §4.4). */
+/** MCP-style content parts a native tool may return (design §4.4). */
+type PluginAgentToolContentPart =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "image";
+      data: string;
+      mimeType: string;
+    };
+type PluginAgentToolResult =
+  | string
+  | {
+      content: PluginAgentToolContentPart[];
+      isError?: boolean;
+    };
+/** Per-call context handed to a native tool's execute (design §4.4). */
+interface PluginAgentToolContext {
+  threadId: string;
+  projectId: string;
+  /** The tool-call request's abort signal (aborts if the daemon round-trip
+   * is torn down mid-call). */
+  signal: AbortSignal;
+}
+/**
+ * Native timeline labels for a plugin tool, keyed by BB's own timeline row
+ * status. This is experimental: BB may refine its presentation contract
+ * before the field is stabilized.
+ */
+interface PluginAgentToolExperimentalStatusLabels {
+  /** Label shown while the tool call is pending. */
+  pending: string;
+  /** Label shown after the tool call completes successfully. */
+  completed: string;
+}
+interface PluginAgentToolRegistrationBase {
+  /** Tool name shown to the model: [a-zA-Z0-9_-]+, unique across plugins,
+   * and not a built-in dynamic tool (see RESERVED_AGENT_TOOL_NAMES in the
+   * server). */
+  name: string;
+  description: string;
+  /**
+   * Optional usage snippet appended to the thread instructions whenever
+   * this tool is in the session's tool set (mirrors the built-in
+   * update_environment_directory guidance). Limited to 4096 characters.
+   */
+  instructions?: string;
+  /**
+   * Optional native timeline labels. When omitted, BB shows the standard
+   * tool name and arguments (for example, `Ran tool search_docs …`). Labels
+   * apply only while the call is pending and after successful completion;
+   * approval, error, and interruption states keep BB's standard rendering.
+   */
+  experimental_statusLabels?: PluginAgentToolExperimentalStatusLabels;
+}
+/** Stable, plain-data context resolved by the server for one agent session. */
+interface PluginAgentConfigurationContext {
+  thread: {
+    id: string;
+    title: string | null;
+    parentThreadId: string | null;
+    sourceThreadId: string | null;
+  };
+  project: {
+    id: string;
+    kind: "standard" | "personal";
+    name: string;
+    gitRemoteUrl: string | null;
+  };
+  environment: {
+    id: string;
+    name: string | null;
+    path: string | null;
+    workspaceProvisionType: "unmanaged" | "managed-worktree" | "personal";
+    branchName: string | null;
+  };
+  host: {
+    id: string;
+    name: string;
+  };
+  provider: {
+    id: string;
+    model: string;
+  };
+  /** How the thread was spawned. A side chat is the builtin side-chat
+   * plugin's fork: `{ kind: "fork", pluginId: "side-chat" }`. */
+  origin: {
+    kind: "fork" | null;
+    pluginId: string | null;
+  };
+}
+/** Object form of a {@link PluginAgentConfiguration} tools entry: selects a
+ * registered tool and overrides the parameter schema advertised to the
+ * provider for this resolution only. */
+interface PluginAgentToolSelection {
+  /** Name of a tool registered by this plugin via `registerTool`. */
+  name: string;
+  /** JSON-schema object (root `type: "object"`, JSON-serializable, at most
+   * 128 KiB serialized) sent to the provider in place of the registered
+   * parameter schema. Execution-side validation still runs the registered
+   * parameters, so the override must only narrow what the registered schema
+   * already accepts. */
+  parameters: Record<string, unknown>;
+}
+/** Per-resolution selection returned by {@link PluginAgents.configure}. */
+interface PluginAgentConfiguration {
+  /** Tool names registered by this plugin, or {@link PluginAgentToolSelection}
+   * entries to also override a tool's advertised parameter schema for this
+   * resolution. Duplicate or unknown names, or an invalid override, reject
+   * this plugin's complete selection for the resolution. */
+  tools: Array<string | PluginAgentToolSelection>;
+  /** Skill frontmatter names from this plugin's manifest skill roots.
+   * Duplicate or unknown names reject this plugin's complete selection. */
+  skills: string[];
+  /** Optional dynamic instructions. Output is truncated to 4096 characters. */
+  instructions?: string;
+}
+interface PluginAgents {
+  /**
+   * Select this plugin's statically registered tools and manifest skills for
+   * each thread/session resolution, with optional dynamic instructions. The
+   * callback is synchronous and runs at `thread.start` / `turn.submit`; it
+   * never rebuilds registrations. Exactly one callback may be registered per
+   * factory execution. A throw, malformed result, duplicate id, unknown id,
+   * or more than 256 tool/skill ids fails closed for this plugin only.
+   *
+   * Tools take effect when the provider session is next started or resumed;
+   * an already-running session is not hot-mutated. Instructions are resolved
+   * for the next turn. Skill changes follow BB's environment runtime policy:
+   * a busy runtime keeps its current catalog until a safe relaunch. Side chats
+   * are ordinary plugin-owned forks here — read `origin` to detect them — and
+   * their returned tool, skill, and dynamic-instruction selections apply at the
+   * same boundaries.
+   */
+  configure(
+    provider: (
+      context: PluginAgentConfigurationContext
+    ) => PluginAgentConfiguration
+  ): void;
+  /**
+   * Register a native dynamic tool (design §4.4). `parameters` is either a
+   * zod schema (validated per call; execute receives the parsed value) or a
+   * plain JSON-schema object (no validation; execute receives the raw
+   * arguments as `unknown`). Tool-set changes apply on the NEXT session
+   * start — a tool registered mid-session is not hot-added to running
+   * provider sessions. A second registration of the same name within this
+   * plugin is rejected; a name already registered by another plugin is
+   * rejected and surfaced as this plugin's status detail.
+   */
+  registerTool<Schema extends z.ZodType>(
+    tool: PluginAgentToolRegistrationBase & {
+      parameters: Schema;
+      execute(
+        params: z.output<Schema>,
+        ctx: PluginAgentToolContext
+      ): PluginAgentToolResult | Promise<PluginAgentToolResult>;
+    }
+  ): void;
+  registerTool(
+    tool: PluginAgentToolRegistrationBase & {
+      /** Raw JSON-schema escape hatch; params arrive unvalidated. */
+      parameters: Record<string, unknown>;
+      execute(
+        params: unknown,
+        ctx: PluginAgentToolContext
+      ): PluginAgentToolResult | Promise<PluginAgentToolResult>;
+    }
+  ): void;
+  /**
+   * Contribute a dynamic section appended to thread instructions. The
+   * provider runs when a thread's runtime command config is resolved
+   * (thread.start / turn.submit); return null to contribute nothing for
+   * that resolution. Must be synchronous and fast — it sits on the
+   * thread-start path. Output longer than 4096 characters is truncated; a
+   * throwing provider is logged against the plugin and contributes nothing.
+   * A repeated registration within one factory execution is rejected.
+   */
+  contributeInstructions(
+    provider: (ctx: { threadId: string; projectId: string }) => string | null
+  ): void;
+}
+type PluginMentionTrigger = "@" | "#" | "$" | "!" | "~";
+/** Search context handed to a mention provider (design §4.9). `projectId`/
+ * `threadId` are null when the composer has not committed one yet. */
+interface PluginMentionSearchContext {
+  trigger: PluginMentionTrigger;
+  query: string;
+  projectId: string | null;
+  threadId: string | null;
+}
+/** One row a mention provider returns from `search`. `id` is the provider's
+ * own item id — the host namespaces it before it reaches the wire. */
+interface PluginMentionItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  icon?: string;
+}
+interface PluginMentionProviderRegistration {
+  /** Unique within this plugin: [a-zA-Z0-9_-]+ (no ":" — the host composes
+   * wire item ids as "<providerId>:<itemId>"). */
+  id: string;
+  /** Section label shown above this provider's rows in the mention menu. */
+  label: string;
+  /**
+   * Composer trigger characters this provider should answer. Omit to use the
+   * default `@` mention trigger. Valid triggers are `@`, `#`, `$`, `!`, and `~`.
+   */
+  triggers?: readonly PluginMentionTrigger[];
+  /**
+   * Runs server-side as the user types after one of this provider's triggers
+   * in the composer. Each call is time-boxed (2s) and failure-isolated: a slow
+   * or throwing provider contributes an empty list — it can never break the
+   * mention menu.
+   */
+  search(
+    ctx: PluginMentionSearchContext
+  ): PluginMentionItem[] | Promise<PluginMentionItem[]>;
+  /**
+   * Resolves one picked item into agent context, called once per unique
+   * item at message send time. The returned `context` is attached to the
+   * message as an agent-visible (user-hidden) prompt input. Throwing blocks
+   * the send with a visible error.
+   */
+  resolve(itemId: string):
+    | {
+        context: string;
+      }
+    | Promise<{
+        context: string;
+      }>;
+}
+interface PluginUi {
+  /** Block until the app submits or cancels a plugin-owned composer form. */
+  requestInput(
+    request: PluginInteractionRequest,
+    options?: {
+      signal?: AbortSignal;
+    }
+  ): Promise<PluginInteractionResult>;
+  /**
+   * Register a mention provider for the shipped app's composer (design §4.9).
+   * Providers default to the `@` trigger and may opt into `#`, `$`, `!`, or
+   * `~` with `triggers`. Items group under `label` in the mention menu; a
+   * picked item becomes a `{ kind: "plugin" }` mention resource whose context
+   * is resolved once at send time. Multiple providers per plugin; ids must be
+   * unique within the plugin.
+   */
+  registerMentionProvider(provider: PluginMentionProviderRegistration): void;
+}
+interface PluginEvents {
+  /**
+   * Add a thread lifecycle listener. Multiple listeners for the same event are
+   * additive and run independently in registration order.
+   */
+  on<E extends PluginThreadEventName>(
+    event: E,
+    handler: PluginThreadEventHandler<E>
+  ): void;
+}
+interface PluginServerApi {
+  /**
+   * This BB server's own loopback base URL (e.g. "http://127.0.0.1:38886"),
+   * which serves the SPA + /api + /ws. For plugins that proxy or relay
+   * traffic back to the server itself (e.g. a tunnel). Bind-gated like
+   * `bb.sdk`: reading it before the server is listening throws, so prefer
+   * reading it from handlers, services, and timers.
+   */
+  readonly loopbackBaseUrl: string;
+}
+interface PluginSharedPortTunnelIdentity {
+  /** Gate routing label assigned to this machine. */
+  label: string;
+  /** Gate apex without a scheme, e.g. "getbb.app". */
+  baseDomain: string;
+}
+interface PluginHosts {
+  /**
+   * Ensure this enrolled host has a gate label and return its read-only public
+   * identity. The daemon chooses the trusted gate and desired label; plugins
+   * cannot influence either credential-bearing destination.
+   */
+  ensureSharedPortTunnel(
+    hostId: string
+  ): Promise<PluginSharedPortTunnelIdentity>;
+  /**
+   * Replace this plugin's desired shared-loopback ports for one host. The
+   * server aggregates declarations, owns generations, and delivers the
+   * resulting set to that host's daemon. Tunnel identity is deliberately not
+   * accepted here: it is owned by the daemon's trusted enrollment.
+   */
+  declareSharedPorts(hostId: string, ports: readonly number[]): void;
+}
+interface PluginStatusApi {
+  /**
+   * Mark this plugin `needs-configuration` (with a message shown in
+   * `bb plugin list` and the UI) instead of failing — e.g. a factory or
+   * service that finds no API key configured. Cleared on the next load;
+   * saving settings does not auto-reload in V1, so ask the user to
+   * `bb plugin reload <id>` after configuring.
+   */
+  needsConfiguration(message: string): void;
+}
+/**
+ * The API object handed to a plugin's factory (design §4). Implemented by
+ * the BB server; this contract is what plugin `server.ts` files compile
+ * against.
+ */
+interface BbPluginApi {
+  /** The plugin's own id (namespaces storage, routes, commands). */
+  readonly pluginId: string;
+  /** Leveled, plugin-scoped logger. */
+  readonly log: PluginLogger;
+  /** Declarative settings (design §4.2). */
+  readonly settings: PluginSettings;
+  /** Namespaced KV + per-plugin database (design §4.3). */
+  readonly storage: PluginStorage;
+  /** HTTP routes under /api/v1/plugins/<id>/http/* (design §4.6). */
+  readonly http: PluginHttp;
+  /** RPC methods under /api/v1/plugins/<id>/rpc/<method> (design §4.6). */
+  readonly rpc: PluginRpc;
+  /** Ephemeral push to connected frontends (design §4.7). */
+  readonly realtime: PluginRealtime;
+  /** Long-lived services + cron schedules (design §4.8). */
+  readonly background: PluginBackground;
+  /** Agent-facing `bb` CLI subcommand (design §4.4). */
+  readonly cli: PluginCli;
+  /** Per-turn agent context contributions (design §4.4). */
+  readonly agents: PluginAgents;
+  /** Host-rendered UI contributions (design §4.9). */
+  readonly ui: PluginUi;
+  /** Additive plugin lifecycle listeners (design §4.5). */
+  readonly events: PluginEvents;
+  /** Plugin-reported status (needs-configuration). */
+  readonly status: PluginStatusApi;
+  /** Read-only facts about the running server (loopback base URL). */
+  readonly server: PluginServerApi;
+  /** Server-to-daemon host control-plane declarations. */
+  readonly hosts: PluginHosts;
+  /**
+   * The full BB SDK, bound to this server over loopback (design §4.1).
+   * Bind-gated: reading this before the host binds the SDK throws. The real
+   * server binds it before loading plugins, so it is available from the
+   * moment factories run there — but isolated harnesses may not, so prefer
+   * using it from handlers, services, and timers for portability.
+   * `threads.spawn` defaults `origin` to "plugin" and `originPluginId` to
+   * this plugin's id so spawned threads are attributed automatically.
+   */
+  readonly sdk: BbSdk;
+  /**
+   * Register cleanup to run on reload/disable/shutdown. Hooks run LIFO.
+   * The sanctioned place to clear timers and close connections.
+   */
+  onDispose(hook: () => void | Promise<void>): void;
+}
+
+export { PLUGIN_CLI_OUTPUT_MAX_BYTES, defineRpcContract };
+export type {
+  BbContext,
+  BbNavigate,
+  BbPluginApi,
+  ComposerCustomization,
+  ComposerPlusMenuItem,
+  ComposerRichTextSpec,
+  ComposerStructuredDraft,
+  ComposerView,
+  JsonValue,
+  MarkdownProps,
+  NewThreadComposerProps,
+  NewThreadRequest,
+  PluginAgentConfiguration,
+  PluginAgentConfigurationContext,
+  PluginAgentToolContentPart,
+  PluginAgentToolContext,
+  PluginAgentToolExperimentalStatusLabels,
+  PluginAgentToolRegistrationBase,
+  PluginAgentToolResult,
+  PluginAgentToolSelection,
+  PluginAgents,
+  PluginAppBuilder,
+  PluginAppComposer,
+  PluginAppContentScripts,
+  PluginAppDefinition,
+  PluginAppSetup,
+  PluginAppSlots,
+  PluginBackground,
+  PluginCli,
+  PluginCliCommandInfo,
+  PluginCliContext,
+  PluginCliExecutionResult,
+  PluginCliOutputLimitError,
+  PluginCliRegistration,
+  PluginCliResult,
+  PluginComposerApi,
+  PluginComposerMention,
+  PluginComposerScope,
+  PluginComposerTextEffect,
+  PluginComposerThreadRowStatus,
+  PluginContentScriptContext,
+  PluginContentScriptDisposer,
+  PluginContentScriptRegistration,
+  PluginEvents,
+  PluginFileOpenerProps,
+  PluginFileOpenerRegistration,
+  PluginFileOpenerSource,
+  PluginHomepageSectionProps,
+  PluginHomepageSectionRegistration,
+  PluginHosts,
+  PluginHttp,
+  PluginHttpAuthMode,
+  PluginHttpHandler,
+  PluginInteractionCancelReason,
+  PluginInteractionRequest,
+  PluginInteractionResult,
+  PluginKvStorage,
+  PluginLogger,
+  PluginMentionItem,
+  PluginMentionProviderRegistration,
+  PluginMentionSearchContext,
+  PluginMentionTrigger,
+  PluginMessageActionContext,
+  PluginMessageActionRegistration,
+  PluginMessageActionThreadPanelOptions,
+  PluginMessageDirectiveMessage,
+  PluginMessageDirectiveOpenWorkspaceFile,
+  PluginMessageDirectiveProps,
+  PluginMessageDirectiveRegistration,
+  PluginNavPanelProps,
+  PluginNavPanelRegistration,
+  PluginPendingInteractionProps,
+  PluginPendingInteractionRegistration,
+  PluginPendingInteractionView,
+  PluginRealtime,
+  PluginRealtimeConnectionState,
+  PluginRpc,
+  PluginRpcCallArgs,
+  PluginRpcClient,
+  PluginRpcContract,
+  PluginRpcError,
+  PluginRpcErrorCode,
+  PluginRpcHandlers,
+  PluginRpcIssuePathSegment,
+  PluginRpcMethodContract,
+  PluginRpcResult,
+  PluginRpcValidationIssue,
+  PluginSdkApp,
+  PluginServerApi,
+  PluginSettingDescriptor,
+  PluginSettingDescriptors,
+  PluginSettingValue,
+  PluginSettings,
+  PluginSettingsHandle,
+  PluginSettingsSectionProps,
+  PluginSettingsSectionRegistration,
+  PluginSettingsState,
+  PluginSettingsValues,
+  PluginSharedPortTunnelIdentity,
+  PluginSidebarFooterActionContext,
+  PluginSidebarFooterActionProps,
+  PluginSidebarFooterActionRegistration,
+  PluginSidebarProject,
+  PluginSidebarPullRequest,
+  PluginSidebarSplitPane,
+  PluginSidebarThread,
+  PluginSidebarThreadActions,
+  PluginSidebarThreadActivity,
+  PluginSidebarThreadIndicator,
+  PluginSidebarThreadPullRequestState,
+  PluginSidebarThreadSplit,
+  PluginSidebarThreadsState,
+  PluginSidebarWorkspaceKind,
+  PluginStatusApi,
+  PluginStorage,
+  PluginThreadEventHandler,
+  PluginThreadEventName,
+  PluginThreadEventPayloads,
+  PluginThreadHeaderActionProps,
+  PluginThreadHeaderActionRegistration,
+  PluginThreadListProps,
+  PluginThreadListRegistration,
+  PluginThreadPanelActionContext,
+  PluginThreadPanelActionRegistration,
+  PluginThreadPanelProps,
+  PluginUi,
+  StandardSchemaV1,
+  StandardSchemaV1InferInput,
+  StandardSchemaV1InferOutput,
+  StandardSchemaV1Issue,
+  StandardSchemaV1Result,
+  ThreadChatMessageAction,
+  ThreadChatMessageReference,
+  ThreadChatProps,
+};


### PR DESCRIPTION
## Context

Unifies the browser design workbench and future bb plugins in one private Bun monorepo while keeping the canonical bb source checkout separate. Tracks #28 in the GitHub roadmap #21.

## What changed

- Renamed the repository and product umbrella to BB Mate
- Added a Bun workspace for apps/* and plugins/*
- Added a runnable React/Vite fake-state sidebar workbench
- Added root AGENTS.md, durable plans, architecture, publishing guidance, and CI
- Deleted the superseded empty bb-plugins repository after explicit approval
- Verified that no standalone bb-workspace repository or local checkout exists

## Verification

- bun run format:check
- bun run check
- bun run test
- bun run build
- Desktop and 390x844 browser QA, including GitButler scenario switching

## Risk

Low. This is a new private workspace with no published plugins or runtime integration yet.

## Issue

Implements #28 under roadmap #21.