### PR TITLE
feat: add explicit bb compatibility drift checks

### DIFF
--- a/.agents/goals/2026-08-07-os-627-independent-alpha/GOAL.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/GOAL.md
@@ -1,0 +1,178 @@
+# Goal Execution Contract: OS-627 upstream-independent alpha
+
+Date: 2026-08-07
+Status: Ready
+Spec: `.agents/goals/2026-08-07-os-627-independent-alpha/SPEC.md`
+Prompt: `.agents/goals/2026-08-07-os-627-independent-alpha/PROMPT.md`
+Retro: `.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md`
+Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
+
+## Completion Horizon
+
+`ready-pr`
+
+Complete when OS-629 through OS-637 are merged to `main` with their Linear
+issues Done, and OS-638 is an open ready PR with green CI, resolved review
+threads, zero open local-review P0-P2 findings, a traceable local candidate,
+and current evidence in `RETRO.md`.
+
+Not complete while work is local-only, a prerequisite PR/CI/review is pending,
+the clean-room trial has an open P0/P1, the candidate lacks an artifact or
+checksum, or the final handoff PR has been merged.
+
+## Authority
+
+- May commit, push, open drafts, mark ready, and merge OS-629 through OS-637
+  after their issue-specific verification, review, and hosted-CI gates.
+- May create local package archives, temporary isolated install environments,
+  deterministic screenshots/diffs, checksums, and static site builds.
+- May update Linear at phase boundaries through Done for merged prerequisites
+  and In Review for OS-638.
+- May passively read public registry data and native bb status/version output.
+- May not merge OS-638, publish packages, create tags/releases, change
+  visibility, send announcements, choose a public license, edit upstream bb,
+  expose/pair Connect, or install/dev/reload/remove plugins in normal bb state.
+- Needs user approval for any real native trial that mutates bb/plugin/Connect
+  state and for any public license, publication, visibility, or release action.
+
+## Boundary
+
+- In scope: OS-629 and OS-632 through OS-638, their code/tests/docs/evidence,
+  dependency-correct PRs, hosted follow-through, merges, and tracker hygiene.
+- Out of scope: OS-639 through OS-644, upstream/private fallbacks, public release.
+- Do not touch: `/Users/mg/Developer/bb/bb`, secrets, authenticated sessions,
+  normal plugin state, or Connect configuration.
+
+## Topology
+
+Central coordinator with bounded audits and reviews. Reviewers may write only
+ignored packet-local scratch reports; source, VCS, tracker, and external writes
+remain centralized. Implementation is sequential across conflict-heavy files.
+Each issue uses its Linear branch name and a focused PR. OS-633, OS-634, and
+OS-632 form an incremental dependency chain; later branches start from
+reconciled `main` after their blockers merge.
+
+## Steps
+
+1. Compatibility alarm (OS-629)
+   - Outcome: one reviewable target data file, deterministic human/JSON check,
+     precise CI failures, focused tests, and manual live remeasurement runbook.
+   - Gate: public immutable inputs only; focused and aggregate checks; standing
+     and targeted reviews; ready/green PR; merge and Linear Done.
+
+2. Surface lab (OS-633)
+   - Outcome: Ladle static/serve workflow, explicit stories and deterministic
+     adapters for every catalog surface, richer bounded states, and completeness
+     tests; content-script discovery remains unmounted.
+   - Gate: no bb/Connect/secrets/sibling dependency; static build and browser
+     smoke proof; two-reviewer loop; ready/green PR; merge and Linear Done.
+
+3. Mate launcher (OS-634)
+   - Outcome: URL-stable plugin/surface/scenario/mode/theme/viewport controls,
+     discovered-candidate validation, accurate prerequisites, accessibility,
+     responsiveness, and explicit CLI/native handoffs.
+   - Gate: interaction and URL tests plus browser QA; no authenticated iframe or
+     implicit mutation; two-reviewer loop; ready/green PR; merge and Linear Done.
+
+4. Visual and accessibility regression (OS-632)
+   - Outcome: checked-in bounded browser matrix and baselines, deterministic
+     fonts/viewport/motion, readable diffs, axe plus keyboard/focus/contrast and
+     overlay interaction checks, measured replica geometry, update runbook.
+   - Gate: fast PR CI, static Ladle enumeration, reviewable baseline update,
+     two-reviewer loop; ready/green PR; merge and Linear Done.
+
+5. Clean local package (OS-635)
+   - Outcome: versioned allowlisted tarball and installed-package asset lookup;
+     help, fixture inspection, surface-lab start, uninstall, and content scans in
+     isolated temporary prefixes.
+   - Gate: no absolute path/symlink/secret/sibling/bundled-plugin dependency;
+     artifact/checksum proof; two-reviewer loop; ready/green PR; merge and Done.
+
+6. External author contract (OS-636)
+   - Outcome: verified quickstart, ownership/fidelity/trust/mutation matrix,
+     compatibility/support/deprecation policy, CONTRIBUTING and SECURITY, and
+     documented private-alpha/no-public-license-grant decision boundary.
+   - Gate: every command verified against clean checkout or artifact; security
+     review plus targeted docs review; ready/green PR; merge and Linear Done.
+
+7. Clean-room trial (OS-637)
+   - Outcome: reproducible isolated first-time-author simulation using only the
+     artifact/docs, with times, versions, successes, failures, decisions, and
+     concrete follow-ups recorded without secrets.
+   - Gate: mandatory fixture/no-bb lane; all P0/P1 fixed and trial rerun; full
+     aggregate and candidate checks; ready/green PR; merge and Linear Done.
+
+8. Local alpha handoff (OS-638)
+   - Outcome: version/changelog proposal, exact tarball/checksum/commit,
+     compatibility matrix, trial and CI evidence, known limitations, install /
+     update / uninstall / rollback guidance, proposed release copy, and go/no-go.
+   - Gate: all independent blockers complete; standing plus fresh full-stack
+     review; green hosted CI and resolved threads; ready PR; stop before merge.
+
+## Reviews
+
+- Keep one standing reviewer across milestones for doctrine, dependency, and
+  prior-finding continuity.
+- Use one fresh targeted reviewer per issue, reused through that issue's fix
+  loop. Fix all P0-P2 and reasonable P3 findings; record residual P3 rationale.
+- OS-637 additionally treats trial P0/P1 findings as blocking and requires rerun.
+- Finish OS-638 with the standing reviewer plus a fresh full-stack reviewer.
+- Store scratch reports beneath this packet's ignored `tmp/` directory.
+
+## Evidence Contract
+
+Record commands/results, report paths/scores/dispositions, branches/PRs/CI,
+thread counts, Linear states/comments, artifact version/path/checksum/content
+scan, trial environment and timings, baseline/diff results, goal amendments,
+and a forbidden-action audit in `RETRO.md`.
+
+## Verification
+
+- Iterate with the smallest relevant tests and runtime probe.
+- Before every ready PR and merge run `bun run format:check`, `bun run check`,
+  `bun run test`, and `bun run build` on the intended branch/stack.
+- Use public immutable artifacts and fake probe inputs for drift unit tests.
+- Use fixed browser/DPR/locale/timezone/color/motion/font inputs for snapshots.
+- Use `mktemp -d` with isolated HOME/XDG/cache/prefix for packaging and trial.
+- Do not use a fake bb binary as evidence of real Live behavior.
+- Validate this packet with both goal-loop prompt checks and the packet doctor.
+
+## Next Move
+
+Narrow failures, fix the owning issue, rerun focused checks/review, then broaden.
+After three failures on one path, change approach and record the evidence.
+Start downstream work only after its blockers are merged and `main` reconciled.
+
+## Waiting State
+
+- Waiting on: bounded review work, hosted CI, and remote review threads.
+- Check workers through collaboration status; CI with `gh pr checks`; PR state
+  with `gh pr view --json`; unresolved threads with the GitHub GraphQL API; and
+  tracker state through live Linear issue reads.
+- Heartbeat cadence: check once after 30 seconds, then at most every 60 seconds
+  while pending; report only state changes or a concise ten-minute heartbeat.
+- Continue when current blockers are green/resolved and `main` is reconciled.
+- Stop when access remains unavailable after verified retries, public/private
+  contracts cannot satisfy the issue, or consequential authority is required.
+- Last checked: preparation on 2026-08-07; clean `main` and CI green.
+
+## Persistence
+
+Keep the active plan and `RETRO.md` current at milestone boundaries. Resume
+from this file, `RETRO.md`, `but status`, live Linear, and GitHub PR state.
+
+## Amendments
+
+Record meaningful execution changes in `RETRO.md`. Do not weaken the horizon,
+authority, review model, or verification gates without explicit user approval.
+
+## Stop Rules
+
+- Stop before OS-638 merge, any publish/tag/release/visibility/announcement,
+  public-license choice, upstream edit, authenticated Connect use, or normal
+  plugin lifecycle mutation.
+- Stop if Fixture requires plugin execution, Harness needs copied/private code,
+  a URL can inspect arbitrary paths, or package/trial evidence depends on local
+  checkout symlinks, secrets, or absolute paths.
+- Stop for unisolatable user-owned changes, persistent authentication failure,
+  or acceptance criteria that require an unavailable public upstream contract.

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/PROMPT.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/PROMPT.md
@@ -1,0 +1,76 @@
+/goal From `/Users/mg/Developer/bb/bb-mate`, execute `.agents/goals/2026-08-07-os-627-independent-alpha` to `ready-pr`.
+
+## Read First
+
+Repo guidance, packet, active plan, live Linear, `but status`, GitHub.
+
+## Objective
+
+Complete remaining independent OS-627 work. Merge OS-629–637; leave OS-638 as the green ready approval PR.
+
+## Authority
+
+- Commit, push, open/ready PRs, merge OS-629–637 after green gates, update Linear.
+- Build local artifacts and isolated tests.
+- Never merge OS-638, release/publicize, choose a public license, edit `../bb`, or mutate normal plugins/Connect.
+
+## Boundary
+
+- In: OS-629 and OS-632–638 through PR/CI/review/Linear.
+- Out: OS-639–644, upstream/private substitutes, authenticated host sessions, release.
+
+## Sequence
+
+1. OS-629: compatibility target, public drift check, remeasurement runbook.
+2. OS-633: deterministic catalog-complete Ladle lab; content scripts stay unmounted.
+3. OS-634: URL-stable accessible launcher with validated targets/native handoffs.
+4. OS-632: bounded deterministic visual/a11y baselines over the finished lab.
+5. OS-635: allowlisted tarball and isolated install/run/uninstall proof.
+6. OS-636: verified author/trust/security/support docs and private-license boundary.
+7. OS-637: artifact/docs-only clean-room no-bb trial; fix P0/P1 and rerun.
+8. OS-638: traceable candidate/evidence/limitations/release proposal/go-no-go; stop ready.
+
+## Loop
+
+Per issue: start Linear/plan; define proof; implement; focused then aggregate Bun gates; standing plus fresh targeted review; fix P0-P2/reasonable P3; GitButler draft; clear hosted CI/threads; ready; merge prerequisite; reconcile main; record evidence.
+
+## Hard Rules
+
+- Native bb owns lifecycle/runtime; Mate discovers, inspects, fixtures, orchestrates, hands off.
+- Fixture is approximate, Harness public-contract behavior, Live bb visual authority. No private SDK fallback.
+- Browser plugin selection accepts only server-discovered candidates, never arbitrary paths.
+- Keep browser matrices small/deterministic; fake bb is not Live evidence.
+- Package/runtime has no sibling checkout, symlink, absolute path, secret, bundled plugin, or desktop asset.
+- Leave OS-639–644 untouched and separately upstream-dependent.
+
+## Verification
+
+Fix browser/DPR/locale/timezone/color/motion/font inputs. Isolate HOME/XDG/cache/prefix. Every ready/merge needs focused and aggregate Bun gates, green CI, resolved threads, correct Linear.
+
+## Review
+
+One standing reviewer; one fresh targeted reviewer per issue; final standing plus fresh full-stack. Zero open P0-P2; trial P0/P1 block.
+
+## Evidence Contract
+
+Update `RETRO.md` with checks, reviews, PR/CI/threads, Linear, baselines, artifact/checksum/scan, trial, amendments, forbidden-action audit.
+
+## Definition Of Done
+
+OS-629–637 merged/Done; OS-638 ready/green/resolved/unmerged. Candidate is traceable; all gates green; no blockers; upstream limits honest.
+
+## Not Done
+
+Local-only work, pending blockers/CI/review, unrerun trial failure, missing checksum/evidence, upstream substitute, merged OS-638, or public/release action.
+
+## Next Move
+
+Narrow failures, fix owning issue, recheck/review, broaden. Reconcile main before downstream work. After three failures change approach and record it.
+
+## Stop Rules
+
+Stop for forbidden authority, unisolatable dirt, persistent access failure, required unavailable public contract, or unsafe native trial. Never weaken the contract without approval.
+
+## Persistence
+
+Resume from `GOAL.md`, `RETRO.md`, `but status`, Linear, PRs. Keep state-change heartbeats. Continue until done unless a stop rule fires.

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md
@@ -1,0 +1,68 @@
+# Goal References: OS-627 upstream-independent alpha
+
+## Repo Guidance
+
+- `AGENTS.md` - native ownership, fixture/Harness/Live boundaries, Bun, plans.
+- `README.md` - current workflows, ownership table, and fidelity language.
+- `docs/architecture.md` - runtime, inspection, and public-surface boundaries.
+- `.agents/goals/2026-08-07-os-627-first-wave/` - completed precursor evidence.
+
+## Tracker
+
+- OS-627 - parent epic and alpha exit criteria.
+- OS-629 - compatibility target and drift alarm.
+- OS-633 - Ladle story lab; blocks OS-632 and OS-635.
+- OS-634 - complete Mate launcher; blocks OS-637.
+- OS-632 - deterministic visual/a11y coverage; blocks OS-637.
+- OS-635 - clean local package; blocks OS-637.
+- OS-636 - author/trust/support docs; blocks OS-637.
+- OS-637 - clean-room trial; blocks OS-638.
+- OS-638 - shareable-alpha handoff; final approval surface.
+- OS-639 through OS-644 - upstream-dependent Backlog, excluded.
+
+## Current Source Surfaces
+
+- `package.json` and `.github/workflows/ci.yml` - aggregate gates.
+- `apps/workbench/package.json` and `bun.lock` - lab/browser dependencies.
+- `apps/workbench/src/surface-catalog.ts` - catalog completeness authority.
+- `apps/workbench/src/surface-fixtures.ts` and `thread-list-fixtures.ts` -
+  deterministic fixture inputs.
+- `apps/workbench/src/App.tsx`, `components/MateOverlay.tsx`, and `styles.css` -
+  launcher and measured preview surface.
+- `apps/workbench/plugin-inspection-server.ts` - discovered target boundary.
+- `apps/cli/` and `packages/inspection/` - installed CLI/runtime dependencies.
+- `plugins/linear/package.json` - example engine ranges and native bb pin.
+
+## Public / Read-only Evidence
+
+- Native `bb --version` and passive JSON/status commands.
+- npm metadata for `bb-app`; unpublished `@bb/plugin-sdk` probe.
+- Immutable `get-bb/bb` release-tag raw artifacts and public registry index.
+- `/Users/mg/Developer/bb/bb/apps/app/package.json` and `.ladle/` - read-only
+  workflow-shape comparison only; never copied or imported.
+
+## Planned Branches
+
+- `os-629-add-explicit-bb-version-registry-and-visual-drift-checks`
+- `os-633-add-a-ladle-story-lab-for-every-plugin-owned-ui-surface`
+- `os-634-complete-the-mate-overlay-as-the-plugin-surface-scenario-and`
+- `os-632-add-deterministic-visual-regression-and-accessibility`
+- `os-635-package-bb-mate-for-clean-room-local-installation`
+- `os-636-write-the-external-plugin-author-guide-trust-model-and`
+- `os-637-run-a-clean-room-external-developer-bb-mate-alpha-trial`
+- `os-638-prepare-the-bb-mate-shareable-alpha-release-handoff`
+
+## Verification Commands
+
+- `bun run format:check`
+- `bun run check`
+- `bun run test`
+- `bun run build`
+- `but status --json`
+- goal-loop `check-goal-prompt --no-placeholders`
+- goal-loop `goal-loop-doctor`
+
+## Review Reports
+
+- `.agents/goals/2026-08-07-os-627-independent-alpha/tmp/reviews/` - ignored
+  scratch reports used during execution.

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -1,0 +1,126 @@
+# Execution Retro: OS-627 upstream-independent alpha
+
+Date started: 2026-08-07
+Date finalized: Pending
+Status: Active
+Spec: `.agents/goals/2026-08-07-os-627-independent-alpha/SPEC.md`
+Goal: `.agents/goals/2026-08-07-os-627-independent-alpha/GOAL.md`
+Prompt: `.agents/goals/2026-08-07-os-627-independent-alpha/PROMPT.md`
+Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
+
+## Summary
+
+- Objective: complete OS-629 and OS-632 through OS-638 without upstream work.
+- Completion horizon: `ready-pr`; OS-629 through OS-637 merge, OS-638 stops ready.
+- Baseline: clean `main` at `a637aa0`; main CI run 31206636916 green.
+- Capability baseline: native bb 0.35.1; official `@bb/plugin-sdk` remains
+  unpublished, so Harness stays accurately unavailable.
+- Forbidden actions: no publication, tag/release, visibility change,
+  announcement, public-license choice, upstream edit, normal plugin/Connect
+  mutation, or final OS-638 merge.
+
+## Readiness
+
+- Prompt checked: yes; 3,604 characters and no placeholders.
+- Goal/prompt alignment checked: yes; packet doctor passes.
+- Review blockers: none in preparation.
+- Verification blockers: none in preparation.
+- Tracker blockers: dependency graph recorded in the goal.
+- Authority blockers: public license/release and OS-638 merge remain owner gates.
+- Next action: start OS-629 and preserve execution evidence here.
+
+## Goal Amendments
+
+| Time            | Change                                | Reason                                                                 | Approved By         |
+| --------------- | ------------------------------------- | ---------------------------------------------------------------------- | ------------------- |
+| 2026-08-07 prep | Finish at ready OS-638 PR, not merged | OS-638 explicitly requires an owner gate before merging its handoff PR | Issue specification |
+| 2026-08-07 prep | Sequence OS-633 -> OS-634 -> OS-632   | Visual/a11y baselines must cover the completed launcher                | Preparation audit   |
+
+## Execution Log
+
+```text
+2026-08-07 - Preparation baseline
+- Changed: Prepared the active plan and direct-start goal packet.
+- Verified: clean main a637aa0; green CI 31206636916; bb 0.35.1; SDK npm E404; live Linear dependency graph.
+- Result: Every included issue is downstream-implementable; Harness and full live parity remain honestly gated.
+- Next: Complete the preparation goal and start OS-629.
+- Blockers: None.
+
+2026-08-07 - OS-629 correction loop aggregate-green
+- Changed: Added a validated compatibility target, public/passive human and JSON checker, fail-closed decision contract, focused tests, CI wiring, and live-remeasurement runbook.
+- Verified: 19 focused tests; sanitized-PATH workspace bb 0.35.1 fallback; immutable public SDK/registry/app/theme probes; format/check/test/build with 127 tests.
+- Result: Standing and targeted round-two reviews are clean at 5/5 after five P1/P2 findings were regression-tested and fixed.
+- Next: Commit OS-629, open its draft PR, and follow hosted CI/review through merge.
+- Blockers: Hosted CI and review state remain pending.
+```
+
+## Preparation Audits
+
+- OS-629: independent branch; one target data file plus deterministic public
+  probes/tests; avoid Ladle, overlay, CSS, catalog, lockfile, and CI edits.
+- OS-633/634/632: use one incremental chain because package, fixtures, overlay,
+  styles, lockfile, and CI overlap. Ladle/Playwright/axe are not yet installed.
+- OS-635/636/637/638: local artifact is achievable after the lab stabilizes;
+  clean-room no-bb lane is mandatory; real native mutation is not authorized;
+  OS-638 stops at its approval surface.
+
+## Review Log
+
+| Milestone | Reviewer           | Report                                     | Score      | Verdict           | Open P0-P2 | Notes                                                |
+| --------- | ------------------ | ------------------------------------------ | ---------- | ----------------- | ---------- | ---------------------------------------------------- |
+| prep      | OS-629 audit       | agent transcript                           | not scored | complete          | 0          | Independent public drift check                       |
+| prep      | surface audit      | agent transcript                           | not scored | complete          | 0          | Incremental 633/634/632 chain                        |
+| prep      | distribution audit | agent transcript                           | not scored | complete          | 0          | Local candidate and stop rules                       |
+| prep      | packet alignment   | agent transcript                           | not scored | clean             | 0          | Three P2s fixed; recheck clean                       |
+| 1         | OS-629 standing    | `tmp/reviews/standing/os-629-round-1.json` | 3/5        | changes requested | 3          | Target validation, decision durability, split errors |
+| 1         | OS-629 targeted    | `tmp/reviews/targeted-os629/round-1.json`  | 2/5        | changes requested | 2          | Decision and release-ref coherence                   |
+| 2         | OS-629 standing    | `tmp/reviews/standing/os-629-round-2.json` | 5/5        | clean             | 0          | All standing and targeted gaps fixed                 |
+| 2         | OS-629 targeted    | `tmp/reviews/targeted-os629/round-2.json`  | 5/5        | clean             | 0          | Negative probes and full gate pass                   |
+
+## Verification Log
+
+| Check                                                                    | Scope                | Result               | Notes                                                      |
+| ------------------------------------------------------------------------ | -------------------- | -------------------- | ---------------------------------------------------------- |
+| `but status --json`                                                      | baseline             | pass                 | no uncommitted files, stacks, or branches                  |
+| Main CI run 31206636916                                                  | baseline             | pass                 | green at `a637aa0`                                         |
+| `bb --version`                                                           | native capability    | pass                 | 0.35.1                                                     |
+| `npm view @bb/plugin-sdk version --json`                                 | Harness capability   | expected unavailable | npm E404; no fallback allowed                              |
+| `check-goal-prompt --no-placeholders`                                    | packet               | pass                 | 3,604/4,000; no placeholders                               |
+| `goal-loop-doctor`                                                       | packet               | pass                 | required files and sections ready                          |
+| `bun test scripts/compatibility-check.test.ts`                           | OS-629               | pass                 | 19 tests; all drift families and fail-closed paths         |
+| Sanitized-PATH `bun run compatibility:check`                             | OS-629 clean CI      | pass                 | workspace-pinned bb-app 0.35.1 fallback                    |
+| `bun run compatibility:check`                                            | OS-629 public probes | pass                 | 18 target/version/registry/dependency/token/catalog checks |
+| `bun run format:check && bun run check && bun run test && bun run build` | OS-629               | pass                 | 127 tests and all builds green                             |
+
+## Prompt / Goal Alignment
+
+- Checked by: coordinator.
+- Result: pass; the goal-loop doctor accepts the packet.
+- Missing from prompt: none.
+- Fixes made: condensed the direct-start prompt and added the required
+  Boundary, Verification, Review, Next Move, Stop Rules, and Persistence
+  resume surfaces.
+
+## Tracker / PR Log
+
+| Item   | State       | Notes                                                  |
+| ------ | ----------- | ------------------------------------------------------ |
+| OS-627 | In Progress | Parent epic                                            |
+| OS-629 | In Progress | Aggregate-green and locally review-clean; PR pending   |
+| OS-633 | Todo        | Unblocked; blocks OS-632/635                           |
+| OS-634 | Todo        | Unblocked; sequenced after OS-633                      |
+| OS-632 | Todo        | Blocked by OS-633; sequenced after OS-634              |
+| OS-635 | Todo        | Blocked by OS-633                                      |
+| OS-636 | Todo        | Unblocked; finalized after artifact commands stabilize |
+| OS-637 | Todo        | Blocked by OS-632/634/635/636                          |
+| OS-638 | Todo        | Blocked by OS-629/637; final ready PR only             |
+
+## Follow-Ups
+
+- OS-639 through OS-644 remain Backlog and `upstream-dependent`.
+- A public license, npm publication, visibility change, and announcement require
+  separate owner decisions after the local candidate review.
+
+## Final State
+
+Pending execution.

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/SPEC.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/SPEC.md
@@ -1,0 +1,100 @@
+# Goal Spec: OS-627 upstream-independent alpha
+
+Date: 2026-08-07
+Status: Ready
+
+## Objective
+
+Complete, test, review, and verify every remaining upstream-independent OS-627
+issue through a reviewable local shareable-alpha handoff, while keeping native
+bb authoritative and leaving OS-639 through OS-644 untouched.
+
+## Context
+
+The foundation and first feature wave are merged on `main` at `a637aa0` with
+green CI. OS-628, OS-630, and OS-631 provide the passive inspection core, thin
+native-loop CLI, and typed public surface catalog. Live Linear verification
+shows OS-629, OS-633, OS-634, and OS-636 are unblocked; OS-632 and OS-635 follow
+OS-633; OS-637 follows OS-632/634/635/636; and OS-638 follows OS-629/637.
+
+Preparation found one useful soft dependency beyond Linear: OS-634 should
+follow OS-633 so its launcher uses the story lab's scenario/theme/viewport
+vocabulary, and OS-632 should follow OS-634 so visual and accessibility
+baselines cover the finished overlay rather than a temporary state.
+
+## Scope
+
+### In
+
+- OS-629 compatibility target data and precise drift checks.
+- OS-633 catalog-complete deterministic Ladle surface lab.
+- OS-634 linkable, accessible Mate launcher with explicit native handoffs.
+- OS-632 bounded visual regression and accessibility coverage.
+- OS-635 deterministic local package artifact and clean install proof.
+- OS-636 external author, trust, security, support, and private-alpha policy.
+- OS-637 simulated first-time-author clean-room trial and triaged report.
+- OS-638 versioned local candidate packet, checksum, evidence, limitations,
+  release proposal, and explicit go/no-go handoff.
+- Tests, docs, plans, goal evidence, PR/CI/review follow-through, merges for
+  prerequisite issues, and Linear hygiene needed to reach the final handoff.
+
+### Out
+
+- OS-639 through OS-644 and any local substitute for their upstream contracts.
+- Editing or importing from `/Users/mg/Developer/bb/bb`.
+- npm publication, tags/releases, repository visibility changes, announcement
+  delivery, or merging the final OS-638 handoff PR.
+- Authenticated Connect embedding or mutation of normal bb/plugin state.
+- Claims that Fixture is exact host rendering or that Harness is available.
+
+## Source Of Truth
+
+- `AGENTS.md`, `README.md`, and `docs/architecture.md`.
+- Linear OS-627 and OS-629/632/633/634/635/636/637/638.
+- The completed first-wave goal and plan under `.agents/`.
+- Public immutable bb release and registry artifacts for compatibility probes.
+- `/Users/mg/Developer/bb/bb` only as read-only development evidence.
+
+## Acceptance Criteria
+
+- OS-629 through OS-637 are merged to `main`, Linear-complete, and proven by
+  focused checks, aggregate Bun gates, local two-reviewer loops, and hosted CI.
+- The surface lab has statically discoverable deterministic stories for every
+  catalog surface and never mounts content scripts through ordinary discovery.
+- The finished launcher is URL-stable, explicit about plugin/mode availability,
+  keyboard accessible, responsive, and delegates lifecycle work to native bb.
+- CI runs a small deterministic visual/a11y matrix with reviewable baselines,
+  readable diffs, and honest fixture-versus-live claims.
+- A versioned allowlisted tarball installs, runs fixture-only workflows, and
+  uninstalls in a temporary environment without monorepo-relative assumptions.
+- Public-facing docs disclose trust and mutation boundaries and record the safe
+  private-alpha license state: no public license grant or publication decision.
+- A reproducible no-secret clean-room trial has no open P0/P1 findings.
+- OS-638 has a green ready PR containing the complete local candidate handoff;
+  its exact artifact/checksum and commit are traceable, and the PR is not merged.
+
+## Decisions
+
+- Completion horizon is `ready-pr`: prerequisite issue PRs may merge after
+  their gates, while OS-638 stops as the final reviewable approval surface.
+- Centralized implementation follows `OS-629`, then the conflict-heavy
+  `OS-633 -> OS-634 -> OS-632` chain, then `OS-635 -> OS-636 -> OS-637 -> OS-638`.
+- Subagents may audit/review and write only packet-local ignored scratch review
+  reports; source, source-control, tracker, and external writes stay centralized
+  because the workbench files overlap heavily.
+- The current private/no-license-grant posture is documented, not replaced by
+  an inferred open-source license. Public licensing remains an owner decision.
+- The clean-room trial uses a fixture-only/no-bb lane as mandatory proof. Any
+  real native lane remains passive unless separately authorized.
+
+## Risks
+
+- Ladle, Playwright, axe, and browser dependencies are new and can expand CI;
+  keep the matrix deliberately bounded and pin deterministic runtime inputs.
+- Current package/workbench paths assume the monorepo and `workspace:*`; OS-635
+  must establish an installed-package boundary without bundling bb or plugins.
+- Launcher URLs must select only server-discovered candidates, never arbitrary
+  filesystem paths supplied by a browser query.
+- OS-636 commands cannot be finalized truthfully until OS-635 packaging lands.
+- OS-638 contains release prose but that prose is evidence only, not authority
+  to publish, publicize, tag, merge, or announce.

