### PR TITLE
feat: complete Mate overlay launcher

### DIFF
--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -27,7 +27,7 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Verification blockers: none in preparation.
 - Tracker blockers: dependency graph recorded in the goal.
 - Authority blockers: public license/release and OS-638 merge remain owner gates.
-- Next action: implement OS-633 and preserve execution evidence here.
+- Next action: implement OS-634 and preserve execution evidence here.
 
 ## Goal Amendments
 
@@ -66,6 +66,34 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: All standing P1/P2 and targeted P1/P2/P3 findings are resolved and regression-tested.
 - Next: Commit OS-633 and complete the hosted PR/merge/main-CI/Linear loop.
 - Blockers: None.
+
+2026-08-07 - OS-633 landed and OS-634 implementation focused-green
+- Changed: Landed OS-633 in PR #7, then added reload-stable launcher state, allowlisted multi-plugin selection, bounded theme/viewport controls, exact mode prerequisites, and explicit copy-only CLI handoffs for OS-634.
+- Verified: OS-633 main CI 31218687904 green; OS-634 focused URL, server-selection, overlay/action, and CLI tests plus workbench/CLI type checks.
+- Result: Browser query values cannot become filesystem paths or native commands; build/live remain explicit terminal actions with inherited native output, and Harness remains capability-gated.
+- Next: Complete aggregate verification, browser QA, review, and the hosted OS-634 loop.
+- Blockers: None.
+
+2026-08-07 - OS-634 review correction pass focused-green
+- Changed: Split low-level Harness contract resolution from launcher availability; replaced false Live fixture rendering with a native handoff canvas; made plugin select values collision-free; recovered stale plugin links through the server allowlist; and redacted missing-target, symlink-realpath, provenance, and incidental native paths.
+- Verified: 53 workbench tests now cover overlay keyboard/control interactions, single-entry history writes, stale async response suppression, stale allowlisted selection recovery, reserved-looking plugin keys, mode honesty, Live non-embedding, and path redaction. Workbench type-check is green.
+- Result: All standing and targeted round-one P1/P2 findings have an implemented regression path; aggregate/browser/review rechecks remain.
+- Next: Run aggregate gates and browser smoke, then request standing and fresh targeted round-two review.
+- Blockers: None.
+
+2026-08-07 - OS-634 correction pass aggregate and browser green
+- Changed: Added a deterministic ignored Live-ready workspace only for browser QA; it does not alter product code or normal bb state.
+- Verified: CI-equivalent format/check/test/build is green with 167 total tests; compatibility probes and workbench, plugin, and 13-story Ladle builds pass. Browser QA proved stale-link canonicalization, one history entry per interaction with Back/Forward restoration, Live handoff-only rendering with zero iframes/Connect requests, browser-session path redaction, 320x568 scrolling, and minimize/Escape focus return.
+- Result: Every round-one standing and targeted finding has automated regression coverage plus runtime evidence where visual or focus behavior matters.
+- Next: Standing and fresh targeted round-two review, then hosted PR/CI/review/merge/main-CI/Linear closeout.
+- Blockers: None.
+
+2026-08-07 - OS-634 round-two review clean
+- Changed: Replaced the assumed global binary with the repo-proven `bun run bb-mate` handoff, withheld cross-workspace commands rather than serializing reconstructable directory hierarchy, and extended native-output redaction to punctuation-adjacent paths, file URLs, and UNC paths while preserving HTTPS URLs.
+- Verified: Standing and fresh targeted round-two reviews are both 5/5 with no open P0-P3 findings. The final post-review aggregate passes 167 tests plus format, type, compatibility, plugin, workbench, and 13-story Ladle build gates.
+- Result: All round-one and round-two findings are fixed and regression-tested; the branch is ready for the hosted PR loop.
+- Next: Commit, create draft PR, verify hosted CI/review threads, mark ready, merge, verify main CI, and move OS-634 to Done.
+- Blockers: None.
 ```
 
 ## Preparation Audits
@@ -95,25 +123,32 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | 2         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-2.json`  | 4/5        | changes requested | 0          | One reasonable P3 isolation-test gap                 |
 | 2         | OS-633 standing    | `tmp/reviews/standing/os-633-round-2.json` | 5/5        | clean             | 0          | All standing and targeted gaps fixed                 |
 | 3         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-3.json`  | 5/5        | clean             | 0          | Full boundary and correction recheck                 |
+| 1         | OS-634 standing    | `tmp/reviews/standing/os-634-round-1.json` | 2/5        | changes requested | 4          | Mode honesty, sentinel, redaction, interactions      |
+| 1         | OS-634 targeted    | `tmp/reviews/targeted-os634/round-1.json`  | 2/5        | changes requested | 5          | Stale links, Live truth, redaction, test gaps        |
+| 2         | OS-634 standing    | `tmp/reviews/standing/os-634-round-2.json` | 5/5        | clean             | 0          | All findings plus final handoff/privacy recheck      |
+| 2         | OS-634 targeted    | `tmp/reviews/targeted-os634/round-2.json`  | 5/5        | clean             | 0          | Acceptance matrix and full final-tree verification   |
 
 ## Verification Log
 
-| Check                                                                    | Scope                | Result               | Notes                                                      |
-| ------------------------------------------------------------------------ | -------------------- | -------------------- | ---------------------------------------------------------- |
-| `but status --json`                                                      | baseline             | pass                 | no uncommitted files, stacks, or branches                  |
-| Main CI run 31206636916                                                  | baseline             | pass                 | green at `a637aa0`                                         |
-| `bb --version`                                                           | native capability    | pass                 | 0.35.1                                                     |
-| `npm view @bb/plugin-sdk version --json`                                 | Harness capability   | expected unavailable | npm E404; no fallback allowed                              |
-| `check-goal-prompt --no-placeholders`                                    | packet               | pass                 | 3,604/4,000; no placeholders                               |
-| `goal-loop-doctor`                                                       | packet               | pass                 | required files and sections ready                          |
-| `bun test scripts/compatibility-check.test.ts`                           | OS-629               | pass                 | 19 tests; all drift families and fail-closed paths         |
-| Sanitized-PATH `bun run compatibility:check`                             | OS-629 clean CI      | pass                 | workspace-pinned bb-app 0.35.1 fallback                    |
-| `bun run compatibility:check`                                            | OS-629 public probes | pass                 | 18 target/version/registry/dependency/token/catalog checks |
-| `bun run format:check && bun run check && bun run test && bun run build` | OS-629               | pass                 | 127 tests and all builds green                             |
-| `bun test apps/workbench/src/surface-lab/surface-lab.test.tsx`           | OS-633 focused       | pass                 | 5 tests; 13 stories and every fixture rendered             |
-| `bun --filter @bb-mate/workbench stories:build`                          | OS-633 static lab    | pass                 | 13-entry metadata and portable static assets               |
-| Local Ladle browser smoke                                                | OS-633 runtime       | pass                 | discovery, controls, host contract, sidebar replacement    |
-| `bun run format:check && bun run check && bun run test && bun run build` | OS-633 final         | pass                 | 135 tests; workbench and 13-story Ladle outputs green      |
+| Check                                                                           | Scope                | Result               | Notes                                                      |
+| ------------------------------------------------------------------------------- | -------------------- | -------------------- | ---------------------------------------------------------- |
+| `but status --json`                                                             | baseline             | pass                 | no uncommitted files, stacks, or branches                  |
+| Main CI run 31206636916                                                         | baseline             | pass                 | green at `a637aa0`                                         |
+| `bb --version`                                                                  | native capability    | pass                 | 0.35.1                                                     |
+| `npm view @bb/plugin-sdk version --json`                                        | Harness capability   | expected unavailable | npm E404; no fallback allowed                              |
+| `check-goal-prompt --no-placeholders`                                           | packet               | pass                 | 3,604/4,000; no placeholders                               |
+| `goal-loop-doctor`                                                              | packet               | pass                 | required files and sections ready                          |
+| `bun test scripts/compatibility-check.test.ts`                                  | OS-629               | pass                 | 19 tests; all drift families and fail-closed paths         |
+| Sanitized-PATH `bun run compatibility:check`                                    | OS-629 clean CI      | pass                 | workspace-pinned bb-app 0.35.1 fallback                    |
+| `bun run compatibility:check`                                                   | OS-629 public probes | pass                 | 18 target/version/registry/dependency/token/catalog checks |
+| `bun run format:check && bun run check && bun run test && bun run build`        | OS-629               | pass                 | 127 tests and all builds green                             |
+| `bun test apps/workbench/src/surface-lab/surface-lab.test.tsx`                  | OS-633 focused       | pass                 | 5 tests; 13 stories and every fixture rendered             |
+| `bun --filter @bb-mate/workbench stories:build`                                 | OS-633 static lab    | pass                 | 13-entry metadata and portable static assets               |
+| Local Ladle browser smoke                                                       | OS-633 runtime       | pass                 | discovery, controls, host contract, sidebar replacement    |
+| `bun run format:check && bun run check && bun run test && bun run build`        | OS-633 final         | pass                 | 135 tests; workbench and 13-story Ladle outputs green      |
+| `bun --filter @bb-mate/workbench check && bun --filter @bb-mate/workbench test` | OS-634 corrections   | pass                 | 53 tests; 518 assertions across 12 files                   |
+| `bun run format:check && bun run check && bun run test && bun run build`        | OS-634 candidate     | pass                 | 167 tests; all compatibility and build gates green         |
+| Local workbench browser smoke                                                   | OS-634 runtime       | pass                 | stale recovery, history, Live truth, redaction, focus      |
 
 ## Prompt / Goal Alignment
 
@@ -130,8 +165,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | ------ | ----------- | ------------------------------------------------------ |
 | OS-627 | In Progress | Parent epic                                            |
 | OS-629 | Done        | PR #6 merged at `7f364f1`; main CI 31216658339 green   |
-| OS-633 | In Progress | Critical-path Ladle surface lab                        |
-| OS-634 | Todo        | Unblocked; sequenced after OS-633                      |
+| OS-633 | Done        | PR #7 merged at `7e11d89`; main CI 31218687904 green   |
+| OS-634 | In Progress | Full Mate overlay launcher                             |
 | OS-632 | Todo        | Blocked by OS-633; sequenced after OS-634              |
 | OS-635 | Todo        | Blocked by OS-633                                      |
 | OS-636 | Todo        | Unblocked; finalized after artifact commands stabilize |

--- a/.agents/plans/2026-08-07-os-634-mate-overlay-launcher.md
+++ b/.agents/plans/2026-08-07-os-634-mate-overlay-launcher.md
@@ -1,0 +1,63 @@
+# OS-634 Mate overlay launcher
+
+## Outcome
+
+Turn the lower-right Mate overlay into the reload-stable control point for the
+surface lab while keeping the bb-facing fixture full-viewport and every native
+or state-changing handoff explicit.
+
+## Slice
+
+1. Define one typed URL-state contract for plugin/workspace, surface, fixture,
+   mode, theme, and viewport selections; catalog and inspection remain the data
+   authorities, with deterministic fallbacks for invalid or stale links.
+2. Extend the dark shadcn/Base UI overlay with responsive, keyboard-accessible
+   controls and exact Fixture/Harness/Live availability reasons. Disabled modes
+   remain unselectable.
+3. Add explicit launch, compatibility-check, and native live-handoff actions
+   through the existing bb-mate CLI boundary. Preserve native output and never
+   fetch or iframe Connect content.
+4. Keep multiple-plugin discovery explicit and avoid introducing a BB Mate
+   manifest or automatic normal-plugin/Connect mutation.
+5. Add focused URL-state, selection, availability, accessibility, and action
+   interaction tests, then browser-smoke the full overlay and minimized FAB.
+
+## Boundaries
+
+- Native bb continues to own build, install, dev/reload, and runtime.
+- Fixture is always the browser approximation. Harness requires both a resolved
+  official contract and an upstream-backed adapter; contract resolution alone
+  is not launcher availability. Live requires a proven native frontend target
+  and renders only an explicit native handoff, never Fixture output.
+- Opening a local fixture lab is reversible; build/live handoffs must be
+  visibly explicit and preserve command output.
+- No authenticated Connect fetch/iframe, upstream source import, SDK copy,
+  hidden manifest, secret access, or automatic plugin installation.
+- Reuse the existing catalog, fixture adapters, inspection report, CLI, and UI
+  primitives; do not add a second orchestration system.
+
+## Verification
+
+- Focused URL-state and overlay interaction tests.
+- Local browser smoke for reload-stable links, keyboard access, responsive
+  layout, unavailable-mode explanations, and minimized FAB.
+- `bun run format:check && bun run check && bun run test && bun run build`.
+- Standing plus fresh targeted review; fix all P0-P2 and reasonable P3.
+- Draft PR, hosted CI/review threads, ready/merge, main CI, Linear Done.
+
+## Progress
+
+- [x] Add the typed, canonical URL state and collision-free plugin selection.
+- [x] Add honest Fixture/Harness/Live rendering and explicit native handoffs.
+- [x] Make the browser session allowlisted, stale-safe, and path-redacted.
+- [x] Cover mounted interactions, history, async races, responsive layout, and
+      focus behavior with tests and browser QA.
+- [x] Complete aggregate gates and standing/fresh-targeted review at 5/5.
+- [ ] Land the draft PR, verify main CI, and move OS-634 to Done.
+
+## Completion
+
+Complete when the overlay owns every accepted lab selection and explicit
+handoff, its links reload deterministically, unavailable modes fail honestly,
+all local/hosted gates are green, OS-634 is merged/Done, and the workspace is
+clean.

--- a/README.md
+++ b/README.md
@@ -101,23 +101,40 @@ BB Mate names three different levels of confidence:
   authority.
 
 The workbench discovers the only plugin under `plugins/` automatically. When a
-workspace contains more than one plugin, choose one explicitly:
+workspace contains more than one plugin, `bun run bb-mate dev` still opens the Fixture
+lab and the overlay requires an explicit selection. Plugin, surface, scenario,
+mode, theme, and viewport are stored in the URL, so a selected lab state is
+reload-stable and shareable without a BB Mate manifest. An explicit CLI target
+remains available:
 
 ```sh
 BB_MATE_PLUGIN=plugins/<name> bun run dev
 ```
 
 The overlay reads `package.json`, native `dist/*.meta.json`, and native bb CLI
-JSON output. Discovery never imports or executes plugin code. Harness mode only
-activates when the selected plugin can resolve the officially distributed
-`@bb/plugin-sdk/testing` and `@bb/plugin-sdk/testing/app` packages; BB Mate does
-not copy them or import them from `../bb`.
+JSON output. Discovery never imports or executes plugin code. Inspection reports
+whether the selected plugin can resolve the official
+`@bb/plugin-sdk/testing` and `@bb/plugin-sdk/testing/app` contracts, but the
+launcher keeps Harness disabled until BB Mate has an upstream-backed adapter.
+BB Mate does not copy the harness or import it from `../bb`. Selecting Live bb
+shows a handoff-only canvas and exact native command; it never relabels Fixture
+output as Live or embeds Connect.
 
 ## Compatibility report
 
-The workbench exposes the selected plugin's passive report at
-`/bb-mate-plugin.json`. The JSON contract is versioned with `schemaVersion: 1`
-and keeps Fixture, Harness, and Live capability claims separate. It checks
+The workbench exposes a browser-safe passive session at
+`/bb-mate-session.json`. The server maps opaque candidate keys to discovered
+plugin roots; browser query values are never resolved as filesystem paths. The
+session redacts absolute target, realpath, provenance, and native-diagnostic
+paths, includes exact copyable `bun run bb-mate` launch, build/check, and live
+commands,
+and keeps Fixture, Harness-contract, launcher, and Live capability claims
+separate. Native actions run only after the developer pastes a command into a
+terminal, preserving native output and making artifact/runtime mutation
+explicit. Repo-local commands use the proven `bun run bb-mate` entrypoint. If
+the inspected workspace is outside this repository, the browser withholds
+copyable handoffs instead of exposing local path hierarchy or claiming that an
+uninstalled global binary exists. The compatibility report checks
 manifests, native build metadata, declared bb and SDK engine ranges, native
 plugin state, npm SDK publication, and native provenance. Registry publication
 is reported separately from selected-plugin dependency resolution, so a missing

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -227,6 +227,7 @@ describe("bb-mate CLI", () => {
           env: {
             BB_CLI: "/fake/bin/bb",
             BB_MATE_PLUGIN: pluginRoot,
+            BB_MATE_WORKSPACE: root,
           },
         },
       },
@@ -509,5 +510,31 @@ describe("bb-mate CLI", () => {
     );
     expect(testRuntime.stdout.join("")).toContain("plugins/notes");
     expect(testRuntime.stdout.join("")).toContain("plugins/second");
+  });
+
+  test("launches ambiguous discovery for explicit selection in the overlay", async () => {
+    const { root, pluginRoot } = await createPlugin({ workspace: true });
+    const second = path.join(root, "plugins", "second");
+    await fs.cp(pluginRoot, second, { recursive: true });
+    const launches: Array<{
+      args: readonly string[];
+      env: NodeJS.ProcessEnv;
+    }> = [];
+    const testRuntime = runtime(root, nativeOutput(pluginRoot), {
+      runInherited: async (_executable, args, options) => {
+        launches.push({ args, env: options.env });
+        return { exitCode: 0, signal: null };
+      },
+    });
+
+    const result = await runCli(["dev"], testRuntime.value);
+
+    expect(result).toEqual({ exitCode: 0, signal: null });
+    expect(launches).toHaveLength(1);
+    expect(launches[0]?.env.BB_MATE_WORKSPACE).toBe(root);
+    expect(launches[0]?.env.BB_MATE_PLUGIN).toBeUndefined();
+    expect(testRuntime.stdout.join("")).toContain(
+      "Plugin selection is ambiguous",
+    );
   });
 });

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -207,7 +207,7 @@ export async function runCli(
   if (args.command === "dev") {
     printInspection(runtime, context, false);
     const pluginRoot = context.report.target?.rootPath;
-    if (!pluginRoot) return failure;
+    if (!pluginRoot && context.report.state !== "ambiguous") return failure;
     line(runtime.stdout, connectExposure(context.report, args.port));
     line(
       runtime.stdout,
@@ -224,7 +224,8 @@ export async function runCli(
         cwd: runtime.workspaceRoot,
         env: {
           ...runtime.env,
-          BB_MATE_PLUGIN: pluginRoot,
+          BB_MATE_WORKSPACE: runtime.cwd,
+          ...(pluginRoot ? { BB_MATE_PLUGIN: pluginRoot } : {}),
           ...(context.bbExecutable ? { BB_CLI: context.bbExecutable } : {}),
         },
       },

--- a/apps/workbench/package.json
+++ b/apps/workbench/package.json
@@ -11,7 +11,7 @@
     "stories": "ladle serve",
     "stories:build": "ladle build",
     "stories:preview": "ladle preview",
-    "test": "bun test src"
+    "test": "bun test --preload ./src/test-dom.ts src"
   },
   "dependencies": {
     "@bb-mate/inspection": "workspace:*",
@@ -30,13 +30,17 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^18.0.1",
     "@ladle/react": "5.1.1",
     "@tailwindcss/vite": "^4.3.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.3.4",
     "@types/node": "^26.1.2",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.2",
+    "happy-dom": "^18.0.1",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.9.2",
     "vite": "^7.1.3"

--- a/apps/workbench/plugin-inspection-server.ts
+++ b/apps/workbench/plugin-inspection-server.ts
@@ -1,12 +1,260 @@
-import type { InspectPluginOptions } from "@bb-mate/inspection";
-import { inspectPlugin } from "@bb-mate/inspection";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  discoverPluginRoots,
+  inspectPlugin,
+  type InspectPluginOptions,
+  type PluginInspection,
+} from "@bb-mate/inspection";
 import type { Plugin } from "vite";
 
 export { inspectPlugin } from "@bb-mate/inspection";
 export type { InspectPluginOptions } from "@bb-mate/inspection";
 
-function inspectionMiddleware(options: InspectPluginOptions): (
-  request: { url?: string },
+export interface BrowserPluginCandidate {
+  key: string;
+  label: string;
+  displayPath: string;
+}
+
+export interface BrowserPluginSession {
+  schemaVersion: 1;
+  workspace: {
+    label: string;
+    candidates: BrowserPluginCandidate[];
+    selectedKey: string | null;
+    selectionError: string | null;
+  };
+  inspection: PluginInspection;
+  handoffs: {
+    launchCommand: string | null;
+    checkCommand: string | null;
+    liveCommand: string | null;
+    detail: string;
+  };
+}
+
+interface PluginSessionOptions extends Omit<
+  InspectPluginOptions,
+  "targetPath"
+> {
+  targetPath?: string;
+  selectedKey?: string | null;
+  commandWorkspaceRoot?: string;
+}
+
+function displayPath(workspaceRoot: string, pluginRoot: string): string {
+  const relative = path.relative(workspaceRoot, pluginRoot);
+  return relative || ".";
+}
+
+function shellArgument(value: string): string {
+  return /^[A-Za-z0-9_./:@+-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function handoffCommand(
+  commandWorkspaceRoot: string,
+  command: "dev" | "check" | "live",
+  pluginRoot: string,
+): string {
+  const commandPath = displayPath(commandWorkspaceRoot, pluginRoot);
+  return `bun run bb-mate ${command} ${shellArgument(commandPath)}`;
+}
+
+async function realPathOrSelf(value: string): Promise<string> {
+  try {
+    return await fs.realpath(value);
+  } catch {
+    return value;
+  }
+}
+
+function redactInspection(
+  inspection: PluginInspection,
+  replacements: ReadonlyArray<readonly [absolutePath: string, label: string]>,
+  selectedDisplayPath: string | null,
+): PluginInspection {
+  const ordered = [...replacements]
+    .filter(([absolutePath]) => path.isAbsolute(absolutePath))
+    .sort(([left], [right]) => right.length - left.length);
+  const redact = (value: string): string => {
+    let visible = value;
+    for (const [absolutePath, label] of ordered) {
+      visible = visible.replaceAll(absolutePath, label);
+    }
+    // Native diagnostics can mention paths unrelated to the selected plugin.
+    // Keep URLs intact while removing remaining POSIX and Windows path tokens.
+    visible = visible.replace(
+      /(\bfile:)\/{2,3}[^\s"',)\]]+/g,
+      "$1[redacted-path]",
+    );
+    visible = visible.replace(
+      /(\b(?:path|file):)\/(?!\/)[^\s"',)\]]+/g,
+      "$1[redacted-path]",
+    );
+    visible = visible.replace(
+      /(^|:(?!\/\/)|[\s"'=(\[`;,])\/(?!\/)[^\s"',)\]]+/g,
+      "$1[redacted-path]",
+    );
+    visible = visible.replace(
+      /(\b(?:path|file):)[A-Za-z]:\\[^\s"',)\]]+/g,
+      "$1[redacted-path]",
+    );
+    visible = visible.replace(
+      /(^|:(?!\/\/)|[\s"'=(\[`;,])[A-Za-z]:\\[^\s"',)\]]+/g,
+      "$1[redacted-path]",
+    );
+    visible = visible.replace(
+      /(^|[\s"'=(\[`;,:])\\\\[^\s"',)\]]+/g,
+      "$1[redacted-path]",
+    );
+    return visible;
+  };
+  const sanitize = (value: unknown): unknown => {
+    if (typeof value === "string") return redact(value);
+    if (Array.isArray(value)) return value.map(sanitize);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, sanitize(item)]),
+    );
+  };
+  const visible = sanitize(inspection) as PluginInspection;
+
+  if (visible.target && selectedDisplayPath) {
+    visible.target.rootPath = selectedDisplayPath;
+    visible.target.displayPath = selectedDisplayPath;
+  }
+  if (
+    visible.provenance?.kind === "path" &&
+    selectedDisplayPath &&
+    inspection.provenance
+  ) {
+    visible.provenance.requested = inspection.provenance.requested
+      ? `path:${selectedDisplayPath}`
+      : null;
+    visible.provenance.resolved = inspection.provenance.resolved
+      ? `path:${selectedDisplayPath}`
+      : null;
+  }
+  return visible;
+}
+
+export async function inspectPluginSession(
+  options: PluginSessionOptions,
+): Promise<BrowserPluginSession> {
+  const roots = await discoverPluginRoots(options.workspaceRoot);
+  const explicitRoot = options.targetPath
+    ? path.resolve(options.workspaceRoot, options.targetPath)
+    : null;
+  const allRoots = [...roots];
+  if (explicitRoot && !allRoots.includes(explicitRoot))
+    allRoots.push(explicitRoot);
+
+  const usedKeys = new Set<string>();
+  const candidates = allRoots.map((root) => {
+    const candidatePath = displayPath(options.workspaceRoot, root);
+    const baseKey = roots.includes(root)
+      ? path.basename(root)
+      : "selected-plugin";
+    let key = baseKey;
+    let suffix = 2;
+    while (usedKeys.has(key)) key = `${baseKey}-${suffix++}`;
+    usedKeys.add(key);
+    return {
+      root,
+      key,
+      label: candidatePath,
+      displayPath: candidatePath,
+    };
+  });
+
+  const requested = options.selectedKey
+    ? candidates.find(({ key }) => key === options.selectedKey)
+    : null;
+  const selectionError =
+    options.selectedKey && !requested
+      ? "The requested plugin selection is unavailable. The launcher reset to a server-discovered target."
+      : null;
+  const selected =
+    requested ??
+    (explicitRoot
+      ? candidates.find(({ root }) => root === explicitRoot)
+      : candidates.length === 1
+        ? candidates[0]
+        : null);
+
+  const {
+    targetPath: _targetPath,
+    selectedKey: _selectedKey,
+    commandWorkspaceRoot: _commandWorkspaceRoot,
+    ...inspectionOptions
+  } = options;
+  const inspection = await inspectPlugin({
+    ...inspectionOptions,
+    ...(selected ? { targetPath: selected.root } : {}),
+  });
+  const realWorkspaceRoot = await realPathOrSelf(options.workspaceRoot);
+  const realSelectedRoot = selected
+    ? await realPathOrSelf(selected.root)
+    : null;
+  const selectedDisplayPath = selected?.displayPath ?? null;
+  const visibleInspection = redactInspection(
+    inspection,
+    [
+      [options.workspaceRoot, "."],
+      [realWorkspaceRoot, "."],
+      ...(selected ? ([[selected.root, selected.displayPath]] as const) : []),
+      ...(realSelectedRoot && selected
+        ? ([[realSelectedRoot, selected.displayPath]] as const)
+        : []),
+    ],
+    selectedDisplayPath,
+  );
+  const commandWorkspaceRoot = path.resolve(
+    options.commandWorkspaceRoot ?? options.workspaceRoot,
+  );
+  const realCommandWorkspaceRoot = await realPathOrSelf(commandWorkspaceRoot);
+  const handoffsAvailable = realCommandWorkspaceRoot === realWorkspaceRoot;
+
+  return {
+    schemaVersion: 1,
+    workspace: {
+      label: path.basename(options.workspaceRoot),
+      candidates: candidates.map(({ key, label, displayPath }) => ({
+        key,
+        label,
+        displayPath,
+      })),
+      selectedKey: selected?.key ?? null,
+      selectionError,
+    },
+    inspection: visibleInspection,
+    handoffs: {
+      launchCommand:
+        selected && handoffsAvailable
+          ? handoffCommand(commandWorkspaceRoot, "dev", selected.root)
+          : null,
+      checkCommand:
+        selected && handoffsAvailable
+          ? handoffCommand(commandWorkspaceRoot, "check", selected.root)
+          : null,
+      liveCommand:
+        selected && handoffsAvailable
+          ? handoffCommand(commandWorkspaceRoot, "live", selected.root)
+          : null,
+      detail: !selected
+        ? "Choose a discovered plugin before using terminal handoffs."
+        : handoffsAvailable
+          ? "Run from the BB Mate repository root."
+          : "Copyable handoffs are unavailable because the inspected workspace is outside the BB Mate command workspace.",
+    },
+  };
+}
+
+function sessionMiddleware(options: PluginSessionOptions): (
+  request: { method?: string; url?: string },
   response: {
     statusCode: number;
     setHeader(name: string, value: string): void;
@@ -15,37 +263,48 @@ function inspectionMiddleware(options: InspectPluginOptions): (
   next: () => void,
 ) => void {
   return (request, response, next) => {
-    if (request.url?.split("?", 1)[0] !== "/bb-mate-plugin.json") {
+    const url = new URL(request.url ?? "/", "http://bb-mate.local");
+    if (url.pathname !== "/bb-mate-session.json") {
       next();
       return;
     }
-    void inspectPlugin(options)
-      .then((inspection) => {
+    if (request.method && request.method !== "GET") {
+      response.statusCode = 405;
+      response.setHeader("Allow", "GET");
+      response.end();
+      return;
+    }
+    void inspectPluginSession({
+      ...options,
+      selectedKey: url.searchParams.get("plugin"),
+    })
+      .then((session) => {
         response.statusCode = 200;
         response.setHeader("Content-Type", "application/json; charset=utf-8");
         response.setHeader("Cache-Control", "no-store");
-        response.end(JSON.stringify(inspection));
+        response.setHeader("Referrer-Policy", "no-referrer");
+        response.end(JSON.stringify(session));
       })
-      .catch((error: unknown) => {
+      .catch(() => {
         response.statusCode = 500;
         response.setHeader("Content-Type", "application/json; charset=utf-8");
         response.end(
           JSON.stringify({
-            error: error instanceof Error ? error.message : String(error),
+            error: "Plugin inspection failed.",
           }),
         );
       });
   };
 }
 
-export function pluginInspectionPlugin(options: InspectPluginOptions): Plugin {
+export function pluginInspectionPlugin(options: PluginSessionOptions): Plugin {
   return {
     name: "bb-mate-plugin-inspection",
     configureServer(server) {
-      server.middlewares.use(inspectionMiddleware(options));
+      server.middlewares.use(sessionMiddleware(options));
     },
     configurePreviewServer(server) {
-      server.middlewares.use(inspectionMiddleware(options));
+      server.middlewares.use(sessionMiddleware(options));
     },
   };
 }

--- a/apps/workbench/src/App.tsx
+++ b/apps/workbench/src/App.tsx
@@ -1,27 +1,87 @@
-import { useState } from "react";
-import { BbShell } from "@/components/BbShell";
+import { useEffect, useMemo } from "react";
 import { MateOverlay } from "@/components/MateOverlay";
-import { resolveCatalogSelection, surfaceCatalog } from "@/surface-catalog";
-import type { SurfaceId } from "@/surface-catalog";
+import { PreviewCanvas } from "@/components/PreviewCanvas";
+import { previewModeCapabilities } from "@/preview-mode";
+import { resolveCatalogSelection } from "@/surface-catalog";
+import { usePluginInspection } from "@/usePluginInspection";
+import { useWorkbenchState } from "@/workbench-state";
 
 export function App() {
-  const [surfaceId, setSurfaceId] = useState<SurfaceId>(surfaceCatalog[0].id);
-  const [fixtureId, setFixtureId] = useState<string>(
-    surfaceCatalog[0].fixtures[0].id,
+  const { state, update } = useWorkbenchState();
+  const selection = resolveCatalogSelection(state.surfaceId, state.fixtureId);
+  const inspection = usePluginInspection(state.plugin);
+  const modeCapabilities = useMemo(
+    () => previewModeCapabilities(inspection.inspection),
+    [inspection.inspection],
   );
-  const selection = resolveCatalogSelection(surfaceId, fixtureId);
+  const renderedMode = modeCapabilities[state.mode].available
+    ? state.mode
+    : "fixture";
+
+  useEffect(() => {
+    if (inspection.selectionError) {
+      update({ plugin: inspection.selectedKey }, { replace: true });
+    } else if (
+      !state.plugin &&
+      inspection.selectedKey &&
+      inspection.candidates.length === 1
+    ) {
+      update({ plugin: inspection.selectedKey }, { replace: true });
+    }
+  }, [
+    inspection.candidates.length,
+    inspection.selectionError,
+    inspection.selectedKey,
+    state.plugin,
+    update,
+  ]);
+
+  useEffect(() => {
+    if (
+      (inspection.inspection || inspection.error) &&
+      !modeCapabilities[state.mode].available
+    ) {
+      update({ mode: "fixture" }, { replace: true });
+    }
+  }, [
+    inspection.error,
+    inspection.inspection,
+    modeCapabilities,
+    state.mode,
+    update,
+  ]);
 
   return (
     <>
-      <BbShell selection={selection} />
+      <PreviewCanvas
+        selection={selection}
+        mode={renderedMode}
+        theme={state.theme}
+        viewport={state.viewport}
+      />
       <MateOverlay
         selection={selection}
+        state={state}
+        inspection={inspection.inspection}
+        inspectionError={inspection.error}
+        selectionError={inspection.selectionError}
+        workspaceLabel={inspection.workspaceLabel}
+        candidates={inspection.candidates}
+        selectedKey={inspection.selectedKey}
+        handoffs={inspection.handoffs}
+        onRefreshInspection={inspection.refresh}
+        onPluginChange={(plugin) => update({ plugin, mode: "fixture" })}
         onSurfaceChange={(nextSurfaceId) => {
           const next = resolveCatalogSelection(nextSurfaceId, "");
-          setSurfaceId(next.surface.id);
-          setFixtureId(next.fixture.id);
+          update({
+            surfaceId: next.surface.id,
+            fixtureId: next.fixture.id,
+          });
         }}
-        onFixtureChange={setFixtureId}
+        onFixtureChange={(fixtureId) => update({ fixtureId })}
+        onModeChange={(mode) => update({ mode })}
+        onThemeChange={(theme) => update({ theme })}
+        onViewportChange={(viewport) => update({ viewport })}
       />
     </>
   );

--- a/apps/workbench/src/components/BbShell.tsx
+++ b/apps/workbench/src/components/BbShell.tsx
@@ -19,11 +19,14 @@ import {
 import { useState } from "react";
 import type { CatalogSelection } from "@/surface-catalog";
 import { isThreadListSelection } from "@/surface-catalog";
+import type { PreviewTheme, PreviewViewport } from "@/workbench-state";
 import { BbIcon } from "./BbIcon";
 import { SidebarListView } from "./SidebarListView";
 
 interface BbShellProps {
   selection: CatalogSelection;
+  theme?: PreviewTheme;
+  viewport?: PreviewViewport;
 }
 
 function BuiltInThreadListPlaceholder() {
@@ -99,14 +102,22 @@ function SidebarAction({
   );
 }
 
-export function BbShell({ selection }: BbShellProps) {
+export function BbShell({
+  selection,
+  theme = "light",
+  viewport = "desktop",
+}: BbShellProps) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const threadListSelection = isThreadListSelection(selection)
     ? selection
     : null;
 
   return (
-    <main className="bb-app" aria-label="BB Mate workbench">
+    <main
+      className={`bb-app bb-theme-${theme}`}
+      data-viewport={viewport}
+      aria-label="BB Mate workbench"
+    >
       {mobileSidebarOpen ? (
         <button
           className="bb-mobile-sidebar-backdrop"

--- a/apps/workbench/src/components/MateLauncherActions.test.tsx
+++ b/apps/workbench/src/components/MateLauncherActions.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  copyTerminalCommand,
+  MateLauncherActions,
+} from "./MateLauncherActions";
+
+describe("Mate launcher actions", () => {
+  test("labels native mutations as copied terminal handoffs", () => {
+    const html = renderToStaticMarkup(
+      <MateLauncherActions
+        commands={{
+          launchCommand: "bun run bb-mate dev plugins/notes",
+          checkCommand: "bun run bb-mate check plugins/notes",
+          liveCommand: "bun run bb-mate live plugins/notes",
+          detail: "Run from the BB Mate repository root.",
+        }}
+        liveAvailable
+        liveUrl="https://bb.example.test"
+      />,
+    );
+
+    expect(html).toContain("Copy launch command");
+    expect(html).toContain("Copy build and re-check");
+    expect(html).toContain("State-changing");
+    expect(html).toContain("Run from the BB Mate repository root");
+    expect(html).toContain("bb plugin build .");
+    expect(html).toContain("bb plugin dev .");
+    expect(html).toContain('target="_blank"');
+    expect(html).not.toContain("iframe");
+  });
+
+  test("does not offer a false live command when Live is unavailable", () => {
+    const html = renderToStaticMarkup(
+      <MateLauncherActions
+        commands={{
+          launchCommand: "bun run bb-mate dev plugins/notes",
+          checkCommand: "bun run bb-mate check plugins/notes",
+          liveCommand: "bun run bb-mate live plugins/notes",
+          detail: "Run from the BB Mate repository root.",
+        }}
+        liveAvailable={false}
+        liveUrl={null}
+      />,
+    );
+
+    expect(html).toContain("Copy live handoff");
+    expect(html).toContain("disabled");
+  });
+
+  test("copies the exact trusted command and announces success", async () => {
+    const copied: string[] = [];
+    const announcement = await copyTerminalCommand(
+      async (command) => {
+        copied.push(command);
+      },
+      "bun run bb-mate check 'plugins/my plugin'",
+      "Build and re-check command",
+    );
+
+    expect(copied).toEqual(["bun run bb-mate check 'plugins/my plugin'"]);
+    expect(announcement).toBe(
+      "Build and re-check command copied. Run it from the inspected workspace terminal.",
+    );
+  });
+
+  test("announces clipboard failure without executing a fallback", async () => {
+    const announcement = await copyTerminalCommand(
+      async () => {
+        throw new Error("denied");
+      },
+      "bun run bb-mate live plugins/notes",
+      "Live handoff command",
+    );
+
+    expect(announcement).toContain("Could not copy live handoff command");
+    expect(announcement).toContain("copy it manually");
+  });
+});

--- a/apps/workbench/src/components/MateLauncherActions.tsx
+++ b/apps/workbench/src/components/MateLauncherActions.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { CheckCheck, Clipboard, ExternalLink, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { PluginHandoffs } from "@/usePluginInspection";
+
+export type CopyCommand = (command: string) => Promise<void>;
+
+const copyWithBrowser: CopyCommand = (command) =>
+  navigator.clipboard.writeText(command);
+
+export async function copyTerminalCommand(
+  copyCommand: CopyCommand,
+  command: string,
+  label: string,
+): Promise<string> {
+  try {
+    await copyCommand(command);
+    return `${label} copied. Run it from the inspected workspace terminal.`;
+  } catch {
+    return `Could not copy ${label.toLowerCase()}. Select the command and copy it manually.`;
+  }
+}
+
+interface MateLauncherActionsProps {
+  commands: PluginHandoffs;
+  liveUrl: string | null;
+  liveAvailable: boolean;
+  copyCommand?: CopyCommand;
+}
+
+function CommandAction({
+  label,
+  command,
+  disclosure,
+  icon,
+  onCopy,
+}: {
+  label: string;
+  command: string | null;
+  disclosure: string;
+  icon: React.ReactNode;
+  onCopy(command: string, label: string): void;
+}) {
+  return (
+    <div className="mate-command-action">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={!command}
+        onClick={() => {
+          if (command) onCopy(command, label);
+        }}
+      >
+        {icon}
+        {label}
+      </Button>
+      <p>{disclosure}</p>
+      {command ? <code>{command}</code> : null}
+    </div>
+  );
+}
+
+export function MateLauncherActions({
+  commands,
+  liveUrl,
+  liveAvailable,
+  copyCommand = copyWithBrowser,
+}: MateLauncherActionsProps) {
+  const [announcement, setAnnouncement] = useState("");
+  const onCopy = (command: string, label: string) => {
+    void copyTerminalCommand(copyCommand, command, label).then(setAnnouncement);
+  };
+
+  return (
+    <section className="mate-actions" aria-labelledby="mate-actions-heading">
+      <div className="mate-field-heading" id="mate-actions-heading">
+        Terminal handoff
+      </div>
+      <p className="mate-help">{commands.detail}</p>
+      <CommandAction
+        label="Copy launch command"
+        command={commands.launchCommand}
+        disclosure="Starts this Fixture workbench through bb-mate. Read-only plugin discovery; native Vite output stays in your terminal."
+        icon={<Play aria-hidden="true" />}
+        onCopy={onCopy}
+      />
+      <CommandAction
+        label="Copy build and re-check"
+        command={commands.checkCommand}
+        disclosure="State-changing: delegates to native `bb plugin build .` and writes build artifacts before refreshing the report."
+        icon={<CheckCheck aria-hidden="true" />}
+        onCopy={onCopy}
+      />
+      <CommandAction
+        label="Copy live handoff"
+        command={liveAvailable ? commands.liveCommand : null}
+        disclosure="State-changing while running: delegates to native `bb plugin dev .` for this exact installed path."
+        icon={<Clipboard aria-hidden="true" />}
+        onCopy={onCopy}
+      />
+      {liveUrl ? (
+        <a
+          className="mate-native-link"
+          href={liveUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Open already-running native bb
+          <ExternalLink aria-hidden="true" />
+        </a>
+      ) : null}
+      <p className="mate-action-status" aria-live="polite">
+        {announcement}
+      </p>
+    </section>
+  );
+}

--- a/apps/workbench/src/components/MateOverlay.interaction.test.tsx
+++ b/apps/workbench/src/components/MateOverlay.interaction.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { PluginInspection } from "@bb-mate/inspection";
+import { resolveCatalogSelection } from "@/surface-catalog";
+import type { WorkbenchState } from "@/workbench-state";
+import { MateOverlay } from "./MateOverlay";
+
+afterEach(cleanup);
+
+const state: WorkbenchState = {
+  plugin: "workspace",
+  surfaceId: "thread-list",
+  fixtureId: "agents",
+  mode: "fixture",
+  theme: "light",
+  viewport: "desktop",
+};
+
+const inspection: PluginInspection = {
+  schemaVersion: 1,
+  state: "ready",
+  outcome: "ready",
+  message: null,
+  candidates: [],
+  target: null,
+  checks: [],
+  modes: {
+    fixture: { available: true, detail: "Fixture." },
+    harness: {
+      available: true,
+      detail: "Official contract resolves.",
+      sdkVersion: "0.4.1",
+      resolution: "available",
+      publication: "published",
+      publishedVersion: "0.4.1",
+    },
+    live: {
+      available: true,
+      detail: "Native bb is ready.",
+      pluginId: "workspace",
+      status: "running",
+      sourceKind: "path",
+      url: "https://example.getbb.app",
+    },
+  },
+  native: { bbVersion: "0.35.1", connectUrl: null },
+  provenance: null,
+  trust: {
+    model: "full-trust-local-code",
+    entrypoints: [],
+    skills: [],
+    themes: [],
+    hasSettings: null,
+    capabilities: [],
+    services: [],
+    undisclosedAccess: [],
+    detail: "Local code.",
+  },
+};
+
+function renderOverlay(
+  overrides: Partial<Parameters<typeof MateOverlay>[0]> = {},
+) {
+  const callbacks = {
+    onRefreshInspection: mock(() => {}),
+    onPluginChange: mock((_plugin: string | null) => {}),
+    onSurfaceChange: mock((_surface: string) => {}),
+    onFixtureChange: mock((_fixture: string) => {}),
+    onModeChange: mock((_mode: WorkbenchState["mode"]) => {}),
+    onThemeChange: mock((_theme: WorkbenchState["theme"]) => {}),
+    onViewportChange: mock((_viewport: WorkbenchState["viewport"]) => {}),
+  };
+  render(
+    <MateOverlay
+      selection={resolveCatalogSelection("thread-list", "agents")}
+      state={state}
+      inspection={inspection}
+      inspectionError={null}
+      selectionError={null}
+      workspaceLabel="bb-mate"
+      candidates={[
+        {
+          key: "workspace",
+          label: "plugins/workspace",
+          displayPath: "plugins/workspace",
+        },
+        { key: "other", label: "plugins/other", displayPath: "plugins/other" },
+      ]}
+      selectedKey="workspace"
+      handoffs={{
+        launchCommand: null,
+        checkCommand: null,
+        liveCommand: null,
+        detail: "Run from the BB Mate repository root.",
+      }}
+      {...callbacks}
+      {...overrides}
+    />,
+  );
+  return callbacks;
+}
+
+describe("MateOverlay interactions", () => {
+  test("minimizes, restores focus to the FAB, and reopens from the keyboard", async () => {
+    const user = userEvent.setup();
+    renderOverlay();
+
+    await user.click(screen.getByRole("button", { name: "Minimize controls" }));
+    const trigger = screen.getByRole("button", {
+      name: "Show BB Mate controls",
+    });
+    expect(document.activeElement).toBe(trigger);
+    expect(screen.queryByText("Workbench controls")).toBeNull();
+
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByText("Workbench controls")).toBeTruthy();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByText("Workbench controls")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test("keeps a plugin named workspace distinct and gates preview modes honestly", async () => {
+    const user = userEvent.setup();
+    const callbacks = renderOverlay();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Plugin / workspace" }),
+    );
+    await user.click(screen.getByRole("option", { name: "plugins/other" }));
+    expect(callbacks.onPluginChange).toHaveBeenCalledWith("other");
+
+    const harness = screen.getByRole("button", { name: /Harness/ });
+    const live = screen.getByRole("button", { name: /Live bb/ });
+    expect((harness as HTMLButtonElement).disabled).toBe(true);
+    expect((live as HTMLButtonElement).disabled).toBe(false);
+    await user.click(live);
+    expect(callbacks.onModeChange).toHaveBeenCalledWith("live");
+  });
+
+  test("routes theme and viewport controls through one explicit callback", async () => {
+    const user = userEvent.setup();
+    const callbacks = renderOverlay();
+
+    await user.click(screen.getByRole("button", { name: "Dark" }));
+    await user.click(screen.getByRole("button", { name: "Compact" }));
+
+    expect(callbacks.onThemeChange).toHaveBeenCalledTimes(1);
+    expect(callbacks.onThemeChange).toHaveBeenCalledWith("dark");
+    expect(callbacks.onViewportChange).toHaveBeenCalledTimes(1);
+    expect(callbacks.onViewportChange).toHaveBeenCalledWith("compact");
+  });
+});

--- a/apps/workbench/src/components/MateOverlay.test.tsx
+++ b/apps/workbench/src/components/MateOverlay.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { PluginInspection } from "@bb-mate/inspection";
-import { PluginInspectionCard } from "./MateOverlay";
+import {
+  candidateSelectionValue,
+  PluginInspectionCard,
+  pluginKeyFromSelection,
+} from "./MateOverlay";
 
 function report(overrides: Partial<PluginInspection> = {}): PluginInspection {
   return {
@@ -129,5 +133,20 @@ describe("PluginInspectionCard", () => {
         <PluginInspectionCard inspection={missingPublication} error={null} />,
       ),
     ).toContain("Track SDK publication");
+  });
+});
+
+describe("MateOverlay plugin selection values", () => {
+  test("keeps reserved-looking plugin keys distinct from workspace control state", () => {
+    expect(candidateSelectionValue("workspace")).toBe("candidate:workspace");
+    expect(pluginKeyFromSelection("candidate:workspace")).toBe("workspace");
+    expect(pluginKeyFromSelection("candidate:selected-plugin")).toBe(
+      "selected-plugin",
+    );
+    expect(pluginKeyFromSelection("control:workspace")).toBeNull();
+  });
+
+  test("does not pass unknown UI values through as server candidate keys", () => {
+    expect(pluginKeyFromSelection("../plugin")).toBeNull();
   });
 });

--- a/apps/workbench/src/components/MateOverlay.tsx
+++ b/apps/workbench/src/components/MateOverlay.tsx
@@ -7,7 +7,9 @@ import {
   Radio,
   SlidersHorizontal,
 } from "lucide-react";
+import { MateLauncherActions } from "@/components/MateLauncherActions";
 import { Button } from "@/components/ui/button";
+import { previewModeCapabilities } from "@/preview-mode";
 import {
   Popover,
   PopoverContent,
@@ -27,7 +29,13 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { CatalogSelection } from "@/surface-catalog";
 import { surfaceCatalog } from "@/surface-catalog";
-import { usePluginInspection } from "@/usePluginInspection";
+import type { PluginCandidate, PluginHandoffs } from "@/usePluginInspection";
+import type {
+  PreviewMode,
+  PreviewTheme,
+  PreviewViewport,
+  WorkbenchState,
+} from "@/workbench-state";
 import type { PluginInspection } from "@bb-mate/inspection";
 
 const surfaceItems = surfaceCatalog.map((surface) => ({
@@ -39,11 +47,37 @@ const pluginSdkPublicationIssue = "https://github.com/get-bb/bb/issues/1134";
 
 interface MateOverlayProps {
   selection: CatalogSelection;
+  state: WorkbenchState;
+  inspection: PluginInspection | null;
+  inspectionError: string | null;
+  selectionError: string | null;
+  workspaceLabel: string | null;
+  candidates: PluginCandidate[];
+  selectedKey: string | null;
+  handoffs: PluginHandoffs;
+  onRefreshInspection: () => void;
+  onPluginChange: (plugin: string | null) => void;
   onSurfaceChange: (surfaceId: string) => void;
   onFixtureChange: (fixtureId: string) => void;
+  onModeChange: (mode: PreviewMode) => void;
+  onThemeChange: (theme: PreviewTheme) => void;
+  onViewportChange: (viewport: PreviewViewport) => void;
 }
 
 const actionableStatuses = new Set(["warning", "fail", "unavailable"]);
+const workspaceSelectionValue = "control:workspace";
+
+export function candidateSelectionValue(key: string): string {
+  return `candidate:${key}`;
+}
+
+export function pluginKeyFromSelection(value: string): string | null {
+  return value === workspaceSelectionValue
+    ? null
+    : value.startsWith("candidate:")
+      ? value.slice("candidate:".length)
+      : null;
+}
 
 export function PluginInspectionCard({
   inspection,
@@ -81,7 +115,7 @@ export function PluginInspectionCard({
               Report {inspection?.outcome}
             </span>
             <span data-available={Boolean(harness?.available)}>
-              Harness {harness?.available ? "ready" : "unavailable"}
+              Harness contract {harness?.available ? "ready" : "unavailable"}
             </span>
             <span>
               Source {inspection?.provenance?.kind ?? "not installed"}
@@ -174,14 +208,38 @@ export function PluginInspectionCard({
 
 export function MateOverlay({
   selection,
+  state,
+  inspection,
+  inspectionError,
+  selectionError,
+  workspaceLabel,
+  candidates,
+  selectedKey,
+  handoffs,
+  onRefreshInspection,
+  onPluginChange,
   onSurfaceChange,
   onFixtureChange,
+  onModeChange,
+  onThemeChange,
+  onViewportChange,
 }: MateOverlayProps) {
   const [open, setOpen] = useState(true);
-  const { inspection, error } = usePluginInspection();
   const harness = inspection?.modes.harness;
+  const live = inspection?.modes.live;
+  const modeCapabilities = previewModeCapabilities(inspection);
   const build =
     inspection?.target?.build.app ?? inspection?.target?.build.server;
+  const pluginItems = [
+    {
+      label: `Discover in ${workspaceLabel ?? "workspace"}`,
+      value: workspaceSelectionValue,
+    },
+    ...candidates.map(({ key, label }) => ({
+      label,
+      value: candidateSelectionValue(key),
+    })),
+  ];
   const fixtureItems = selection.surface.fixtures.map((fixture) => ({
     label: fixture.name,
     value: fixture.id,
@@ -232,38 +290,97 @@ export function MateOverlay({
           <div className="mate-divider" />
 
           <div className="mate-field">
+            <label className="mate-field-heading" htmlFor="mate-plugin">
+              Plugin / workspace
+            </label>
+            <Select
+              items={pluginItems}
+              value={
+                state.plugin || selectedKey
+                  ? candidateSelectionValue(state.plugin ?? selectedKey ?? "")
+                  : workspaceSelectionValue
+              }
+              onValueChange={(value) => {
+                if (value) onPluginChange(pluginKeyFromSelection(value));
+              }}
+            >
+              <SelectTrigger id="mate-plugin" className="mate-select-trigger">
+                <SelectValue placeholder="Choose a discovered plugin" />
+              </SelectTrigger>
+              <SelectContent
+                align="end"
+                alignItemWithTrigger={false}
+                className="dark mate-select-content"
+              >
+                <SelectGroup>
+                  {pluginItems.map((item) => (
+                    <SelectItem key={item.value} value={item.value}>
+                      {item.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {candidates.length > 1 && !selectedKey ? (
+              <p className="mate-help" role="status">
+                Multiple plugins were discovered. Choose one explicitly before
+                using native handoffs.
+              </p>
+            ) : null}
+            {selectionError ? (
+              <p className="mate-help" role="status">
+                {selectionError}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="mate-field">
             <div className="mate-field-heading">
               <span>Source</span>
               <span className="mate-source-status">
-                <i aria-hidden="true" /> fixture
+                <i aria-hidden="true" /> {state.mode}
               </span>
             </div>
             <ToggleGroup
               aria-label="State source"
               className="mate-source-toggle"
               spacing={0}
-              value={["fixtures"]}
+              value={[state.mode]}
+              onValueChange={(values) => {
+                const mode = values[0] as PreviewMode | undefined;
+                if (mode) onModeChange(mode);
+              }}
             >
-              <ToggleGroupItem value="fixtures">
+              <ToggleGroupItem value="fixture">
                 <Database data-icon="inline-start" />
                 Fixtures
               </ToggleGroupItem>
-              <ToggleGroupItem value="harness" disabled={!harness?.available}>
+              <ToggleGroupItem
+                value="harness"
+                disabled={!modeCapabilities.harness.available}
+              >
                 <FlaskConical data-icon="inline-start" />
                 Harness
               </ToggleGroupItem>
-              <ToggleGroupItem value="live" disabled>
+              <ToggleGroupItem
+                value="live"
+                disabled={!modeCapabilities.live.available}
+              >
                 <Radio data-icon="inline-start" />
                 Live bb
               </ToggleGroupItem>
             </ToggleGroup>
             <p className="mate-help">
-              {harness?.detail ??
-                "Inspecting the official SDK harness and native bb runtime…"}
+              Fixture: deterministic approximation. Harness:{" "}
+              {modeCapabilities.harness.detail} Live:{" "}
+              {modeCapabilities.live.detail}
             </p>
           </div>
 
-          <PluginInspectionCard inspection={inspection} error={error} />
+          <PluginInspectionCard
+            inspection={inspection}
+            error={inspectionError}
+          />
 
           <div className="mate-field">
             <label className="mate-field-heading" htmlFor="mate-surface">
@@ -297,7 +414,7 @@ export function MateOverlay({
 
           <div className="mate-field">
             <label className="mate-field-heading" htmlFor="mate-fixture">
-              Fixture
+              Scenario
             </label>
             <Select
               items={fixtureItems}
@@ -307,7 +424,7 @@ export function MateOverlay({
               }}
             >
               <SelectTrigger id="mate-fixture" className="mate-select-trigger">
-                <SelectValue placeholder="Choose a fixture" />
+                <SelectValue placeholder="Choose a scenario" />
               </SelectTrigger>
               <SelectContent
                 align="end"
@@ -324,6 +441,56 @@ export function MateOverlay({
               </SelectContent>
             </Select>
           </div>
+
+          <div className="mate-control-row">
+            <div className="mate-field">
+              <span className="mate-field-heading">Theme</span>
+              <ToggleGroup
+                aria-label="Preview theme"
+                className="mate-compact-toggle"
+                spacing={0}
+                value={[state.theme]}
+                onValueChange={(values) => {
+                  const theme = values[0] as PreviewTheme | undefined;
+                  if (theme) onThemeChange(theme);
+                }}
+              >
+                <ToggleGroupItem value="light">Light</ToggleGroupItem>
+                <ToggleGroupItem value="dark">Dark</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+            <div className="mate-field">
+              <span className="mate-field-heading">Viewport</span>
+              <ToggleGroup
+                aria-label="Preview viewport"
+                className="mate-compact-toggle"
+                spacing={0}
+                value={[state.viewport]}
+                onValueChange={(values) => {
+                  const viewport = values[0] as PreviewViewport | undefined;
+                  if (viewport) onViewportChange(viewport);
+                }}
+              >
+                <ToggleGroupItem value="desktop">Desktop</ToggleGroupItem>
+                <ToggleGroupItem value="compact">Compact</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+          </div>
+
+          <MateLauncherActions
+            commands={handoffs}
+            liveAvailable={Boolean(live?.available)}
+            liveUrl={live?.url ?? null}
+          />
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onRefreshInspection}
+          >
+            Refresh passive report
+          </Button>
 
           <div className="mate-runtime-line">
             <span>bb {inspection?.native.bbVersion ?? "unavailable"}</span>

--- a/apps/workbench/src/components/PreviewCanvas.test.tsx
+++ b/apps/workbench/src/components/PreviewCanvas.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PreviewCanvas } from "./PreviewCanvas";
+import { resolveCatalogSelection } from "../surface-catalog";
+
+const selection = resolveCatalogSelection("thread-list", "agents");
+
+describe("PreviewCanvas", () => {
+  test("renders Fixture through the deterministic BB Mate shell", () => {
+    const markup = renderToStaticMarkup(
+      <PreviewCanvas
+        selection={selection}
+        mode="fixture"
+        theme="dark"
+        viewport="compact"
+      />,
+    );
+
+    expect(markup).toContain('aria-label="BB Mate workbench"');
+    expect(markup).toContain('data-viewport="compact"');
+  });
+
+  test("renders Live as a native handoff instead of Fixture output", () => {
+    const markup = renderToStaticMarkup(
+      <PreviewCanvas
+        selection={selection}
+        mode="live"
+        theme="light"
+        viewport="desktop"
+      />,
+    );
+
+    expect(markup).toContain("Continue in native bb");
+    expect(markup).toContain("does not fetch, embed, or reproduce");
+    expect(markup).not.toContain('aria-label="BB Mate workbench"');
+    expect(markup).not.toContain("<iframe");
+  });
+});

--- a/apps/workbench/src/components/PreviewCanvas.tsx
+++ b/apps/workbench/src/components/PreviewCanvas.tsx
@@ -1,0 +1,47 @@
+import { BbShell } from "@/components/BbShell";
+import type { CatalogSelection } from "@/surface-catalog";
+import type {
+  PreviewMode,
+  PreviewTheme,
+  PreviewViewport,
+} from "@/workbench-state";
+
+interface PreviewCanvasProps {
+  selection: CatalogSelection;
+  mode: PreviewMode;
+  theme: PreviewTheme;
+  viewport: PreviewViewport;
+}
+
+export function PreviewCanvas({
+  selection,
+  mode,
+  theme,
+  viewport,
+}: PreviewCanvasProps) {
+  if (mode === "fixture") {
+    return <BbShell selection={selection} theme={theme} viewport={viewport} />;
+  }
+
+  return (
+    <main
+      className={`bb-mode-handoff bb-theme-${theme}`}
+      data-viewport={viewport}
+      aria-label={`${mode === "live" ? "Live bb" : "Harness"} handoff`}
+    >
+      <section>
+        <span>{mode === "live" ? "Live bb" : "Harness"}</span>
+        <h1>
+          {mode === "live"
+            ? "Continue in native bb"
+            : "Harness preview is unavailable"}
+        </h1>
+        <p>
+          {mode === "live"
+            ? "Live bb is the visual authority. BB Mate does not fetch, embed, or reproduce the Connect runtime. Use the launcher handoff to open this plugin in bb."
+            : "The official testing contract may resolve, but BB Mate will not claim Harness fidelity until the upstream-backed adapter exists."}
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/workbench/src/plugin-inspection-server.test.ts
+++ b/apps/workbench/src/plugin-inspection-server.test.ts
@@ -3,9 +3,13 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { CommandResult, HarnessResolution } from "@bb-mate/inspection";
-import { inspectPlugin } from "../plugin-inspection-server";
+import {
+  inspectPlugin,
+  inspectPluginSession,
+} from "../plugin-inspection-server";
 
 const temporaryRoots: string[] = [];
+const bbMateRoot = path.resolve(import.meta.dir, "../../..");
 
 async function createWorkspace(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-inspection-"));
@@ -256,5 +260,329 @@ describe("plugin inspection", () => {
 
     expect(inspection.state).toBe("ambiguous");
     expect(inspection.candidates).toEqual(["plugins/one", "plugins/two"]);
+  });
+
+  test("selects only a server-discovered opaque candidate key", async () => {
+    const workspaceRoot = await createWorkspace();
+    await writePlugin(workspaceRoot, "one", {
+      name: "bb-plugin-one",
+      version: "1.0.0",
+      bb: {
+        name: "One",
+        description: "One test plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+      },
+    });
+    await writePlugin(workspaceRoot, "two", {
+      name: "bb-plugin-two",
+      version: "1.0.0",
+      bb: {
+        name: "Two",
+        description: "Two test plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+      },
+    });
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      selectedKey: "two",
+      resolveHarness: async () => unavailableHarness,
+      runBb: async (args) =>
+        args[0] === "--version"
+          ? command("0.35.1")
+          : { stdout: "", stderr: "unavailable", exitCode: 1 },
+    });
+
+    expect(session.workspace).toMatchObject({
+      label: path.basename(workspaceRoot),
+      selectedKey: "two",
+      selectionError: null,
+      candidates: [
+        { key: "one", displayPath: "plugins/one" },
+        { key: "two", displayPath: "plugins/two" },
+      ],
+    });
+    expect(session.inspection.target?.displayPath).toBe("plugins/two");
+    expect(session.inspection.target?.rootPath).toBe("plugins/two");
+    expect(session.handoffs.checkCommand).toBe(
+      "bun run bb-mate check plugins/two",
+    );
+    expect(JSON.stringify(session)).not.toContain(workspaceRoot);
+  });
+
+  test("recovers stale and path-like selections using only allowlisted candidates", async () => {
+    const workspaceRoot = await createWorkspace();
+    await writePlugin(workspaceRoot, "one", {
+      name: "bb-plugin-one",
+      version: "1.0.0",
+      bb: {
+        name: "One",
+        description: "One test plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+      },
+    });
+
+    for (const selectedKey of ["../one", "/tmp/one", "plugins/one"]) {
+      const session = await inspectPluginSession({
+        workspaceRoot,
+        selectedKey,
+        runBb: async () => ({
+          stdout: "",
+          stderr: "unavailable",
+          exitCode: 1,
+        }),
+      });
+
+      expect(session.workspace.selectedKey).toBe("one");
+      expect(session.workspace.selectionError).toContain("unavailable");
+      expect(session.inspection.target?.displayPath).toBe("plugins/one");
+      expect(session.workspace.selectionError).not.toContain(selectedKey);
+    }
+  });
+
+  test("returns discovery when a stale selection has no unique fallback", async () => {
+    const workspaceRoot = await createWorkspace();
+    for (const name of ["one", "two"]) {
+      await writePlugin(workspaceRoot, name, {
+        name: `bb-plugin-${name}`,
+        version: "1.0.0",
+        bb: {
+          name,
+          description: `${name} test plugin`,
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+        },
+      });
+    }
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      selectedKey: "removed",
+    });
+
+    expect(session.workspace.selectedKey).toBeNull();
+    expect(session.workspace.selectionError).toContain("unavailable");
+    expect(session.workspace.candidates).toHaveLength(2);
+    expect(session.handoffs.checkCommand).toBeNull();
+  });
+
+  test("withholds cross-workspace commands for an explicit standalone plugin", async () => {
+    const workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-standalone-"),
+    );
+    temporaryRoots.push(workspaceRoot);
+    await fs.writeFile(
+      path.join(workspaceRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-standalone",
+        version: "1.0.0",
+        bb: {
+          name: "Standalone",
+          description: "Standalone test plugin",
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+        },
+      }),
+    );
+    await fs.writeFile(path.join(workspaceRoot, "server.ts"), "export {};\n");
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      targetPath: workspaceRoot,
+      commandWorkspaceRoot: bbMateRoot,
+      runBb: async () => ({ stdout: "", stderr: "unavailable", exitCode: 1 }),
+    });
+
+    expect(session.workspace.selectedKey).toBe("selected-plugin");
+    expect(session.workspace.selectionError).toBeNull();
+    expect(session.handoffs).toEqual({
+      launchCommand: null,
+      checkCommand: null,
+      liveCommand: null,
+      detail:
+        "Copyable handoffs are unavailable because the inspected workspace is outside the BB Mate command workspace.",
+    });
+    expect(JSON.stringify(session)).not.toContain(workspaceRoot);
+  });
+
+  test("keeps explicit candidate keys unique when a plugin uses the reserved-looking name", async () => {
+    const workspaceRoot = await createWorkspace();
+    await writePlugin(workspaceRoot, "selected-plugin", {
+      name: "bb-plugin-selected",
+      version: "1.0.0",
+      bb: {
+        name: "Selected",
+        description: "Discovered plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+      },
+    });
+    const explicitRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-explicit-plugin-"),
+    );
+    temporaryRoots.push(explicitRoot);
+    await fs.writeFile(
+      path.join(explicitRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-explicit",
+        version: "1.0.0",
+        bb: {
+          name: "Explicit",
+          description: "Explicit plugin",
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+        },
+      }),
+    );
+    await fs.writeFile(path.join(explicitRoot, "server.ts"), "export {};\n");
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      targetPath: explicitRoot,
+      runBb: async () => ({ stdout: "", stderr: "unavailable", exitCode: 1 }),
+    });
+
+    expect(session.workspace.candidates.map(({ key }) => key)).toEqual([
+      "selected-plugin",
+      "selected-plugin-2",
+    ]);
+    expect(session.workspace.selectedKey).toBe("selected-plugin-2");
+  });
+
+  test("shell-quotes server-trusted candidate paths in terminal handoffs", async () => {
+    const workspaceRoot = await createWorkspace();
+    await writePlugin(workspaceRoot, "my plugin's", {
+      name: "bb-plugin-special",
+      version: "1.0.0",
+      bb: {
+        name: "Special",
+        description: "Shell quoting test plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+      },
+    });
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      selectedKey: "my plugin's",
+      runBb: async () => ({ stdout: "", stderr: "unavailable", exitCode: 1 }),
+    });
+
+    expect(session.handoffs.checkCommand).toBe(
+      `bun run bb-mate check 'plugins/my plugin'"'"'s'`,
+    );
+  });
+
+  test("redacts an explicit missing target even when inspection has no target", async () => {
+    const workspaceRoot = await createWorkspace();
+    const missingRoot = path.join(os.tmpdir(), "bb-mate-private", "missing");
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      targetPath: missingRoot,
+    });
+    const json = JSON.stringify(session);
+
+    expect(session.inspection.target).toBeNull();
+    expect(json).not.toContain(missingRoot);
+    expect(json).not.toContain(workspaceRoot);
+  });
+
+  test("redacts real paths behind a symlinked plugin and path provenance", async () => {
+    const workspaceRoot = await createWorkspace();
+    const externalRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-external-plugin-"),
+    );
+    temporaryRoots.push(externalRoot);
+    await fs.writeFile(
+      path.join(externalRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-linked",
+        version: "1.0.0",
+        bb: {
+          name: "Linked",
+          description: "Linked test plugin",
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+        },
+      }),
+    );
+    await fs.writeFile(path.join(externalRoot, "server.ts"), "export {};\n");
+    const linkedRoot = path.join(workspaceRoot, "plugins", "linked");
+    await fs.symlink(externalRoot, linkedRoot);
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      selectedKey: "linked",
+      runBb: async (args) => {
+        if (args[0] === "--version") return command("0.35.1");
+        if (args[1] === "list") {
+          return command(
+            JSON.stringify({
+              plugins: [
+                {
+                  id: "linked",
+                  rootDir: externalRoot,
+                  source: `path:${externalRoot}`,
+                  status: "running",
+                },
+              ],
+            }),
+          );
+        }
+        if (args[1] === "source") {
+          return command(
+            JSON.stringify({
+              requested: `path:${linkedRoot}`,
+              resolved: `path:${externalRoot}`,
+            }),
+          );
+        }
+        return { stdout: "", stderr: "unavailable", exitCode: 1 };
+      },
+    });
+    const json = JSON.stringify(session);
+
+    expect(session.inspection.target?.rootPath).toBe("plugins/linked");
+    expect(session.inspection.provenance).toMatchObject({
+      requested: "path:plugins/linked",
+      resolved: "path:plugins/linked",
+    });
+    expect(json).not.toContain(externalRoot);
+    expect(json).not.toContain(linkedRoot);
+    expect(json).not.toContain(workspaceRoot);
+  });
+
+  test("redacts unrelated absolute paths in native diagnostics", async () => {
+    const workspaceRoot = await createWorkspace();
+    await writePlugin(workspaceRoot, "one", {
+      name: "bb-plugin-one",
+      version: "1.0.0",
+      bb: {
+        name: "One",
+        description: "One test plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+      },
+    });
+
+    const session = await inspectPluginSession({
+      workspaceRoot,
+      runBb: async () => ({
+        stdout: "",
+        stderr: String.raw`failed while reading path:/Users/private/secret.json, [/Volumes/private/file], ENOENT:/private/adjacent.json, file:///Users/private/local.ts, and \\server\share\secret.ts; https://example.test/stays`,
+        exitCode: 1,
+      }),
+    });
+
+    expect(JSON.stringify(session)).not.toContain("/Users/private");
+    expect(JSON.stringify(session)).not.toContain("/Volumes/private");
+    expect(JSON.stringify(session)).not.toContain("/private/adjacent");
+    expect(JSON.stringify(session)).not.toContain("/Users/private/local");
+    expect(JSON.stringify(session)).not.toContain("server\\share");
+    expect(JSON.stringify(session)).toContain("https://example.test/stays");
+    expect(JSON.stringify(session)).toContain("[redacted-path]");
   });
 });

--- a/apps/workbench/src/preview-mode.test.ts
+++ b/apps/workbench/src/preview-mode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { PluginInspection } from "@bb-mate/inspection";
+import { previewModeCapabilities } from "./preview-mode";
+
+function inspectionWithHarness(available: boolean): PluginInspection {
+  return {
+    schemaVersion: 1,
+    state: "ready",
+    outcome: "ready",
+    message: null,
+    candidates: [],
+    target: null,
+    checks: [],
+    modes: {
+      fixture: { available: true, detail: "Fixture." },
+      harness: {
+        available,
+        detail: available ? "Official contract resolves." : "Unavailable.",
+        sdkVersion: available ? "0.4.1" : null,
+        resolution: available ? "available" : "dependency-unresolved",
+        publication: available ? "published" : "unknown",
+        publishedVersion: available ? "0.4.1" : null,
+      },
+      live: {
+        available: true,
+        detail: "Native bb is ready.",
+        pluginId: "example",
+        status: "running",
+        sourceKind: "path",
+        url: "https://example.getbb.app",
+      },
+    },
+    native: { bbVersion: "0.35.1", connectUrl: null },
+    provenance: null,
+    trust: {
+      model: "full-trust-local-code",
+      entrypoints: [],
+      skills: [],
+      themes: [],
+      hasSettings: null,
+      capabilities: [],
+      services: [],
+      undisclosedAccess: [],
+      detail: "Local code.",
+    },
+  };
+}
+
+describe("launcher preview capabilities", () => {
+  test("keeps Harness unavailable until the upstream-backed adapter exists", () => {
+    const capabilities = previewModeCapabilities(inspectionWithHarness(true));
+
+    expect(capabilities.harness).toEqual({
+      available: false,
+      detail:
+        "The official Harness contract resolves, but BB Mate has no upstream-backed Harness adapter yet.",
+    });
+  });
+
+  test("exposes proven native live availability without changing Fixture", () => {
+    const capabilities = previewModeCapabilities(inspectionWithHarness(false));
+
+    expect(capabilities.fixture.available).toBe(true);
+    expect(capabilities.live).toEqual({
+      available: true,
+      detail: "Native bb is ready.",
+    });
+  });
+});

--- a/apps/workbench/src/preview-mode.ts
+++ b/apps/workbench/src/preview-mode.ts
@@ -1,0 +1,31 @@
+import type { PluginInspection } from "@bb-mate/inspection";
+import type { PreviewMode } from "@/workbench-state";
+
+export interface LauncherPreviewCapability {
+  available: boolean;
+  detail: string;
+}
+
+export function previewModeCapabilities(
+  inspection: PluginInspection | null,
+): Record<PreviewMode, LauncherPreviewCapability> {
+  const harness = inspection?.modes.harness;
+  const live = inspection?.modes.live;
+
+  return {
+    fixture: {
+      available: true,
+      detail: "Deterministic approximation rendered by BB Mate.",
+    },
+    harness: {
+      available: false,
+      detail: harness?.available
+        ? "The official Harness contract resolves, but BB Mate has no upstream-backed Harness adapter yet."
+        : (harness?.detail ?? "Inspecting the official SDK testing contract."),
+    },
+    live: {
+      available: Boolean(live?.available),
+      detail: live?.detail ?? "Inspecting native bb.",
+    },
+  };
+}

--- a/apps/workbench/src/styles.css
+++ b/apps/workbench/src/styles.css
@@ -91,6 +91,104 @@ button {
   background: var(--background);
 }
 
+.bb-app.bb-theme-dark,
+.bb-mode-handoff.bb-theme-dark {
+  --background: oklch(18% 0.01 260);
+  --foreground: oklch(94% 0.008 260);
+  --bb-sidebar: oklch(21% 0.012 260);
+  --bb-sidebar-foreground: oklch(91% 0.008 260);
+  --bb-sidebar-accent: oklch(27% 0.014 260);
+  --bb-sidebar-border: oklch(31% 0.014 260);
+  --bb-subtle-foreground: oklch(70% 0.014 260);
+  color: var(--foreground);
+}
+
+.bb-app[data-viewport="compact"] {
+  position: relative;
+  width: min(390px, 100%);
+  height: min(844px, 100dvh);
+  margin: auto;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px var(--bb-sidebar-border);
+}
+
+.bb-app[data-viewport="compact"] .bb-sidebar {
+  position: absolute;
+  z-index: 30;
+  display: flex;
+  transform: translateX(-100%);
+}
+
+.bb-app[data-viewport="compact"] .bb-sidebar.mobile-open {
+  transform: translateX(0);
+}
+
+.bb-app[data-viewport="compact"] .bb-mobile-sidebar-button {
+  display: grid;
+}
+
+.bb-app[data-viewport="compact"] .bb-mobile-sidebar-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: oklch(0% 0 0 / 0.12);
+  backdrop-filter: blur(1px);
+}
+
+.bb-app[data-viewport="compact"] .bb-compose-wrap {
+  width: calc(100% - 32px);
+}
+
+.bb-mode-handoff {
+  display: grid;
+  width: 100%;
+  height: 100dvh;
+  padding: 32px;
+  color: var(--foreground);
+  background: var(--background);
+  place-items: center;
+}
+
+.bb-mode-handoff[data-viewport="compact"] {
+  width: min(390px, 100%);
+  height: min(844px, 100dvh);
+  margin: auto;
+  box-shadow: 0 0 0 1px var(--bb-sidebar-border);
+}
+
+.bb-mode-handoff section {
+  width: min(100%, 520px);
+  padding: 32px;
+  border: 1px solid var(--bb-sidebar-border);
+  border-radius: 16px;
+  background: var(--bb-sidebar);
+}
+
+.bb-mode-handoff span {
+  color: var(--bb-subtle-foreground);
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bb-mode-handoff h1 {
+  margin: 10px 0 12px;
+  font-size: clamp(24px, 5vw, 40px);
+  letter-spacing: -0.04em;
+}
+
+.bb-mode-handoff p {
+  margin: 0;
+  color: var(--bb-subtle-foreground);
+  line-height: 1.6;
+}
+
 .bb-sidebar {
   position: relative;
   display: flex;
@@ -530,8 +628,9 @@ button {
 
 .mate-overlay {
   position: fixed;
-  right: 20px;
-  bottom: 20px;
+  z-index: 60;
+  right: max(20px, env(safe-area-inset-right));
+  bottom: max(20px, env(safe-area-inset-bottom));
   font-family: "Geist Variable", Geist, sans-serif;
 }
 
@@ -566,9 +665,12 @@ button {
 
 .mate-popover {
   width: min(340px, calc(100vw - 24px));
+  max-height: calc(100dvh - 80px);
   gap: 14px;
   padding: 15px;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border: 1px solid oklch(33% 0.018 260);
   border-radius: 18px;
   background:
@@ -688,6 +790,32 @@ button {
 
 .mate-source-toggle [disabled] {
   opacity: 0.36;
+}
+
+.mate-control-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.mate-compact-toggle {
+  width: 100%;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  background: oklch(13% 0.01 260 / 0.8);
+}
+
+.mate-compact-toggle [data-slot="toggle-group-item"] {
+  flex: 1;
+  min-width: 0;
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.mate-compact-toggle [aria-pressed="true"] {
+  color: var(--foreground);
+  background: var(--muted);
 }
 
 .mate-help {
@@ -906,6 +1034,59 @@ button {
   height: 11px;
 }
 
+.mate-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 2px;
+}
+
+.mate-command-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 3px 8px;
+}
+
+.mate-command-action [data-slot="button"] {
+  grid-column: 1 / -1;
+  justify-content: flex-start;
+}
+
+.mate-command-action p,
+.mate-action-status {
+  margin: 0;
+  color: oklch(60% 0.015 260);
+  font-size: 9px;
+  line-height: 1.42;
+}
+
+.mate-command-action code {
+  overflow: hidden;
+  color: oklch(72% 0.06 255);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mate-native-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: oklch(76% 0.1 255);
+  font-size: 10px;
+  text-decoration: none;
+}
+
+.mate-native-link svg {
+  width: 12px;
+  height: 12px;
+}
+
+.mate-action-status:empty {
+  display: none;
+}
+
 .mate-runtime-line {
   display: flex;
   align-items: center;
@@ -926,6 +1107,13 @@ button {
   .bb-sidebar-row,
   .bb-thread-row {
     height: var(--bb-sidebar-row-height-coarse);
+  }
+
+  .mate-fab,
+  .mate-popover [data-slot="button"],
+  .mate-popover [data-slot="select-trigger"],
+  .mate-popover [data-slot="toggle-group-item"] {
+    min-height: 44px;
   }
 }
 
@@ -980,8 +1168,8 @@ button {
   }
 
   .mate-overlay {
-    right: 12px;
-    bottom: 12px;
+    right: max(12px, env(safe-area-inset-right));
+    bottom: max(12px, env(safe-area-inset-bottom));
   }
 }
 

--- a/apps/workbench/src/test-dom.ts
+++ b/apps/workbench/src/test-dom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();

--- a/apps/workbench/src/usePluginInspection.test.tsx
+++ b/apps/workbench/src/usePluginInspection.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { PluginInspection } from "@bb-mate/inspection";
+import { pluginSessionUrl, usePluginInspection } from "./usePluginInspection";
+
+afterEach(cleanup);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function session(selectedKey: string) {
+  return {
+    schemaVersion: 1,
+    workspace: {
+      label: "bb-mate",
+      candidates: [
+        { key: selectedKey, label: selectedKey, displayPath: selectedKey },
+      ],
+      selectedKey,
+      selectionError: null,
+    },
+    inspection: {} as PluginInspection,
+    handoffs: {
+      launchCommand: null,
+      checkCommand: null,
+      liveCommand: null,
+      detail: "Run from the BB Mate repository root.",
+    },
+  } as const;
+}
+
+describe("usePluginInspection", () => {
+  test("encodes an opaque plugin key into the session request", () => {
+    expect(pluginSessionUrl("my plugin's")).toBe(
+      "/bb-mate-session.json?plugin=my+plugin%27s",
+    );
+    expect(pluginSessionUrl(null)).toBe("/bb-mate-session.json");
+  });
+
+  test("ignores a superseded response after plugin selection changes", async () => {
+    const originalFetch = globalThis.fetch;
+    const oldRequest = deferred<Response>();
+    const newRequest = deferred<Response>();
+    const fetchMock = mock((input: string | URL | Request) =>
+      String(input).includes("plugin=old")
+        ? oldRequest.promise
+        : newRequest.promise,
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const { result, rerender } = renderHook(
+        ({ plugin }: { plugin: string }) => usePluginInspection(plugin),
+        { initialProps: { plugin: "old" } },
+      );
+      rerender({ plugin: "new" });
+
+      await act(async () => {
+        newRequest.resolve(Response.json(session("new")));
+      });
+      await waitFor(() => expect(result.current.selectedKey).toBe("new"));
+
+      await act(async () => {
+        oldRequest.resolve(Response.json(session("old")));
+        await Promise.resolve();
+      });
+      expect(result.current.selectedKey).toBe("new");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/workbench/src/usePluginInspection.ts
+++ b/apps/workbench/src/usePluginInspection.ts
@@ -1,20 +1,81 @@
 import { useEffect, useState } from "react";
 import type { PluginInspection } from "@/plugin-inspection";
 
+export interface PluginCandidate {
+  key: string;
+  label: string;
+  displayPath: string;
+}
+
+export interface PluginHandoffs {
+  launchCommand: string | null;
+  checkCommand: string | null;
+  liveCommand: string | null;
+  detail: string;
+}
+
+interface PluginSession {
+  schemaVersion: 1;
+  workspace: {
+    label: string;
+    candidates: PluginCandidate[];
+    selectedKey: string | null;
+    selectionError: string | null;
+  };
+  inspection: PluginInspection;
+  handoffs: PluginHandoffs;
+}
+
 interface InspectionResult {
   inspection: PluginInspection | null;
   error: string | null;
+  workspaceLabel: string | null;
+  candidates: PluginCandidate[];
+  selectedKey: string | null;
+  selectionError: string | null;
+  handoffs: PluginHandoffs;
+  refresh(): void;
 }
 
-export function usePluginInspection(): InspectionResult {
+const emptyHandoffs: PluginHandoffs = {
+  launchCommand: null,
+  checkCommand: null,
+  liveCommand: null,
+  detail: "Choose a discovered plugin before using terminal handoffs.",
+};
+
+export function pluginSessionUrl(plugin: string | null): string {
+  const params = new URLSearchParams();
+  if (plugin) params.set("plugin", plugin);
+  const query = params.size > 0 ? `?${params.toString()}` : "";
+  return `/bb-mate-session.json${query}`;
+}
+
+export function usePluginInspection(plugin: string | null): InspectionResult {
+  const [revision, setRevision] = useState(0);
   const [result, setResult] = useState<InspectionResult>({
     inspection: null,
     error: null,
+    workspaceLabel: null,
+    candidates: [],
+    selectedKey: null,
+    selectionError: null,
+    handoffs: emptyHandoffs,
+    refresh: () => setRevision((value) => value + 1),
   });
 
   useEffect(() => {
     const controller = new AbortController();
-    void fetch("/bb-mate-plugin.json", {
+    setResult((current) => ({
+      ...current,
+      inspection: null,
+      error: null,
+      candidates: [],
+      selectedKey: null,
+      selectionError: null,
+      handoffs: emptyHandoffs,
+    }));
+    void fetch(pluginSessionUrl(plugin), {
       signal: controller.signal,
       cache: "no-store",
     })
@@ -24,18 +85,35 @@ export function usePluginInspection(): InspectionResult {
             `Plugin inspection failed with HTTP ${response.status}`,
           );
         }
-        return (await response.json()) as PluginInspection;
+        return (await response.json()) as PluginSession;
       })
-      .then((inspection) => setResult({ inspection, error: null }))
+      .then((session) => {
+        if (controller.signal.aborted) return;
+        setResult((current) => ({
+          ...current,
+          inspection: session.inspection,
+          error: null,
+          workspaceLabel: session.workspace.label,
+          candidates: session.workspace.candidates,
+          selectedKey: session.workspace.selectedKey,
+          selectionError: session.workspace.selectionError,
+          handoffs: session.handoffs,
+        }));
+      })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
-        setResult({
+        setResult((current) => ({
+          ...current,
           inspection: null,
           error: error instanceof Error ? error.message : String(error),
-        });
+          candidates: [],
+          selectedKey: null,
+          selectionError: null,
+          handoffs: emptyHandoffs,
+        }));
       });
     return () => controller.abort();
-  }, []);
+  }, [plugin, revision]);
 
   return result;
 }

--- a/apps/workbench/src/workbench-state.test.ts
+++ b/apps/workbench/src/workbench-state.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import {
+  commitWorkbenchState,
+  readWorkbenchState,
+  writeWorkbenchState,
+} from "./workbench-state";
+
+describe("workbench URL state", () => {
+  test("round-trips every linkable launcher selection", () => {
+    const state = readWorkbenchState(
+      "?plugin=linear&surface=thread-list&scenario=quiet&mode=live&theme=dark&viewport=compact",
+    );
+
+    expect(state).toEqual({
+      plugin: "linear",
+      surfaceId: "thread-list",
+      fixtureId: "quiet",
+      mode: "live",
+      theme: "dark",
+      viewport: "compact",
+    });
+    expect(readWorkbenchState(writeWorkbenchState(state))).toEqual(state);
+  });
+
+  test("falls back deterministically for stale catalog and enum values", () => {
+    expect(
+      readWorkbenchState(
+        "?surface=removed&scenario=removed&mode=magic&theme=system&viewport=wide",
+      ),
+    ).toMatchObject({
+      plugin: null,
+      surfaceId: "homepage-section",
+      fixtureId: "project-selected",
+      mode: "fixture",
+      theme: "light",
+      viewport: "desktop",
+    });
+  });
+
+  test("uses the selected surface default when its scenario is stale", () => {
+    expect(
+      readWorkbenchState("?surface=thread-list&scenario=homepage"),
+    ).toMatchObject({ surfaceId: "thread-list", fixtureId: "agents" });
+  });
+
+  test("preserves unrelated query parameters while owning launcher keys", () => {
+    const state = readWorkbenchState("?surface=thread-list&scenario=quiet");
+    const search = writeWorkbenchState(state, "?debug=1&surface=removed");
+
+    expect(search).toContain("debug=1");
+    expect(new URLSearchParams(search).get("surface")).toBe("thread-list");
+  });
+
+  test("commits one history entry for one launcher interaction", () => {
+    const calls: Array<{ method: string; url: string }> = [];
+    const history = {
+      pushState: (_data: unknown, _unused: string, url?: string | URL | null) =>
+        calls.push({ method: "push", url: String(url) }),
+      replaceState: (
+        _data: unknown,
+        _unused: string,
+        url?: string | URL | null,
+      ) => calls.push({ method: "replace", url: String(url) }),
+    };
+    const initial = readWorkbenchState(
+      "?surface=homepage-section&scenario=project-selected",
+    );
+    const next = commitWorkbenchState(
+      initial,
+      { theme: "dark" },
+      { pathname: "/", search: "?debug=1", hash: "#preview" },
+      history,
+    );
+
+    expect(next.theme).toBe("dark");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ method: "push" });
+    expect(calls[0]?.url).toContain("theme=dark");
+    expect(calls[0]?.url).toContain("debug=1");
+  });
+
+  test("uses replaceState for automatic corrections without adding history", () => {
+    const calls: string[] = [];
+    const current = readWorkbenchState("?mode=live");
+    commitWorkbenchState(
+      current,
+      { mode: "fixture" },
+      { pathname: "/", search: "?mode=live", hash: "" },
+      {
+        pushState: () => calls.push("push"),
+        replaceState: () => calls.push("replace"),
+      },
+      { replace: true },
+    );
+
+    expect(calls).toEqual(["replace"]);
+  });
+
+  test("commits a surface and its default scenario as one history entry", () => {
+    const calls: string[] = [];
+    const next = commitWorkbenchState(
+      readWorkbenchState(""),
+      { surfaceId: "thread-list", fixtureId: "agents" },
+      { pathname: "/", search: "", hash: "" },
+      {
+        pushState: (_data, _unused, url) => calls.push(String(url)),
+        replaceState: () => calls.push("unexpected replacement"),
+      },
+    );
+
+    expect(next).toMatchObject({
+      surfaceId: "thread-list",
+      fixtureId: "agents",
+    });
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/apps/workbench/src/workbench-state.ts
+++ b/apps/workbench/src/workbench-state.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { resolveCatalogSelection, surfaceCatalog } from "@/surface-catalog";
+
+export type PreviewMode = "fixture" | "harness" | "live";
+export type PreviewTheme = "light" | "dark";
+export type PreviewViewport = "desktop" | "compact";
+
+export interface WorkbenchState {
+  plugin: string | null;
+  surfaceId: string;
+  fixtureId: string;
+  mode: PreviewMode;
+  theme: PreviewTheme;
+  viewport: PreviewViewport;
+}
+
+const modes = new Set<PreviewMode>(["fixture", "harness", "live"]);
+const themes = new Set<PreviewTheme>(["light", "dark"]);
+const viewports = new Set<PreviewViewport>(["desktop", "compact"]);
+
+export function readWorkbenchState(search: string): WorkbenchState {
+  const params = new URLSearchParams(search);
+  const selection = resolveCatalogSelection(
+    params.get("surface") ?? surfaceCatalog[0].id,
+    params.get("scenario") ?? "",
+  );
+  const requestedMode = params.get("mode") as PreviewMode | null;
+  const requestedTheme = params.get("theme") as PreviewTheme | null;
+  const requestedViewport = params.get("viewport") as PreviewViewport | null;
+
+  return {
+    plugin: params.get("plugin") || null,
+    surfaceId: selection.surface.id,
+    fixtureId: selection.fixture.id,
+    mode: requestedMode && modes.has(requestedMode) ? requestedMode : "fixture",
+    theme:
+      requestedTheme && themes.has(requestedTheme) ? requestedTheme : "light",
+    viewport:
+      requestedViewport && viewports.has(requestedViewport)
+        ? requestedViewport
+        : "desktop",
+  };
+}
+
+export function writeWorkbenchState(
+  state: WorkbenchState,
+  existingSearch = "",
+): string {
+  const params = new URLSearchParams(existingSearch);
+  for (const key of [
+    "plugin",
+    "surface",
+    "scenario",
+    "mode",
+    "theme",
+    "viewport",
+  ]) {
+    params.delete(key);
+  }
+  if (state.plugin) params.set("plugin", state.plugin);
+  params.set("surface", state.surfaceId);
+  params.set("scenario", state.fixtureId);
+  params.set("mode", state.mode);
+  params.set("theme", state.theme);
+  params.set("viewport", state.viewport);
+  return `?${params.toString()}`;
+}
+
+function browserState(): WorkbenchState {
+  return readWorkbenchState(window.location.search);
+}
+
+interface WorkbenchLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+interface WorkbenchHistory {
+  pushState(data: unknown, unused: string, url?: string | URL | null): void;
+  replaceState(data: unknown, unused: string, url?: string | URL | null): void;
+}
+
+export function commitWorkbenchState(
+  current: WorkbenchState,
+  patch: Partial<WorkbenchState>,
+  location: WorkbenchLocation,
+  history: WorkbenchHistory,
+  options: { replace?: boolean } = {},
+): WorkbenchState {
+  const next = readWorkbenchState(
+    writeWorkbenchState({ ...current, ...patch }),
+  );
+  history[options.replace ? "replaceState" : "pushState"](
+    null,
+    "",
+    `${location.pathname}${writeWorkbenchState(next, location.search)}${location.hash}`,
+  );
+  return next;
+}
+
+export function useWorkbenchState() {
+  const [state, setState] = useState(browserState);
+  const stateRef = useRef(state);
+
+  useEffect(() => {
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${writeWorkbenchState(browserState(), window.location.search)}${window.location.hash}`,
+    );
+    const onPopState = () => {
+      const next = browserState();
+      stateRef.current = next;
+      setState(next);
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const update = useCallback(
+    (patch: Partial<WorkbenchState>, options: { replace?: boolean } = {}) => {
+      const next = commitWorkbenchState(
+        stateRef.current,
+        patch,
+        window.location,
+        window.history,
+        options,
+      );
+      stateRef.current = next;
+      setState(next);
+    },
+    [],
+  );
+
+  return { state, update };
+}

--- a/apps/workbench/vite.config.ts
+++ b/apps/workbench/vite.config.ts
@@ -4,7 +4,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { pluginInspectionPlugin } from "./plugin-inspection-server";
 
-const workspaceRoot = path.resolve(__dirname, "../..");
+const sourceRoot = path.resolve(__dirname, "../..");
+const workspaceRoot = process.env.BB_MATE_WORKSPACE ?? sourceRoot;
 
 export default defineConfig({
   plugins: [
@@ -12,6 +13,7 @@ export default defineConfig({
     tailwindcss(),
     pluginInspectionPlugin({
       workspaceRoot,
+      commandWorkspaceRoot: sourceRoot,
       targetPath: process.env.BB_MATE_PLUGIN,
     }),
   ],

--- a/bun.lock
+++ b/bun.lock
@@ -46,13 +46,17 @@
         "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "^18.0.1",
         "@ladle/react": "5.1.1",
         "@tailwindcss/vite": "^4.3.3",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/bun": "^1.3.4",
         "@types/node": "^26.1.2",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.2",
+        "happy-dom": "^18.0.1",
         "tailwindcss": "^4.3.3",
         "typescript": "^5.9.2",
         "vite": "^7.1.3",
@@ -228,6 +232,8 @@
     "@fontsource-variable/geist": ["@fontsource-variable/geist@5.3.0", "", {}, "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA=="],
 
     "@fontsource-variable/inter": ["@fontsource-variable/inter@5.3.0", "", {}, "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^18.0.1" } }, "sha512-xCy/cpEP8xyJ6u0eokYgaQxeUmcKqHx/+aC3R0DLa7/S38efhZAVDQqLJ5zzTguLFS0gvAzZHP40NGaLwRyapQ=="],
 
     "@hono/node-server": ["@hono/node-server@2.1.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg=="],
 
@@ -427,7 +433,15 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.3", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -477,6 +491,8 @@
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
@@ -511,11 +527,13 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -707,6 +725,8 @@
 
     "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
@@ -864,6 +884,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
+
+    "happy-dom": ["happy-dom@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -1050,6 +1072,8 @@
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1292,6 +1316,8 @@
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -1599,6 +1625,8 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -1650,6 +1678,8 @@
     "@dotenvx/dotenvx/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "@happy-dom/global-registrator/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
 
     "@ladle/react/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -1723,6 +1753,8 @@
 
     "finalhandler/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
+    "happy-dom/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
     "http-errors/depd": ["depd@1.1.2", "", {}, "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
@@ -1740,6 +1772,10 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -1771,6 +1807,8 @@
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -1797,6 +1835,8 @@
 
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
+    "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "@ladle/react/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@ladle/react/@vitejs/plugin-react/react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
@@ -1817,11 +1857,7 @@
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1830,6 +1866,8 @@
     "express/type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "express/type-is/media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "raw-body/http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1893,10 +1931,6 @@
 
     "@ladle/react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "body-parser/type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,9 @@ The workbench puts the bb surface directly in the viewport. Workbench controls
 belong in the collapsible Mate overlay, not in a permanent wrapper around the
 prototype. The overlay uses vendored shadcn/Base UI source and has its own dark
 theme; bb-facing views use bb's typography, icon family, and measured semantic
-tokens.
+tokens. The URL is the complete launcher-state contract for plugin, surface,
+scenario, mode, theme, and viewport. The overlay emits copyable CLI handoffs;
+it never owns a browser-triggered native command runner.
 
 `SidebarListView` is the current host-neutral seam. The workbench supplies its
 model from deterministic scenarios. A future plugin adapter can supply the same
@@ -61,8 +63,12 @@ The source control in the Mate overlay represents adapters, not a browser data
 fetch:
 
 - **Fixtures** are always available in `apps/workbench`.
-- **Live bb** becomes available when the view is mounted by a bb plugin and the
-  public SDK adapter is present.
+- **Harness** remains unavailable in the launcher until an upstream-backed
+  public testing adapter exists, even when inspection can resolve the official
+  contract.
+- **Live bb** becomes selectable only when native inspection proves the selected
+  frontend plugin is installed and runnable. The browser then renders a
+  handoff-only canvas; native bb remains the visual authority.
 
 Do not proxy, scrape, or iframe an authenticated bb Connect session to simulate
 live state. Even when a client can be displayed, cross-origin content is not a
@@ -70,11 +76,24 @@ state/action contract and cannot safely drive plugin behavior.
 
 ### Plugin inspection
 
-The workbench dev server may inspect one explicit plugin directory. Inspection
-is data-only: it reads the ordinary package manifest, native
+The workbench dev server may inspect one explicit plugin directory or require a
+choice from its discovered workspace candidates. Candidate keys are mapped to
+trusted roots server-side and never interpreted as browser-provided paths. The
+browser projection redacts lexical roots, symlink realpaths, path provenance,
+and incidental absolute paths in native diagnostics. Inspection is data-only: it reads
+the ordinary package manifest, native
 `dist/server.meta.json` and `dist/app.meta.json`, and the JSON output of native
 bb commands. It must not evaluate the plugin entrypoint, mount a content script,
 or introduce a BB Mate manifest.
+
+Build/check and Live handoffs use the repository-proven `bun run bb-mate`
+entrypoint and are copied under an explicit user gesture. Targets are expressed
+relative to the BB Mate command workspace. If inspection started in an external
+workspace, copyable handoffs are unavailable: serializing a cross-root command
+would disclose local path hierarchy, while a bare `bb-mate` binary is not part
+of the proven private-workspace installation. Available commands execute only
+in the developer's terminal, where the CLI delegates to native bb with inherited
+output. There is no HTTP action endpoint and no Connect fetch, proxy, or iframe.
 
 The official SDK frontend collector currently exposes these registration
 groups, which define the eventual surface inventory:
@@ -92,8 +111,10 @@ Component registrations can receive deterministic behavior through
 `mountPluginContentScripts` lifecycle and must never be mounted during ordinary
 discovery. Host-rendered actions still require live bb for their real chrome.
 
-Until `@bb/plugin-sdk` is publicly installable, the workbench exposes Harness as
-an unavailable capability. The sibling checkout is not a fallback dependency.
+Until an official testing package and upstream-backed adapter are both usable,
+the launcher exposes Harness as unavailable. Inspection may independently say
+that the official contract resolves; that is contract readiness, not a rendered
+Harness preview. The sibling checkout is not a fallback dependency.
 [get-bb/bb#1134](https://github.com/get-bb/bb/issues/1134) is the upstream
 publication tracker.
 


### PR DESCRIPTION
## Context
#36 turns the lower-right BB Mate overlay into the reload-stable control point for plugin, surface, scenario, fidelity mode, theme, viewport, and explicit native handoffs.

## What changed
- added typed URL/history state with deterministic stale-link recovery
- added allowlisted browser-safe plugin sessions and complete path redaction
- separated Fixture, Harness-contract, launcher, and Live claims; Live renders a handoff-only canvas
- added responsive keyboard-accessible overlay controls and repo-proven copy-only native commands
- added mounted interaction, async race, history, selection, redaction, and mode regression tests

## Verification
- bun run format:check
- bun run check
- bun run test (167 tests)
- bun run build (workbench, plugin, and 13-story Ladle build)
- local browser QA at desktop and 320x568
- standing review 5/5; fresh targeted review 5/5

## Risks / rollout
- Harness stays unavailable until an upstream-backed adapter exists
- external inspected workspaces intentionally withhold copyable handoffs to avoid leaking path hierarchy
- no Connect fetch/embed, browser native mutation, upstream edit, install, publish, or release action

## Issue

Implements #36 under roadmap #21.