--- a/.agents/plans/2026-08-07-os-627-independent-alpha.md
+++ b/.agents/plans/2026-08-07-os-627-independent-alpha.md
@@ -1,0 +1,53 @@
+# OS-627 upstream-independent alpha
+
+## Outcome
+
+Complete and merge every remaining upstream-independent prerequisite through
+OS-637, then prepare OS-638 as the green, review-ready local-alpha approval
+surface without publishing, publicizing, or editing upstream bb.
+
+## Current status
+
+Preparation complete; direct-start goal packet validated and ready to execute.
+
+- Baseline: clean `main` at `a637aa061f7fd7eb09a28dffc9b4a7aede2fa4c0`.
+- Main CI: run 31206636916 green.
+- Included: OS-629 and OS-632 through OS-638.
+- Excluded: OS-639 through OS-644 (`upstream-dependent`).
+- Harness remains capability-gated because `@bb/plugin-sdk` is unpublished.
+- Goal: `.agents/goals/2026-08-07-os-627-independent-alpha/GOAL.md`.
+
+## Execution waves
+
+1. OS-629 compatibility alarm from current main; merge after full gates.
+2. OS-633 surface lab; merge after static/browser/full gates.
+3. OS-634 complete launcher on reconciled main; merge after interaction QA.
+4. OS-632 visual/a11y coverage over the finished lab and launcher; merge.
+5. OS-635 local packaging and isolated install/uninstall proof; merge.
+6. OS-636 verified author/trust/security/support docs and private license state;
+   merge without publication or visibility changes.
+7. OS-637 isolated first-time-author trial; fix all P0/P1 and rerun; merge.
+8. OS-638 assemble exact candidate/handoff evidence; stop at ready green PR.
+
+Each issue receives a focused plan before implementation, one standing and one
+targeted review loop, aggregate Bun gates, hosted CI/thread follow-through, and
+Linear phase updates. Source-control and tracker writes remain centralized.
+
+## Constraints
+
+- Native bb owns scaffold/build/install/dev/reload/runtime and Connect.
+- Fixture remains approximate; Harness remains public-contract gated; Live bb
+  remains the visual authority.
+- No runtime/test dependency on `/Users/mg/Developer/bb/bb`, private app code,
+  copied SDK harnesses, authenticated sessions, or normal plugin state.
+- Browser target selection must be bounded to discovered candidates.
+- Package/trial proof uses isolated temporary paths and no secrets or symlinks.
+- No npm publish, public license inference, tag/release, visibility change,
+  announcement delivery, or OS-638 merge.
+
+## Completion
+
+Complete at `ready-pr` when OS-629 through OS-637 are merged and Done, OS-638
+is open ready/green/resolved but unmerged, all local and hosted gates pass, the
+candidate artifact/checksum/commit and clean-room report are traceable, and the
+goal retro contains a final forbidden-action audit.

--- a/.agents/plans/2026-08-07-os-629-compatibility-drift.md
+++ b/.agents/plans/2026-08-07-os-629-compatibility-drift.md
@@ -1,0 +1,44 @@
+# OS-629 compatibility drift alarm
+
+## Outcome
+
+Make BB Mate's targeted bb, SDK, component-registry, dependency, measured-token,
+and public-registration contracts explicit and fail precisely when they drift.
+
+## Slice
+
+1. Add one versioned JSON target containing expected bb/SDK versions, immutable
+   public release artifacts, registry digest/items, local/upstream dependency
+   ranges, measured replica tokens, and the selected registration paths.
+2. Add a deterministic TypeScript checker with human and JSON output. It reads
+   local public contracts, executes only `bb --version`, and fetches immutable
+   public GitHub artifacts. Network/probe failures are blocking and actionable.
+3. Add unit tests for matching, every drift family, unverified probes, report
+   formatting, and the explicit documented-decision escape hatch.
+4. Wire the checker and its static/tests into the existing root gates without a
+   bespoke CI workflow step.
+5. Document the deliberately manual target-update/live-bb verification process.
+
+## Boundaries
+
+- No upstream/private imports, sibling runtime dependency, plugin execution,
+  lifecycle command, Connect access, automatic updater, or broad CSS hash.
+- The registry is checked through its public immutable release artifact.
+- The measured token list is intentionally small and names only replica values.
+- The existing surface catalog remains the registration-path authority.
+- An accepted drift requires a committed decision record with owner, reason,
+  and expiry; default CI never passes drift silently.
+
+## Verification
+
+- `bun test scripts/compatibility-check.test.ts`
+- `bunx tsc -p scripts/tsconfig.json`
+- `bun run compatibility:check`
+- `bun run format:check && bun run check && bun run test && bun run build`
+- Passive real probes only: active `bb --version` and public immutable URLs.
+- Standing plus targeted reviews, then GitButler draft/hosted CI/thread gate.
+
+## Completion
+
+Complete when the issue PR is ready, green, reviewed with zero open P0-P2,
+merged to main, Linear is Done, and the goal retro records exact proof.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ that supported metadata actually exposes; general filesystem, network, secret,
 and external-service access remains explicitly undisclosed rather than inferred
 from source.
 
+The broader native/version target is recorded in
+`compatibility/bb-target.json`. Run `bun run compatibility:check` for an
+actionable human report or add `--json` for the machine report. The manual live
+verification and update workflow is documented in
+[`docs/compatibility-target.md`](docs/compatibility-target.md).
+
 Current upstream dependencies:
 
 - [get-bb/bb#1134](https://github.com/get-bb/bb/issues/1134) tracks the missing

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,10 @@
     "": {
       "name": "bb-mate",
       "devDependencies": {
+        "@types/bun": "^1.3.4",
+        "@types/node": "^26.1.2",
         "prettier": "^3.6.2",
+        "typescript": "^5.9.2",
       },
     },
     "apps/cli": {

--- a/compatibility/bb-target.json
+++ b/compatibility/bb-target.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "./bb-target.schema.json",
+  "schemaVersion": 1,
+  "acceptedDecision": null,
+  "target": {
+    "bbVersion": "0.35.1",
+    "pluginSdkVersion": "0.4.1",
+    "pluginSdkEngineRange": "^0.4.1",
+    "upstreamRef": "desktop-v0.35.1"
+  },
+  "publicArtifacts": {
+    "appPackageUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/apps/app/package.json",
+    "pluginSdkPackageUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/packages/plugin-sdk/package.json",
+    "themeCssUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/apps/app/src/components/ui/theme.css",
+    "registry": {
+      "url": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/packages/plugin-registry/r/index.json",
+      "sha256": "ae65ae093d2435540e445707529337598cfa9f3446a8535986affef0939fe1e2",
+      "items": [
+        "accordion",
+        "alert",
+        "alert-dialog",
+        "aspect-ratio",
+        "avatar",
+        "badge",
+        "breadcrumb",
+        "button",
+        "calendar",
+        "card",
+        "carousel",
+        "chart",
+        "checkbox",
+        "coarse-pointer-sizing",
+        "collapsible",
+        "command",
+        "context-menu",
+        "dialog",
+        "drawer",
+        "dropdown-menu",
+        "form",
+        "hover-card",
+        "icon",
+        "input",
+        "input-otp",
+        "label",
+        "menu-item-hover",
+        "menubar",
+        "motion",
+        "navigation-menu",
+        "overlay-trigger",
+        "pagination",
+        "popover",
+        "portal-scope",
+        "progress",
+        "radio-group",
+        "resizable",
+        "responsive-overlay",
+        "scroll-area",
+        "select",
+        "separator",
+        "sheet",
+        "skeleton",
+        "slider",
+        "switch",
+        "table",
+        "tabs",
+        "textarea",
+        "toggle",
+        "toggle-group",
+        "tooltip",
+        "use-browser-dimming-modal",
+        "use-compact-viewport",
+        "use-media-query",
+        "use-pointer-coarse",
+        "utils"
+      ]
+    }
+  },
+  "dependencies": [
+    {
+      "id": "hugeicons-core",
+      "package": "@hugeicons/core-free-icons",
+      "localRange": "^4.1.3",
+      "upstreamRange": "^4.1.3"
+    },
+    {
+      "id": "hugeicons-react",
+      "package": "@hugeicons/react",
+      "localRange": "^1.1.6",
+      "upstreamRange": "^1.1.6"
+    },
+    {
+      "id": "inter",
+      "package": "@fontsource-variable/inter",
+      "localRange": "^5.3.0",
+      "upstreamRange": "^5.2.8"
+    }
+  ],
+  "measuredTokens": [
+    {
+      "name": "--bb-sidebar-width",
+      "localValue": "320px",
+      "source": "manual-live-measurement"
+    },
+    {
+      "name": "--bb-sidebar-row-height",
+      "localValue": "1.75rem",
+      "upstreamValue": "1.75rem",
+      "source": "public-theme-css"
+    },
+    {
+      "name": "--bb-sidebar-row-height-coarse",
+      "localValue": "2.5rem",
+      "upstreamValue": "2.5rem",
+      "source": "public-theme-css"
+    }
+  ],
+  "registrationPaths": [
+    "slots.homepageSection",
+    "slots.settingsSection",
+    "slots.navPanel",
+    "slots.threadPanelAction",
+    "slots.pendingInteraction",
+    "slots.sidebarFooterAction",
+    "slots.experimental_threadList",
+    "slots.experimental_threadHeaderAction",
+    "slots.fileOpener",
+    "slots.messageDirective",
+    "slots.messageAction",
+    "composer.customize",
+    "contentScripts.register"
+  ]
+}

--- a/compatibility/bb-target.schema.json
+++ b/compatibility/bb-target.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bb-mate.local/compatibility/bb-target.schema.json",
+  "title": "BB Mate compatibility target",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "acceptedDecision",
+    "target",
+    "publicArtifacts",
+    "dependencies",
+    "measuredTokens",
+    "registrationPaths"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "acceptedDecision": {
+      "type": ["string", "null"],
+      "pattern": "^compatibility/decisions/[A-Za-z0-9._-]+\\.md$"
+    },
+    "target": {
+      "type": "object",
+      "required": [
+        "bbVersion",
+        "pluginSdkVersion",
+        "pluginSdkEngineRange",
+        "upstreamRef"
+      ]
+    },
+    "publicArtifacts": {
+      "type": "object",
+      "required": [
+        "appPackageUrl",
+        "pluginSdkPackageUrl",
+        "themeCssUrl",
+        "registry"
+      ]
+    },
+    "dependencies": { "type": "array", "minItems": 1 },
+    "measuredTokens": { "type": "array", "minItems": 1 },
+    "registrationPaths": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/compatibility-target.md
+++ b/docs/compatibility-target.md
@@ -1,0 +1,66 @@
+# BB Mate compatibility target
+
+`compatibility/bb-target.json` is the reviewable record of the public bb
+contracts and deliberately measured fixture values that BB Mate targets. The
+check is an alarm, not an updater.
+
+```sh
+bun run compatibility:check
+bun run compatibility:check --json
+```
+
+The check reads local manifests, the surface catalog, and the small named token
+set; executes only `bb --version`; and fetches immutable public artifacts from
+the recorded bb release tag. `BB_CLI` wins when set, then `bb` on `PATH`, then
+the workspace's pinned `bb-app` binary so clean CI observes the same release
+used for plugin builds. It does not load plugin code, contact Connect, or use
+the sibling bb checkout. A failed network or native probe is `unverified` and
+fails the command rather than silently passing.
+
+The target is validated before any network request. Guard lists must be
+non-empty and unique, and artifact URLs must be exact immutable paths on
+`raw.githubusercontent.com/get-bb/bb`. Redirects are rejected.
+
+## Updating the target
+
+1. Read every failed check and its next action. Do not update values merely to
+   make CI green.
+2. Inspect the public diff between the old and proposed bb release refs. Review
+   registry item and digest changes together. Reconcile SDK and registration
+   changes with the public surface catalog first.
+3. Run the full repository gate against the proposed values.
+4. Open live bb at the proposed version and manually compare the representative
+   sidebar and composer fixtures at their recorded viewport. Confirm row
+   heights, sidebar geometry, typography, theme colors, focus treatment, and
+   host-owned versus plugin-owned boundaries. Live bb is the visual authority;
+   a green fixture check is not parity proof.
+5. Record the live comparison and rationale in the pull request. Update only
+   `compatibility/bb-target.json` and code genuinely required by the public
+   contract. The expected target-only change should remain a small diff.
+
+The local Inter range intentionally differs from the targeted bb app range.
+Both values are recorded so either change is visible instead of being silently
+normalized.
+
+## Explicit temporary decisions
+
+Default CI has no skip. A time-bounded exception must be a committed Markdown
+record under `compatibility/decisions/` containing all four fields:
+
+```md
+# Compatibility Decision
+
+Status: accepted
+Owner: owner name
+Reason: concrete bounded rationale
+Expires: YYYY-MM-DD
+```
+
+Record that same repository-relative path as `acceptedDecision` in
+`compatibility/bb-target.json`, then run
+`bun run compatibility:check --decision compatibility/decisions/<record.md>`.
+External paths, symlinks, missing fields, invalid dates, dates more than 90 days
+away, and command-line-only explanations are rejected. Unverified network or
+native probes can never be waived. For an accepted contract mismatch, the
+report stays `accepted-drift`, lists every mismatch, and must not be described
+as a clean compatibility pass.

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
     "bb-mate": "bun apps/cli/src/bin.ts",
     "dev": "bun --filter @bb-mate/workbench dev",
     "build": "bun --filter '*' build",
-    "check": "bun --filter '*' check",
-    "test": "bun --filter '*' test",
+    "check": "bun --filter '*' check && tsc -p scripts/tsconfig.json && bun run compatibility:check",
+    "compatibility:check": "bun scripts/compatibility-check.ts",
+    "test": "bun --filter '*' test && bun test scripts",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },
   "devDependencies": {
-    "prettier": "^3.6.2"
+    "@types/bun": "^1.3.4",
+    "@types/node": "^26.1.2",
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.2"
   }
 }

--- a/scripts/compatibility-check.test.ts
+++ b/scripts/compatibility-check.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { surfaceCatalog } from "../apps/workbench/src/surface-catalog";
+import {
+  evaluateCompatibility,
+  formatCompatibilityReport,
+  parseCompatibilityTarget,
+  resolveCompatibilityDecisionPath,
+  validCompatibilityDecision,
+  type CompatibilityObservations,
+  type CompatibilityTarget,
+} from "./compatibility-check";
+
+const target: CompatibilityTarget = {
+  schemaVersion: 1,
+  acceptedDecision: null,
+  target: {
+    bbVersion: "0.35.1",
+    pluginSdkVersion: "0.4.1",
+    pluginSdkEngineRange: "^0.4.1",
+    upstreamRef: "desktop-v0.35.1",
+  },
+  publicArtifacts: {
+    appPackageUrl:
+      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/apps/app/package.json",
+    pluginSdkPackageUrl:
+      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/packages/plugin-sdk/package.json",
+    themeCssUrl:
+      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/apps/app/src/components/ui/theme.css",
+    registry: {
+      url: "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/packages/plugin-registry/r/index.json",
+      sha256: "abc",
+      items: ["button"],
+    },
+  },
+  dependencies: [
+    {
+      id: "icons",
+      package: "icons",
+      localRange: "^1.0.0",
+      upstreamRange: "^1.0.0",
+    },
+  ],
+  measuredTokens: [
+    {
+      name: "--row-height",
+      localValue: "1rem",
+      upstreamValue: "1rem",
+      source: "public-theme-css",
+    },
+  ],
+  registrationPaths: ["slots.example"],
+};
+
+function matchingObservations(): CompatibilityObservations {
+  return {
+    bbVersion: "0.35.1",
+    pluginSdkEngineRange: "^0.4.1",
+    pluginSdkVersion: "0.4.1",
+    registrySha256: "abc",
+    registryItems: ["button"],
+    dependencies: { icons: { local: "^1.0.0", upstream: "^1.0.0" } },
+    tokens: { "--row-height": { local: "1rem", upstream: "1rem" } },
+    registrationPaths: ["slots.example"],
+  };
+}
+
+describe("compatibility evaluation", () => {
+  test("passes a completely matching observation", () => {
+    const report = evaluateCompatibility(target, matchingObservations());
+    expect(report.outcome).toBe("pass");
+    expect(report.checks.every(({ status }) => status === "pass")).toBe(true);
+  });
+
+  test("fails when release identity and immutable URLs diverge", () => {
+    const incoherent: CompatibilityTarget = {
+      ...target,
+      target: { ...target.target, upstreamRef: "desktop-v9.9.9" },
+    };
+    expect(
+      evaluateCompatibility(incoherent, matchingObservations()).checks.find(
+        ({ id }) => id === "target.release-coherence",
+      ),
+    ).toMatchObject({
+      status: "fail",
+      observed: expect.arrayContaining([expect.any(String)]),
+    });
+  });
+
+  test.each([
+    [
+      "bb version",
+      (value: CompatibilityObservations) => (value.bbVersion = "0.36.0"),
+      "bb.version",
+    ],
+    [
+      "SDK engine",
+      (value: CompatibilityObservations) =>
+        (value.pluginSdkEngineRange = "^0.5.0"),
+      "plugin-sdk.engine-range",
+    ],
+    [
+      "SDK version",
+      (value: CompatibilityObservations) => (value.pluginSdkVersion = "0.5.0"),
+      "plugin-sdk.public-version",
+    ],
+    [
+      "registry digest",
+      (value: CompatibilityObservations) => (value.registrySha256 = "def"),
+      "component-registry.sha256",
+    ],
+    [
+      "registry items",
+      (value: CompatibilityObservations) =>
+        (value.registryItems = ["button", "card"]),
+      "component-registry.items",
+    ],
+    [
+      "local dependency",
+      (value: CompatibilityObservations) =>
+        (value.dependencies.icons!.local = "^2.0.0"),
+      "dependency.icons.local",
+    ],
+    [
+      "upstream dependency",
+      (value: CompatibilityObservations) =>
+        (value.dependencies.icons!.upstream = "^2.0.0"),
+      "dependency.icons.upstream",
+    ],
+    [
+      "local token",
+      (value: CompatibilityObservations) =>
+        (value.tokens["--row-height"]!.local = "2rem"),
+      "token.--row-height.local",
+    ],
+    [
+      "upstream token",
+      (value: CompatibilityObservations) =>
+        (value.tokens["--row-height"]!.upstream = "2rem"),
+      "token.--row-height.upstream",
+    ],
+    [
+      "registration paths",
+      (value: CompatibilityObservations) =>
+        (value.registrationPaths = ["slots.new"]),
+      "plugin-registration.paths",
+    ],
+  ])("reports precise %s drift", (_name, mutate, checkId) => {
+    const observed = matchingObservations();
+    mutate(observed);
+    const report = evaluateCompatibility(target, observed);
+    expect(report.outcome).toBe("fail");
+    expect(report.checks.find(({ id }) => id === checkId)).toMatchObject({
+      status: "fail",
+      nextAction: expect.any(String),
+    });
+  });
+
+  test("fails closed when a public probe is unverified", () => {
+    const observed = matchingObservations();
+    observed.registrySha256 = undefined;
+    observed.registryItems = undefined;
+    observed.registryError = "network unavailable";
+    const report = evaluateCompatibility(target, observed);
+    expect(report.outcome).toBe("fail");
+    expect(
+      report.checks.filter(({ id }) => id.startsWith("component-registry")),
+    ).toEqual([
+      expect.objectContaining({
+        status: "unverified",
+        observed: "network unavailable",
+      }),
+      expect.objectContaining({
+        status: "unverified",
+        observed: "network unavailable",
+      }),
+    ]);
+  });
+
+  test("formats a concise actionable terminal report", () => {
+    const observed = matchingObservations();
+    observed.bbVersion = "0.36.0";
+    const output = formatCompatibilityReport(
+      evaluateCompatibility(target, observed),
+    );
+    expect(output).toContain("BB Mate compatibility: fail");
+    expect(output).toContain("✗ bb.version: fail");
+    expect(output).toContain("next:");
+  });
+});
+
+describe("explicit compatibility decisions", () => {
+  test("requires accepted status, owner, reason, and an unexpired date", () => {
+    const now = new Date("2026-08-07T12:00:00Z");
+    expect(
+      validCompatibilityDecision(
+        "# Compatibility Decision\nStatus: accepted\nOwner: Matt\nReason: bounded migration\nExpires: 2026-08-08\n",
+        now,
+      ),
+    ).toBe(true);
+    expect(
+      validCompatibilityDecision(
+        "Status: accepted\nOwner: Matt\nReason: bounded migration\nExpires: 2026-08-06\n",
+        now,
+      ),
+    ).toBe(false);
+    expect(validCompatibilityDecision("Status: accepted\n", now)).toBe(false);
+    expect(
+      validCompatibilityDecision(
+        "Status: accepted\nOwner: Matt\nReason: invalid date\nExpires: 9999-99-99\n",
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("requires a target-declared repository decision path", () => {
+    const withDecision = {
+      ...target,
+      acceptedDecision: "compatibility/decisions/bounded.md",
+    };
+    expect(() =>
+      resolveCompatibilityDecisionPath(withDecision, "/dev/stdin"),
+    ).toThrow("acceptedDecision");
+    expect(
+      resolveCompatibilityDecisionPath(
+        withDecision,
+        "compatibility/decisions/bounded.md",
+      ),
+    ).toEndWith("/compatibility/decisions/bounded.md");
+  });
+});
+
+describe("target validation", () => {
+  test("rejects removed guard families and non-public artifact URLs", () => {
+    expect(() =>
+      parseCompatibilityTarget({ ...target, dependencies: [] }),
+    ).toThrow("dependencies");
+    expect(() =>
+      parseCompatibilityTarget({
+        ...target,
+        publicArtifacts: {
+          ...target.publicArtifacts,
+          appPackageUrl: "https://example.test/app.json",
+        },
+      }),
+    ).toThrow("immutable public");
+  });
+});
+
+test("the checked-in target mirrors the catalog registration paths", async () => {
+  const text = await readFile(
+    path.resolve("compatibility/bb-target.json"),
+    "utf8",
+  );
+  const checkedTarget = JSON.parse(text) as CompatibilityTarget;
+  expect(checkedTarget.registrationPaths).toEqual(
+    surfaceCatalog.map(({ registrationPath }) => registrationPath),
+  );
+});
+
+test("keeps local checks valid when only an upstream probe fails", () => {
+  const observed = matchingObservations();
+  observed.dependencies.icons = {
+    local: "^1.0.0",
+    upstreamError: "public app package unavailable",
+  };
+  observed.tokens["--row-height"] = {
+    local: "1rem",
+    upstreamError: "public theme unavailable",
+  };
+  const checks = evaluateCompatibility(target, observed).checks;
+  expect(checks.find(({ id }) => id === "dependency.icons.local")?.status).toBe(
+    "pass",
+  );
+  expect(
+    checks.find(({ id }) => id === "dependency.icons.upstream")?.status,
+  ).toBe("unverified");
+  expect(
+    checks.find(({ id }) => id === "token.--row-height.local")?.status,
+  ).toBe("pass");
+  expect(
+    checks.find(({ id }) => id === "token.--row-height.upstream")?.status,
+  ).toBe("unverified");
+});

--- a/scripts/compatibility-check.ts
+++ b/scripts/compatibility-check.ts
@@ -1,0 +1,723 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { surfaceCatalog } from "../apps/workbench/src/surface-catalog.ts";
+
+const execFile = promisify(execFileCallback);
+const repositoryRoot = path.resolve(
+  fileURLToPath(new URL("..", import.meta.url)),
+);
+const targetPath = path.join(repositoryRoot, "compatibility/bb-target.json");
+
+interface DependencyTarget {
+  id: string;
+  package: string;
+  localRange: string;
+  upstreamRange: string;
+}
+
+interface TokenTarget {
+  name: string;
+  localValue: string;
+  upstreamValue?: string;
+  source: string;
+}
+
+export interface CompatibilityTarget {
+  schemaVersion: 1;
+  acceptedDecision?: string | null;
+  target: {
+    bbVersion: string;
+    pluginSdkVersion: string;
+    pluginSdkEngineRange: string;
+    upstreamRef: string;
+  };
+  publicArtifacts: {
+    appPackageUrl: string;
+    pluginSdkPackageUrl: string;
+    themeCssUrl: string;
+    registry: { url: string; sha256: string; items: string[] };
+  };
+  dependencies: DependencyTarget[];
+  measuredTokens: TokenTarget[];
+  registrationPaths: string[];
+}
+
+interface DependencyObservation {
+  local?: string;
+  upstream?: string;
+  localError?: string;
+  upstreamError?: string;
+}
+
+interface TokenObservation {
+  local?: string;
+  upstream?: string;
+  localError?: string;
+  upstreamError?: string;
+}
+
+export interface CompatibilityObservations {
+  bbVersion?: string;
+  bbError?: string;
+  pluginSdkEngineRange?: string;
+  pluginSdkVersion?: string;
+  pluginSdkError?: string;
+  registrySha256?: string;
+  registryItems?: string[];
+  registryError?: string;
+  dependencies: Record<string, DependencyObservation>;
+  tokens: Record<string, TokenObservation>;
+  registrationPaths: string[];
+}
+
+export type CompatibilityStatus = "pass" | "fail" | "unverified";
+
+export interface CompatibilityCheck {
+  id: string;
+  status: CompatibilityStatus;
+  target: unknown;
+  observed: unknown;
+  nextAction?: string;
+}
+
+export interface CompatibilityReport {
+  schemaVersion: 1;
+  upstreamRef: string;
+  outcome: "pass" | "fail" | "accepted-drift";
+  decision?: string;
+  checks: CompatibilityCheck[];
+}
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function exactCheck(
+  id: string,
+  target: unknown,
+  observed: unknown,
+  nextAction: string,
+  error?: string,
+): CompatibilityCheck {
+  if (error || observed === undefined) {
+    return {
+      id,
+      status: "unverified",
+      target,
+      observed: error ?? "No observation was produced.",
+      nextAction,
+    };
+  }
+  return serialized(target) === serialized(observed)
+    ? { id, status: "pass", target, observed }
+    : { id, status: "fail", target, observed, nextAction };
+}
+
+export function evaluateCompatibility(
+  target: CompatibilityTarget,
+  observed: CompatibilityObservations,
+): CompatibilityReport {
+  const checks: CompatibilityCheck[] = [
+    exactCheck(
+      "target.release-coherence",
+      [],
+      targetCoherenceIssues(target),
+      "Make upstreamRef, bbVersion, SDK range, and every public artifact URL identify one release.",
+    ),
+    exactCheck(
+      "bb.version",
+      target.target.bbVersion,
+      observed.bbVersion,
+      "Install the targeted bb release or update compatibility/bb-target.json after verification.",
+      observed.bbError,
+    ),
+    exactCheck(
+      "plugin-sdk.engine-range",
+      target.target.pluginSdkEngineRange,
+      observed.pluginSdkEngineRange,
+      "Align the example plugin engines.bbPluginSdk range or review and update the target.",
+    ),
+    exactCheck(
+      "plugin-sdk.public-version",
+      target.target.pluginSdkVersion,
+      observed.pluginSdkVersion,
+      "Inspect the public SDK release contract and update the target after compatibility review.",
+      observed.pluginSdkError,
+    ),
+    exactCheck(
+      "component-registry.sha256",
+      target.publicArtifacts.registry.sha256,
+      observed.registrySha256,
+      "Review the public registry diff, then update its digest and item list together.",
+      observed.registryError,
+    ),
+    exactCheck(
+      "component-registry.items",
+      target.publicArtifacts.registry.items,
+      observed.registryItems,
+      "Review added or removed public components before updating the recorded item list.",
+      observed.registryError,
+    ),
+  ];
+
+  for (const dependency of target.dependencies) {
+    const value = observed.dependencies[dependency.id];
+    checks.push(
+      exactCheck(
+        `dependency.${dependency.id}.local`,
+        dependency.localRange,
+        value?.local,
+        `Review ${dependency.package} in the workbench and update the compatibility target.`,
+        value?.localError,
+      ),
+      exactCheck(
+        `dependency.${dependency.id}.upstream`,
+        dependency.upstreamRange,
+        value?.upstream,
+        `Review upstream ${dependency.package} changes before updating the target.`,
+        value?.upstreamError,
+      ),
+    );
+  }
+
+  for (const token of target.measuredTokens) {
+    const value = observed.tokens[token.name];
+    checks.push(
+      exactCheck(
+        `token.${token.name}.local`,
+        token.localValue,
+        value?.local,
+        `Remeasure ${token.name} in live bb and record the manual comparison before updating the target.`,
+        value?.localError,
+      ),
+    );
+    if (token.upstreamValue !== undefined) {
+      checks.push(
+        exactCheck(
+          `token.${token.name}.upstream`,
+          token.upstreamValue,
+          value?.upstream,
+          `Review the public theme change for ${token.name}, remeasure live bb, then update the target.`,
+          value?.upstreamError,
+        ),
+      );
+    }
+  }
+
+  checks.push(
+    exactCheck(
+      "plugin-registration.paths",
+      target.registrationPaths,
+      observed.registrationPaths,
+      "Reconcile the public surface catalog and declaration coverage, then update the target.",
+    ),
+  );
+
+  return {
+    schemaVersion: 1,
+    upstreamRef: target.target.upstreamRef,
+    outcome: checks.every(({ status }) => status === "pass") ? "pass" : "fail",
+    checks,
+  };
+}
+
+function targetCoherenceIssues(target: CompatibilityTarget): string[] {
+  const issues: string[] = [];
+  const expectedRef = `desktop-v${target.target.bbVersion}`;
+  if (target.target.upstreamRef !== expectedRef) {
+    issues.push(`upstreamRef must be ${expectedRef}`);
+  }
+  if (
+    target.target.pluginSdkEngineRange !== `^${target.target.pluginSdkVersion}`
+  ) {
+    issues.push("plugin SDK engine range must target the recorded SDK version");
+  }
+  const urls = [
+    target.publicArtifacts.appPackageUrl,
+    target.publicArtifacts.pluginSdkPackageUrl,
+    target.publicArtifacts.themeCssUrl,
+    target.publicArtifacts.registry.url,
+  ];
+  if (urls.some((url) => !url.includes(`/${target.target.upstreamRef}/`))) {
+    issues.push(
+      "every public artifact URL must contain upstreamRef as its release path",
+    );
+  }
+  return issues;
+}
+
+function packageRange(
+  packageJson: Record<string, unknown>,
+  packageName: string,
+): string | undefined {
+  for (const section of ["dependencies", "devDependencies"] as const) {
+    const values = packageJson[section];
+    if (values && typeof values === "object" && !Array.isArray(values)) {
+      const value = (values as Record<string, unknown>)[packageName];
+      if (typeof value === "string") return value;
+    }
+  }
+  return undefined;
+}
+
+function cssVariable(css: string, name: string): string | undefined {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped}\\s*:\\s*([^;]+);`).exec(css)?.[1]?.trim();
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: { "user-agent": "bb-mate-compatibility-check" },
+    redirect: "error",
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok)
+    throw new Error(`${response.status} ${response.statusText}`);
+  return response.text();
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseBbVersion(output: string): string | undefined {
+  return /\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/.exec(output)?.[1];
+}
+
+async function observeBbVersion(): Promise<string> {
+  const explicit = process.env.BB_CLI?.trim();
+  const candidates = explicit
+    ? [explicit]
+    : ["bb", path.join(repositoryRoot, "plugins/linear/node_modules/.bin/bb")];
+  let missingError: unknown;
+  for (const candidate of candidates) {
+    try {
+      const { stdout, stderr } = await execFile(candidate, ["--version"], {
+        cwd: repositoryRoot,
+        timeout: 10_000,
+      });
+      const version = parseBbVersion(`${stdout}\n${stderr}`);
+      if (!version)
+        throw new Error(`${candidate} --version returned no semantic version.`);
+      return version;
+    } catch (error) {
+      if (!explicit && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        missingError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw missingError ?? new Error("No bb executable is available.");
+}
+
+export async function collectCompatibilityObservations(
+  target: CompatibilityTarget,
+): Promise<CompatibilityObservations> {
+  const observed: CompatibilityObservations = {
+    dependencies: {},
+    tokens: {},
+    registrationPaths: surfaceCatalog.map(
+      ({ registrationPath }) => registrationPath,
+    ),
+  };
+
+  try {
+    observed.bbVersion = await observeBbVersion();
+  } catch (error) {
+    observed.bbError = `bb --version failed: ${message(error)}`;
+  }
+
+  const [pluginPackageText, workbenchPackageText, localCss] = await Promise.all(
+    [
+      readFile(
+        path.join(repositoryRoot, "plugins/linear/package.json"),
+        "utf8",
+      ),
+      readFile(
+        path.join(repositoryRoot, "apps/workbench/package.json"),
+        "utf8",
+      ),
+      readFile(
+        path.join(repositoryRoot, "apps/workbench/src/styles.css"),
+        "utf8",
+      ),
+    ],
+  );
+  const pluginPackage = JSON.parse(pluginPackageText) as Record<
+    string,
+    unknown
+  >;
+  const engines = pluginPackage.engines;
+  if (engines && typeof engines === "object" && !Array.isArray(engines)) {
+    const range = (engines as Record<string, unknown>).bbPluginSdk;
+    if (typeof range === "string") observed.pluginSdkEngineRange = range;
+  }
+  const workbenchPackage = JSON.parse(workbenchPackageText) as Record<
+    string,
+    unknown
+  >;
+
+  let upstreamPackage: Record<string, unknown> | undefined;
+  try {
+    upstreamPackage = JSON.parse(
+      await fetchText(target.publicArtifacts.appPackageUrl),
+    ) as Record<string, unknown>;
+  } catch (error) {
+    const detail = `Could not read public app package: ${message(error)}`;
+    for (const dependency of target.dependencies)
+      observed.dependencies[dependency.id] = { upstreamError: detail };
+  }
+  for (const dependency of target.dependencies) {
+    const current = observed.dependencies[dependency.id] ?? {};
+    observed.dependencies[dependency.id] = {
+      ...current,
+      local: packageRange(workbenchPackage, dependency.package),
+      upstream: upstreamPackage
+        ? packageRange(upstreamPackage, dependency.package)
+        : undefined,
+    };
+  }
+
+  try {
+    const sdkPackage = JSON.parse(
+      await fetchText(target.publicArtifacts.pluginSdkPackageUrl),
+    ) as Record<string, unknown>;
+    if (typeof sdkPackage.version === "string")
+      observed.pluginSdkVersion = sdkPackage.version;
+    else observed.pluginSdkError = "Public SDK package has no version.";
+  } catch (error) {
+    observed.pluginSdkError = `Could not read public SDK package: ${message(error)}`;
+  }
+
+  try {
+    const registryText = await fetchText(target.publicArtifacts.registry.url);
+    const registry = JSON.parse(registryText) as {
+      items?: Array<{ name?: unknown }>;
+    };
+    observed.registrySha256 = createHash("sha256")
+      .update(registryText)
+      .digest("hex");
+    observed.registryItems = registry.items?.flatMap(({ name }) =>
+      typeof name === "string" ? [name] : [],
+    );
+    if (!observed.registryItems)
+      observed.registryError = "Registry has no items array.";
+  } catch (error) {
+    observed.registryError = `Could not read public registry: ${message(error)}`;
+  }
+
+  let upstreamCss: string | undefined;
+  try {
+    upstreamCss = await fetchText(target.publicArtifacts.themeCssUrl);
+  } catch (error) {
+    const detail = `Could not read public theme CSS: ${message(error)}`;
+    for (const token of target.measuredTokens) {
+      if (token.upstreamValue !== undefined)
+        observed.tokens[token.name] = { upstreamError: detail };
+    }
+  }
+  for (const token of target.measuredTokens) {
+    const current = observed.tokens[token.name] ?? {};
+    observed.tokens[token.name] = {
+      ...current,
+      local: cssVariable(localCss, token.name),
+      upstream: upstreamCss ? cssVariable(upstreamCss, token.name) : undefined,
+    };
+  }
+  return observed;
+}
+
+export function validCompatibilityDecision(
+  text: string,
+  now = new Date(),
+): boolean {
+  const status = /^Status:\s*accepted\s*$/im.test(text);
+  const owner = /^Owner:\s*\S.+$/im.test(text);
+  const reason = /^Reason:\s*\S.+$/im.test(text);
+  const expiry = /^Expires:\s*(\d{4}-\d{2}-\d{2})\s*$/im.exec(text)?.[1];
+  const expiryDate = expiry ? new Date(`${expiry}T00:00:00Z`) : undefined;
+  const validDate = Boolean(
+    expiry &&
+    expiryDate &&
+    !Number.isNaN(expiryDate.valueOf()) &&
+    expiryDate.toISOString().slice(0, 10) === expiry,
+  );
+  const maximumExpiry = new Date(now);
+  maximumExpiry.setUTCDate(maximumExpiry.getUTCDate() + 90);
+  return Boolean(
+    status &&
+    owner &&
+    reason &&
+    validDate &&
+    expiryDate &&
+    expiryDate >= new Date(`${now.toISOString().slice(0, 10)}T00:00:00Z`) &&
+    expiryDate <= maximumExpiry,
+  );
+}
+
+export function resolveCompatibilityDecisionPath(
+  target: CompatibilityTarget,
+  decisionArgument: string,
+): string {
+  const normalized = decisionArgument.replaceAll("\\", "/");
+  if (target.acceptedDecision !== normalized) {
+    throw new Error(
+      "The decision path must be recorded as acceptedDecision in compatibility/bb-target.json.",
+    );
+  }
+  if (!/^compatibility\/decisions\/[A-Za-z0-9._-]+\.md$/.test(normalized)) {
+    throw new Error(
+      "Compatibility decisions must be Markdown files under compatibility/decisions/.",
+    );
+  }
+  return path.join(repositoryRoot, ...normalized.split("/"));
+}
+
+export function formatCompatibilityReport(report: CompatibilityReport): string {
+  const lines = [
+    `BB Mate compatibility: ${report.outcome}`,
+    `Target: ${report.upstreamRef}`,
+  ];
+  for (const check of report.checks) {
+    lines.push(
+      `${check.status === "pass" ? "✓" : "✗"} ${check.id}: ${check.status}`,
+    );
+    if (check.status !== "pass") {
+      lines.push(`  targeted: ${serialized(check.target)}`);
+      lines.push(`  observed: ${serialized(check.observed)}`);
+      if (check.nextAction) lines.push(`  next: ${check.nextAction}`);
+    }
+  }
+  if (report.decision) lines.push(`Decision: ${report.decision}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function string(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function stringArray(value: unknown, name: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${name} must be a non-empty array.`);
+  }
+  const values = value.map((entry, index) =>
+    string(entry, `${name}[${index}]`),
+  );
+  if (new Set(values).size !== values.length)
+    throw new Error(`${name} must be unique.`);
+  return values;
+}
+
+function publicArtifactUrl(
+  value: unknown,
+  ref: string,
+  suffix: string,
+  name: string,
+): string {
+  const text = string(value, name);
+  const url = new URL(text);
+  const expectedPath = `/get-bb/bb/${ref}/${suffix}`;
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "raw.githubusercontent.com" ||
+    url.pathname !== expectedPath ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      `${name} must be the immutable public ${expectedPath} artifact.`,
+    );
+  }
+  return text;
+}
+
+export function parseCompatibilityTarget(value: unknown): CompatibilityTarget {
+  const root = record(value, "compatibility target");
+  if (root.schemaVersion !== 1) throw new Error("schemaVersion must be 1.");
+  const target = record(root.target, "target");
+  const bbVersion = string(target.bbVersion, "target.bbVersion");
+  const pluginSdkVersion = string(
+    target.pluginSdkVersion,
+    "target.pluginSdkVersion",
+  );
+  const pluginSdkEngineRange = string(
+    target.pluginSdkEngineRange,
+    "target.pluginSdkEngineRange",
+  );
+  const upstreamRef = string(target.upstreamRef, "target.upstreamRef");
+  const artifacts = record(root.publicArtifacts, "publicArtifacts");
+  const registry = record(artifacts.registry, "publicArtifacts.registry");
+  const dependencies = (
+    Array.isArray(root.dependencies) ? root.dependencies : []
+  ).map((entry, index) => {
+    const item = record(entry, `dependencies[${index}]`);
+    return {
+      id: string(item.id, `dependencies[${index}].id`),
+      package: string(item.package, `dependencies[${index}].package`),
+      localRange: string(item.localRange, `dependencies[${index}].localRange`),
+      upstreamRange: string(
+        item.upstreamRange,
+        `dependencies[${index}].upstreamRange`,
+      ),
+    };
+  });
+  if (dependencies.length === 0)
+    throw new Error("dependencies must be a non-empty array.");
+  if (new Set(dependencies.map(({ id }) => id)).size !== dependencies.length) {
+    throw new Error("dependency ids must be unique.");
+  }
+  const measuredTokens = (
+    Array.isArray(root.measuredTokens) ? root.measuredTokens : []
+  ).map((entry, index) => {
+    const item = record(entry, `measuredTokens[${index}]`);
+    const upstreamValue = item.upstreamValue;
+    return {
+      name: string(item.name, `measuredTokens[${index}].name`),
+      localValue: string(
+        item.localValue,
+        `measuredTokens[${index}].localValue`,
+      ),
+      ...(upstreamValue === undefined
+        ? {}
+        : {
+            upstreamValue: string(
+              upstreamValue,
+              `measuredTokens[${index}].upstreamValue`,
+            ),
+          }),
+      source: string(item.source, `measuredTokens[${index}].source`),
+    };
+  });
+  if (measuredTokens.length === 0)
+    throw new Error("measuredTokens must be a non-empty array.");
+  if (
+    new Set(measuredTokens.map(({ name }) => name)).size !==
+    measuredTokens.length
+  ) {
+    throw new Error("measured token names must be unique.");
+  }
+  const acceptedDecision = root.acceptedDecision;
+  if (acceptedDecision !== null && typeof acceptedDecision !== "string") {
+    throw new Error(
+      "acceptedDecision must be null or a repository-relative string.",
+    );
+  }
+  return {
+    schemaVersion: 1,
+    acceptedDecision,
+    target: { bbVersion, pluginSdkVersion, pluginSdkEngineRange, upstreamRef },
+    publicArtifacts: {
+      appPackageUrl: publicArtifactUrl(
+        artifacts.appPackageUrl,
+        upstreamRef,
+        "apps/app/package.json",
+        "publicArtifacts.appPackageUrl",
+      ),
+      pluginSdkPackageUrl: publicArtifactUrl(
+        artifacts.pluginSdkPackageUrl,
+        upstreamRef,
+        "packages/plugin-sdk/package.json",
+        "publicArtifacts.pluginSdkPackageUrl",
+      ),
+      themeCssUrl: publicArtifactUrl(
+        artifacts.themeCssUrl,
+        upstreamRef,
+        "apps/app/src/components/ui/theme.css",
+        "publicArtifacts.themeCssUrl",
+      ),
+      registry: {
+        url: publicArtifactUrl(
+          registry.url,
+          upstreamRef,
+          "packages/plugin-registry/r/index.json",
+          "publicArtifacts.registry.url",
+        ),
+        sha256: string(registry.sha256, "publicArtifacts.registry.sha256"),
+        items: stringArray(registry.items, "publicArtifacts.registry.items"),
+      },
+    },
+    dependencies,
+    measuredTokens,
+    registrationPaths: stringArray(root.registrationPaths, "registrationPaths"),
+  };
+}
+
+export async function loadCompatibilityTarget(): Promise<CompatibilityTarget> {
+  return parseCompatibilityTarget(
+    JSON.parse(await readFile(targetPath, "utf8")),
+  );
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const json = args.includes("--json");
+  const decisionIndex = args.indexOf("--decision");
+  const decisionPath = decisionIndex >= 0 ? args[decisionIndex + 1] : undefined;
+  const unknown = args.filter(
+    (arg, index) =>
+      arg !== "--json" && arg !== "--decision" && index !== decisionIndex + 1,
+  );
+  if (unknown.length > 0 || (decisionIndex >= 0 && !decisionPath)) {
+    throw new Error(
+      "Usage: bun run compatibility:check [--json] [--decision <record.md>]",
+    );
+  }
+
+  const target = await loadCompatibilityTarget();
+  const observations = await collectCompatibilityObservations(target);
+  const report = evaluateCompatibility(target, observations);
+  if (report.outcome === "fail" && decisionPath) {
+    if (report.checks.some(({ status }) => status === "unverified")) {
+      throw new Error(
+        "Compatibility decisions cannot waive unverified probes.",
+      );
+    }
+    const resolvedDecision = resolveCompatibilityDecisionPath(
+      target,
+      decisionPath,
+    );
+    const decisionStat = await lstat(resolvedDecision);
+    if (!decisionStat.isFile() || decisionStat.isSymbolicLink()) {
+      throw new Error(
+        "Compatibility decision must be a regular, non-symlink file.",
+      );
+    }
+    const decisionText = await readFile(resolvedDecision, "utf8");
+    if (!validCompatibilityDecision(decisionText)) {
+      throw new Error(
+        "Compatibility decision must contain accepted Status, Owner, Reason, and an unexpired Expires date.",
+      );
+    }
+    report.outcome = "accepted-drift";
+    report.decision = target.acceptedDecision ?? undefined;
+  }
+
+  process.stdout.write(
+    json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : formatCompatibilityReport(report),
+  );
+  if (report.outcome === "fail") process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    process.stderr.write(`${message(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["bun", "node"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Context

BB Mate needs an explicit downstream alarm when its targeted bb release, public SDK and component registry, measured replica tokens, or catalog contract drift.

## What changed

- add a runtime-validated, reviewable compatibility target for bb 0.35.1 / SDK 0.4.1
- add human and versioned JSON reports using passive bb version and immutable public get-bb/bb artifacts
- fail closed on missing probes, incoherent release refs, removed guard families, redirects, or unreviewed drift
- require target-declared, time-bounded repository decision records for temporary accepted contract drift; unverified probes cannot be waived
- wire the checker, static validation, and 19 focused tests into the normal CI gates
- document the manual live-bb remeasurement/update workflow

## How to test

- bun test scripts/compatibility-check.test.ts
- bun run compatibility:check
- bun run format:check && bun run check && bun run test && bun run build

## Risks / boundaries

The normal check performs network reads against immutable raw.githubusercontent.com/get-bb/bb release paths and fails if they are unavailable. It executes only bb --version, never plugin lifecycle or Connect commands. Live bb remains the visual authority; this is a drift alarm, not an updater or parity claim.

## Issue

Implements #31 under roadmap #21.