### PR TITLE
feat: package BB Mate for clean-room local installation

### DIFF
--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -136,6 +136,20 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The next hosted run can execute the already-reviewed exact-image test shape without changing visual acceptance thresholds or baselines.
 - Next: Lint, review, commit, push, and follow both hosted jobs to green.
 - Blockers: None.
+
+2026-08-07 - OS-632 landed and OS-635 started
+- Changed: Merged OS-632 in PR #9, reconciled its GitButler lane, moved Linear to Done, and opened the recommended OS-635 branch and plan from clean main.
+- Verified: PR run 31225976689 and post-merge main run 31226118637 both passed the full verify and pinned visual jobs; merge commit 9f2aa0c; no review threads; clean lane-free workspace.
+- Result: Deterministic visual/accessibility coverage is now the packaging baseline.
+- Next: Build and prove the private versioned local artifact without publishing.
+- Blockers: None.
+
+2026-08-07 - OS-635 package walking skeleton green
+- Changed: Defined a staged private package manifest without workspace dependencies; bundled the Bun CLI; packaged the 13-story lab; added a loopback-only, path/symlink-confined GET/HEAD server; isolated clean-room state; added third-party notices and local package docs.
+- Verified: 32 CLI/server tests pass. The lifecycle test performs two complete builds plus a staging repack under an isolated exact-tool PATH, requires byte-identical output, checks the 40-file allowlist and path/source/symlink boundaries, installs under isolated HOME/XDG/npm/Bun state, runs help and expected-nonzero missing-bb inspection, proves the entrypoint stayed inert, serves all 13 stories with bb/Connect/SDK unavailable, and verifies uninstall package/manifest/root-lock/hidden-lock residue. The generated license payload covers direct runtimes, their closures, the complete Ladle static-client import set, and embedded notices. Current SHA-256: 6e8b25d89345c2e68908131eb2d8f9e4cb31ab12be1b238447f3f8f9e64afc13.
+- Result: The installed artifact works outside the source checkout with no sibling bb, workspace link, plugin package, or publication side effect.
+- Next: Run aggregate gates, standing and fresh targeted implementation review, then the hosted PR loop.
+- Blockers: None.
 ```
 
 ## Preparation Audits
@@ -177,6 +191,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | 3         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-3.json`  | 5/5        | clean             | 0          | Coverage, script boundary, and workflow recheck      |
 | 4         | OS-632 standing    | `tmp/reviews/standing/os-632-round-4.json` | 5/5        | clean             | 0          | Fresh-image unzip prerequisite proof                 |
 | 4         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-4.json`  | 5/5        | clean             | 0          | Minimal bootstrap and unchanged-policy recheck       |
+| 1         | OS-635 standing    | `tmp/reviews/standing/os-635-round-1.json` | 3/5        | changes requested | 3          | Isolation, notices, and failed-bind diagnostics      |
+| 1         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-1.json`  | 3/5        | changes requested | 3          | Full-build determinism, notices, uninstall residue   |
+| 2         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-2.json`  | 4/5        | changes requested | 1          | Missing Ladle static-client runtime license closure  |
+| 3         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-3.json`  | 5/5        | superseded        | 1          | Premature approval missed npm hidden-lock residue    |
+| 2         | OS-635 standing    | `tmp/reviews/standing/os-635-round-2.json` | 4/5        | changes requested | 1          | Traversal-form root and hidden npm lock residue      |
+| 3         | OS-635 standing    | `tmp/reviews/standing/os-635-round-3.json` | 5/5        | clean             | 0          | Independent npm residue and full final recheck       |
+| 4         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-4.json`  | 5/5        | clean             | 0          | Superseding residue reconstruction and final recheck |
 
 ## Verification Log
 
@@ -208,6 +229,9 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | CI-shaped pinned container without host IPC (14 tests)                          | OS-632 CI correction | pass                 | standing reviewer independently passed in 14.2 seconds     |
 | Hosted CI 31225715348                                                           | OS-632 split jobs    | expected failure     | verify green; visual stopped before tests on missing unzip |
 | Fresh pinned-image unzip probe                                                  | OS-632 bootstrap     | pass                 | exact apt step installed `/usr/bin/unzip`                  |
+| `bun run package:test`                                                          | OS-635 clean room    | pass                 | two full builds; 40 files; 13 stories; SHA `6e8b25d…fc13`  |
+| `bun run format:check && bun run check && bun run test && bun run build`        | OS-635 candidate     | pass                 | 172 tests; package lifecycle and all builds green          |
+| macOS Playwright/axe matrix (14 tests)                                          | OS-635 regression    | pass                 | unchanged fixture baselines and accessibility matrix       |
 
 ## Prompt / Goal Alignment
 
@@ -226,8 +250,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-629 | Done        | PR #6 merged at `7f364f1`; main CI 31216658339 green   |
 | OS-633 | Done        | PR #7 merged at `7e11d89`; main CI 31218687904 green   |
 | OS-634 | Done        | PR #8 merged at `f14afd3`; main CI 31222879164 green   |
-| OS-632 | In Progress | Deterministic visual and accessibility regression      |
-| OS-635 | Todo        | Blocked by OS-633                                      |
+| OS-632 | Done        | PR #9 merged at `9f2aa0c`; main CI 31226118637 green   |
+| OS-635 | In Progress | Local package implementation and review                |
 | OS-636 | Todo        | Unblocked; finalized after artifact commands stabilize |
 | OS-637 | Todo        | Blocked by OS-632/634/635/636                          |
 | OS-638 | Todo        | Blocked by OS-629/637; final ready PR only             |

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -150,6 +150,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The installed artifact works outside the source checkout with no sibling bb, workspace link, plugin package, or publication side effect.
 - Next: Run aggregate gates, standing and fresh targeted implementation review, then the hosted PR loop.
 - Blockers: None.
+
+2026-08-07 - OS-635 hosted Linux tool closure corrected
+- Changed: Added the exact `gzip` executable to the clean-room PATH alongside `tar`; GNU tar delegates gzip decompression to that binary on the hosted Linux runner.
+- Verified: Hosted run 31228900314 proved the missing-tool failure after visual passed. The corrected snapshot passes `bun run package:test` and the complete format/check/test/build/diff gate locally with the artifact hash and 40-file allowlist unchanged.
+- Result: The package test now declares the complete external tool closure it actually needs on both macOS and Linux.
+- Next: Re-run standing and targeted review on the changed snapshot, amend the PR, and follow hosted CI to green.
+- Blockers: None.
 ```
 
 ## Preparation Audits
@@ -164,40 +171,42 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 
 ## Review Log
 
-| Milestone | Reviewer           | Report                                     | Score      | Verdict           | Open P0-P2 | Notes                                                |
-| --------- | ------------------ | ------------------------------------------ | ---------- | ----------------- | ---------- | ---------------------------------------------------- |
-| prep      | OS-629 audit       | agent transcript                           | not scored | complete          | 0          | Independent public drift check                       |
-| prep      | surface audit      | agent transcript                           | not scored | complete          | 0          | Incremental 633/634/632 chain                        |
-| prep      | distribution audit | agent transcript                           | not scored | complete          | 0          | Local candidate and stop rules                       |
-| prep      | packet alignment   | agent transcript                           | not scored | clean             | 0          | Three P2s fixed; recheck clean                       |
-| 1         | OS-629 standing    | `tmp/reviews/standing/os-629-round-1.json` | 3/5        | changes requested | 3          | Target validation, decision durability, split errors |
-| 1         | OS-629 targeted    | `tmp/reviews/targeted-os629/round-1.json`  | 2/5        | changes requested | 2          | Decision and release-ref coherence                   |
-| 2         | OS-629 standing    | `tmp/reviews/standing/os-629-round-2.json` | 5/5        | clean             | 0          | All standing and targeted gaps fixed                 |
-| 2         | OS-629 targeted    | `tmp/reviews/targeted-os629/round-2.json`  | 5/5        | clean             | 0          | Negative probes and full gate pass                   |
-| 1         | OS-633 standing    | `tmp/reviews/standing/os-633-round-1.json` | 3/5        | changes requested | 2          | Sidebar scenario and viewport gaps                   |
-| 1         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-1.json`  | 3/5        | changes requested | 2          | Host-action evidence and inert viewport              |
-| 2         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-2.json`  | 4/5        | changes requested | 0          | One reasonable P3 isolation-test gap                 |
-| 2         | OS-633 standing    | `tmp/reviews/standing/os-633-round-2.json` | 5/5        | clean             | 0          | All standing and targeted gaps fixed                 |
-| 3         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-3.json`  | 5/5        | clean             | 0          | Full boundary and correction recheck                 |
-| 1         | OS-634 standing    | `tmp/reviews/standing/os-634-round-1.json` | 2/5        | changes requested | 4          | Mode honesty, sentinel, redaction, interactions      |
-| 1         | OS-634 targeted    | `tmp/reviews/targeted-os634/round-1.json`  | 2/5        | changes requested | 5          | Stale links, Live truth, redaction, test gaps        |
-| 2         | OS-634 standing    | `tmp/reviews/standing/os-634-round-2.json` | 5/5        | clean             | 0          | All findings plus final handoff/privacy recheck      |
-| 2         | OS-634 targeted    | `tmp/reviews/targeted-os634/round-2.json`  | 5/5        | clean             | 0          | Acceptance matrix and full final-tree verification   |
-| 1         | OS-632 standing    | `tmp/reviews/standing/os-632-round-1.json` | 2/5        | changes requested | 3          | Ambient Mate state, portal/traversal, stale servers  |
-| 1         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-1.json`  | 2/5        | changes requested | 3          | Matrix/panel axe gaps and shallow traversal          |
-| 2         | OS-632 standing    | `tmp/reviews/standing/os-632-round-2.json` | 5/5        | clean             | 0          | Determinism, portal/traversal, stale-port recheck    |
-| 2         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-2.json`  | 5/5        | clean             | 0          | Full matrix, portal, and keyboard recheck            |
-| 3         | OS-632 standing    | `tmp/reviews/standing/os-632-round-3.json` | 5/5        | clean             | 0          | Pinned CI container and 14-test shape recheck        |
-| 3         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-3.json`  | 5/5        | clean             | 0          | Coverage, script boundary, and workflow recheck      |
-| 4         | OS-632 standing    | `tmp/reviews/standing/os-632-round-4.json` | 5/5        | clean             | 0          | Fresh-image unzip prerequisite proof                 |
-| 4         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-4.json`  | 5/5        | clean             | 0          | Minimal bootstrap and unchanged-policy recheck       |
-| 1         | OS-635 standing    | `tmp/reviews/standing/os-635-round-1.json` | 3/5        | changes requested | 3          | Isolation, notices, and failed-bind diagnostics      |
-| 1         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-1.json`  | 3/5        | changes requested | 3          | Full-build determinism, notices, uninstall residue   |
-| 2         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-2.json`  | 4/5        | changes requested | 1          | Missing Ladle static-client runtime license closure  |
-| 3         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-3.json`  | 5/5        | superseded        | 1          | Premature approval missed npm hidden-lock residue    |
-| 2         | OS-635 standing    | `tmp/reviews/standing/os-635-round-2.json` | 4/5        | changes requested | 1          | Traversal-form root and hidden npm lock residue      |
-| 3         | OS-635 standing    | `tmp/reviews/standing/os-635-round-3.json` | 5/5        | clean             | 0          | Independent npm residue and full final recheck       |
-| 4         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-4.json`  | 5/5        | clean             | 0          | Superseding residue reconstruction and final recheck |
+| Milestone | Reviewer           | Report                                     | Score      | Verdict           | Open P0-P2 | Notes                                                 |
+| --------- | ------------------ | ------------------------------------------ | ---------- | ----------------- | ---------- | ----------------------------------------------------- |
+| prep      | OS-629 audit       | agent transcript                           | not scored | complete          | 0          | Independent public drift check                        |
+| prep      | surface audit      | agent transcript                           | not scored | complete          | 0          | Incremental 633/634/632 chain                         |
+| prep      | distribution audit | agent transcript                           | not scored | complete          | 0          | Local candidate and stop rules                        |
+| prep      | packet alignment   | agent transcript                           | not scored | clean             | 0          | Three P2s fixed; recheck clean                        |
+| 1         | OS-629 standing    | `tmp/reviews/standing/os-629-round-1.json` | 3/5        | changes requested | 3          | Target validation, decision durability, split errors  |
+| 1         | OS-629 targeted    | `tmp/reviews/targeted-os629/round-1.json`  | 2/5        | changes requested | 2          | Decision and release-ref coherence                    |
+| 2         | OS-629 standing    | `tmp/reviews/standing/os-629-round-2.json` | 5/5        | clean             | 0          | All standing and targeted gaps fixed                  |
+| 2         | OS-629 targeted    | `tmp/reviews/targeted-os629/round-2.json`  | 5/5        | clean             | 0          | Negative probes and full gate pass                    |
+| 1         | OS-633 standing    | `tmp/reviews/standing/os-633-round-1.json` | 3/5        | changes requested | 2          | Sidebar scenario and viewport gaps                    |
+| 1         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-1.json`  | 3/5        | changes requested | 2          | Host-action evidence and inert viewport               |
+| 2         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-2.json`  | 4/5        | changes requested | 0          | One reasonable P3 isolation-test gap                  |
+| 2         | OS-633 standing    | `tmp/reviews/standing/os-633-round-2.json` | 5/5        | clean             | 0          | All standing and targeted gaps fixed                  |
+| 3         | OS-633 targeted    | `tmp/reviews/targeted-os633/round-3.json`  | 5/5        | clean             | 0          | Full boundary and correction recheck                  |
+| 1         | OS-634 standing    | `tmp/reviews/standing/os-634-round-1.json` | 2/5        | changes requested | 4          | Mode honesty, sentinel, redaction, interactions       |
+| 1         | OS-634 targeted    | `tmp/reviews/targeted-os634/round-1.json`  | 2/5        | changes requested | 5          | Stale links, Live truth, redaction, test gaps         |
+| 2         | OS-634 standing    | `tmp/reviews/standing/os-634-round-2.json` | 5/5        | clean             | 0          | All findings plus final handoff/privacy recheck       |
+| 2         | OS-634 targeted    | `tmp/reviews/targeted-os634/round-2.json`  | 5/5        | clean             | 0          | Acceptance matrix and full final-tree verification    |
+| 1         | OS-632 standing    | `tmp/reviews/standing/os-632-round-1.json` | 2/5        | changes requested | 3          | Ambient Mate state, portal/traversal, stale servers   |
+| 1         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-1.json`  | 2/5        | changes requested | 3          | Matrix/panel axe gaps and shallow traversal           |
+| 2         | OS-632 standing    | `tmp/reviews/standing/os-632-round-2.json` | 5/5        | clean             | 0          | Determinism, portal/traversal, stale-port recheck     |
+| 2         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-2.json`  | 5/5        | clean             | 0          | Full matrix, portal, and keyboard recheck             |
+| 3         | OS-632 standing    | `tmp/reviews/standing/os-632-round-3.json` | 5/5        | clean             | 0          | Pinned CI container and 14-test shape recheck         |
+| 3         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-3.json`  | 5/5        | clean             | 0          | Coverage, script boundary, and workflow recheck       |
+| 4         | OS-632 standing    | `tmp/reviews/standing/os-632-round-4.json` | 5/5        | clean             | 0          | Fresh-image unzip prerequisite proof                  |
+| 4         | OS-632 targeted    | `tmp/reviews/targeted-os632/round-4.json`  | 5/5        | clean             | 0          | Minimal bootstrap and unchanged-policy recheck        |
+| 1         | OS-635 standing    | `tmp/reviews/standing/os-635-round-1.json` | 3/5        | changes requested | 3          | Isolation, notices, and failed-bind diagnostics       |
+| 1         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-1.json`  | 3/5        | changes requested | 3          | Full-build determinism, notices, uninstall residue    |
+| 2         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-2.json`  | 4/5        | changes requested | 1          | Missing Ladle static-client runtime license closure   |
+| 3         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-3.json`  | 5/5        | superseded        | 1          | Premature approval missed npm hidden-lock residue     |
+| 2         | OS-635 standing    | `tmp/reviews/standing/os-635-round-2.json` | 4/5        | changes requested | 1          | Traversal-form root and hidden npm lock residue       |
+| 3         | OS-635 standing    | `tmp/reviews/standing/os-635-round-3.json` | 5/5        | clean             | 0          | Independent npm residue and full final recheck        |
+| 4         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-4.json`  | 5/5        | clean             | 0          | Superseding residue reconstruction and final recheck  |
+| 4         | OS-635 standing    | `tmp/reviews/standing/os-635-round-4.json` | 5/5        | clean             | 0          | Exact gzip closure and Linux GNU tar control          |
+| 5         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-5.json`  | 5/5        | clean             | 0          | Linux portability, isolation, and determinism recheck |
 
 ## Verification Log
 
@@ -232,6 +241,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | `bun run package:test`                                                          | OS-635 clean room    | pass                 | two full builds; 40 files; 13 stories; SHA `6e8b25d…fc13`  |
 | `bun run format:check && bun run check && bun run test && bun run build`        | OS-635 candidate     | pass                 | 172 tests; package lifecycle and all builds green          |
 | macOS Playwright/axe matrix (14 tests)                                          | OS-635 regression    | pass                 | unchanged fixture baselines and accessibility matrix       |
+| Hosted CI 31228900314                                                           | OS-635 Linux probe   | expected failure     | visual green; clean-room tar PATH lacked external gzip     |
+| Corrected OS-635 aggregate                                                      | OS-635 candidate     | pass                 | explicit gzip tool; artifact SHA unchanged                 |
 
 ## Prompt / Goal Alignment
 

--- a/.agents/plans/2026-08-07-os-635-clean-room-package.md
+++ b/.agents/plans/2026-08-07-os-635-clean-room-package.md
@@ -1,0 +1,60 @@
+# OS-635 clean-room local package
+
+## Outcome
+
+Produce a private, versioned `bb-mate` tarball that installs and runs outside
+the monorepo, while preserving native bb ownership and making publication a
+separate owner decision.
+
+## Slice
+
+1. Make `apps/cli` the private package boundary with an explicit version,
+   runtime metadata, bin path, and `files` allowlist.
+2. Build one Bun-targeted CLI bundle plus the deterministic 13-story static
+   surface lab. In source mode `dev` keeps launching Vite; from the artifact it
+   serves the packaged lab on the same strict host/port boundary.
+3. Add a root packaging command that recreates the distribution directory and
+   emits a version-named local npm tarball without publishing.
+4. Add package-content inspection and a clean-room test that installs the
+   tarball under a temporary prefix, runs the installed bin for help and
+   missing-native inspection, opens the packaged lab over HTTP, then uninstalls
+   it.
+5. Document prerequisites, contents, commands, unavailable capability behavior,
+   and the explicit no-publish boundary.
+
+## Boundaries
+
+- The package stays `private: true`; no registry publish, tag, release,
+  visibility change, license choice, or announcement occurs.
+- Plugin packages remain independently versioned and are not bundled.
+- The artifact contains no `../bb`, desktop bundle, absolute developer path,
+  node_modules, workspace symlink, authenticated state, or unpublished SDK.
+- Fixture mode may inspect manifests and serve deterministic assets; it does not
+  install/build/reload plugins or mutate bb/Connect state.
+- Bun is the executable runtime. Node/npm may install or inspect the tarball but
+  Node is not claimed as a supported CLI runtime. The candidate is macOS-only.
+
+## Verification
+
+- Unit tests for source-versus-package launch selection and the static server.
+- Two-pack checksum/content comparison plus explicit allowlist/path scan.
+- Temporary-prefix install/help/inspect/lab/uninstall test with no `bb` on PATH.
+- `bun run format:check && bun run check && bun run test && bun run build`.
+- Standing plus fresh targeted review; fix all P0-P2 and reasonable P3.
+- Draft PR, hosted CI/review threads, ready/merge, main CI, Linear Done.
+
+## Progress
+
+- [x] Define and build the allowlisted versioned artifact.
+- [x] Make the installed bin serve the packaged surface lab safely.
+- [x] Add deterministic package inspection and clean-room lifecycle proof.
+- [x] Document the supported runtime/capability and no-publish boundary.
+- [x] Complete aggregate gates and standing/fresh-targeted review.
+- [ ] Land the PR, verify main CI, and move OS-635 to Done.
+
+## Completion
+
+Complete when a fresh temporary environment can install the local tarball, run
+help and passive inspection without native bb, load all catalog surfaces from
+the packaged lab, uninstall cleanly, and reproduce the same allowlisted artifact
+without any source-checkout assumption or publication side effect.

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 *.log
 .vite/
 coverage/
+artifacts/
 .agents/goals/*/tmp/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ bb reports the selected real path as installed. Otherwise it prints the exact
 path-install command without running it. Set `BB_CLI` to select a specific bb
 executable; an executable on `PATH` is used as the fallback.
 
+## Local alpha package
+
+Build and inspect the private, versioned local artifact without publishing:
+
+```sh
+bun run package:artifact
+bun run package:inspect
+bun run package:test
+```
+
+The artifact bundles the Bun CLI and static 13-story surface lab behind an
+explicit package allowlist. Its installed `dev` command serves only loopback
+Fixture assets; source-checkout `dev` retains the interactive workbench. The
+[clean-room package workflow](docs/local-package.md) documents contents,
+runtime support, missing-capability behavior, temporary install/uninstall, and
+the no-publish boundary.
+
 ## Layout
 
 ```text

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,58 @@
+# BB Mate local alpha artifact
+
+This private package is a local-only BB Mate candidate. It contains a bundled
+`bb-mate` CLI and the deterministic static surface lab; it does not contain bb,
+plugin packages, a copied plugin SDK, or authenticated host state.
+
+## Runtime support
+
+- Bun 1.3.14 or newer executes the `bb-mate` bin.
+- npm may install or inspect the tarball, but Node is not a supported CLI
+  runtime.
+- Native bb handoffs target the supported macOS bb host. Fixture inspection and
+  the packaged surface lab are also exercised in isolated Linux CI.
+- The package is `private` and `UNLICENSED`. Neither this artifact nor its
+  version is approved for registry publication.
+
+## Build and inspect
+
+From a clean BB Mate checkout:
+
+```sh
+bun install --frozen-lockfile
+bun run package:artifact
+bun run package:inspect
+```
+
+The first command produces `artifacts/bb-mate-0.1.0-alpha.0.tgz`. npm's pack
+report exposes every included file; the package manifest allowlists only
+`README.md`, `package.json`, self-contained third-party notices/licenses, the
+bundled CLI, and static lab assets.
+
+## Temporary local installation
+
+Choose an empty prefix and install the generated file without publishing:
+
+```sh
+prefix="$(mktemp -d)"
+npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.0.tgz
+export PATH="$prefix/node_modules/.bin:$PATH"
+bb-mate --help
+bb-mate inspect ./path/to/plugin
+bb-mate dev ./path/to/plugin
+npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
+```
+
+`inspect` reads manifests and generated metadata without executing the plugin.
+When native `bb` is missing, the report names that unavailable capability and
+still permits Fixture use. In the installed artifact, `dev` serves the packaged
+13-story surface lab; it does not install, build, reload, or run plugin code.
+Source-checkout `dev` continues to launch the interactive Vite workbench.
+The packaged static server binds only to `127.0.0.1`, `::1`, or `localhost`,
+confines decoded requests and resolved symlinks to its generated lab directory,
+and accepts only GET/HEAD. It never exposes plugin or inspection data over HTTP.
+
+Native `check` and `live` remain explicit terminal handoffs and fail clearly
+when a compatible `bb` executable or installed path plugin is unavailable.
+Harness remains unavailable unless the selected plugin installs the official
+public testing package.

--- a/apps/cli/THIRD_PARTY_NOTICES.md
+++ b/apps/cli/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,34 @@
+# Third-party notices
+
+The BB Mate local artifact bundles or embeds output from the packages and fonts
+below. `THIRD_PARTY_LICENSES.md` is generated from the exact installed versions'
+license and copyright files and adds explicit notices for transitive code
+flattened into Ladle's distributed browser client. Both files are packaged and
+checked before any public distribution decision.
+
+| Component                          | License    | Upstream                                        |
+| ---------------------------------- | ---------- | ----------------------------------------------- |
+| Base UI React                      | MIT        | <https://github.com/mui/base-ui>                |
+| class-variance-authority           | Apache-2.0 | <https://github.com/joe-bell/cva>               |
+| clsx                               | MIT        | <https://github.com/lukeed/clsx>                |
+| Geist variable font via Fontsource | OFL-1.1    | <https://github.com/fontsource/font-files>      |
+| Inter variable font via Fontsource | OFL-1.1    | <https://github.com/fontsource/font-files>      |
+| Hugeicons Core Free Icons          | MIT        | <https://github.com/hugeicons/hugeicons>        |
+| Hugeicons React                    | MIT        | <https://github.com/hugeicons/hugeicons>        |
+| Ladle React                        | MIT        | <https://github.com/tajo/ladle>                 |
+| Ladle embedded client dependencies | MIT / ISC  | See `THIRD_PARTY_LICENSES.md`                   |
+| Lucide React                       | ISC        | <https://github.com/lucide-icons/lucide>        |
+| React                              | MIT        | <https://github.com/facebook/react>             |
+| React DOM                          | MIT        | <https://github.com/facebook/react>             |
+| saxes                              | ISC        | <https://github.com/lddubeau/saxes>             |
+| semver                             | ISC        | <https://github.com/npm/node-semver>            |
+| tailwind-merge                     | MIT        | <https://github.com/dcastil/tailwind-merge>     |
+| tw-animate-css                     | MIT        | <https://github.com/Wombosvideo/tw-animate-css> |
+| xmlchars                           | MIT        | <https://github.com/lddubeau/xmlchars>          |
+
+The generated payload includes Base UI's runtime dependency closure, Ladle,
+classnames, Prism React Renderer and PrismJS, PropTypes and React Is, React and
+scheduler, the Focus Lock/React Remove Scroll family, Reach UI dialog, tslib,
+and the inspection parser dependency closure. This inventory and those notices
+do not choose or grant a license for BB Mate itself; the local artifact remains
+private and `UNLICENSED`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,10 +1,25 @@
 {
-  "name": "@bb-mate/cli",
-  "version": "0.0.0",
+  "name": "bb-mate",
+  "version": "0.1.0-alpha.0",
   "private": true,
+  "license": "UNLICENSED",
   "type": "module",
   "bin": {
-    "bb-mate": "./src/bin.ts"
+    "bb-mate": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "THIRD_PARTY_NOTICES.md",
+    "THIRD_PARTY_LICENSES.md"
+  ],
+  "engines": {
+    "bun": ">=1.3.14"
+  },
+  "bbMate": {
+    "runtime": "Bun",
+    "nativeHost": "macOS",
+    "fixtureCi": "Linux"
   },
   "scripts": {
     "build": "tsc --noEmit",

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runCli, type CliRuntime } from "./commands.ts";
 import {
@@ -7,14 +9,33 @@ import {
   runCapturedCommand,
   runInheritedCommand,
 } from "./native.ts";
+import { runSurfaceLab } from "./surface-lab-server.ts";
 
 const workspaceRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packagedLabRoot = path.join(moduleDirectory, "lab");
+const packaged = await fs
+  .access(path.join(packagedLabRoot, "index.html"))
+  .then(() => true)
+  .catch(() => false);
 
 const runtime: CliRuntime = {
   cwd: process.cwd(),
   env: process.env,
   bunExecutable: process.execPath,
   workspaceRoot,
+  ...(packaged
+    ? {
+        fixtureName: "surface lab",
+        runFixture: (options: { host: string; port: number }) =>
+          runSurfaceLab({
+            root: packagedLabRoot,
+            ...options,
+            stdout: (value) => process.stdout.write(value),
+            stderr: (value) => process.stderr.write(value),
+          }),
+      }
+    : {}),
   stdout: (value) => process.stdout.write(value),
   stderr: (value) => process.stderr.write(value),
   resolveBb: () =>

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -240,6 +240,33 @@ describe("bb-mate CLI", () => {
     );
   });
 
+  test("uses the packaged surface-lab launcher without a source checkout", async () => {
+    const { root, pluginRoot } = await createPlugin({ workspace: true });
+    const fixtureLaunches: Array<{ host: string; port: number }> = [];
+    let inherited = false;
+    const testRuntime = runtime(root, nativeOutput(pluginRoot), {
+      fixtureName: "surface lab",
+      runFixture: async (options) => {
+        fixtureLaunches.push(options);
+        return { exitCode: 0, signal: null };
+      },
+      runInherited: async () => {
+        inherited = true;
+        return { exitCode: 1, signal: null };
+      },
+    });
+
+    const result = await runCli(
+      ["dev", "--host", "127.0.0.1", "--port", "4317"],
+      testRuntime.value,
+    );
+
+    expect(result).toEqual({ exitCode: 0, signal: null });
+    expect(fixtureLaunches).toEqual([{ host: "127.0.0.1", port: 4317 }]);
+    expect(inherited).toBe(false);
+    expect(testRuntime.stdout.join("")).not.toContain("Launching Fixture");
+  });
+
   test("does not present the Connect base URL as an unshared workbench port", async () => {
     const { root, pluginRoot } = await createPlugin({ workspace: true });
     const testRuntime = runtime(root, nativeOutput(pluginRoot));

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -20,6 +20,7 @@ export interface CliRuntime {
   env: NodeJS.ProcessEnv;
   bunExecutable: string;
   workspaceRoot: string;
+  fixtureName?: string;
   stdout(value: string): void;
   stderr(value: string): void;
   resolveBb(): Promise<string | null>;
@@ -33,6 +34,7 @@ export interface CliRuntime {
     args: readonly string[],
     options: { cwd: string; env: NodeJS.ProcessEnv },
   ): Promise<ProcessExit>;
+  runFixture?(options: { host: string; port: number }): Promise<ProcessExit>;
 }
 
 interface InspectionContext {
@@ -49,8 +51,8 @@ const help = `Usage: bb-mate [path]
        bb-mate check [path]
        bb-mate live [path]
 
-Fixture workbench and passive inspection stay in BB Mate. Native bb owns build,
-install, dev/reload, and live runtime.`;
+Fixture workbench, packaged surface lab, and passive inspection stay in BB Mate.
+Native bb owns build, install, dev/reload, and live runtime.`;
 
 function line(writer: (value: string) => void, value = "") {
   writer(`${value}\n`);
@@ -209,9 +211,12 @@ export async function runCli(
     const pluginRoot = context.report.target?.rootPath;
     if (!pluginRoot && context.report.state !== "ambiguous") return failure;
     line(runtime.stdout, connectExposure(context.report, args.port));
+    if (runtime.runFixture) {
+      return runtime.runFixture({ host: args.host, port: args.port });
+    }
     line(
       runtime.stdout,
-      `Launching Fixture workbench at http://${displayHost(args.host)}:${args.port}`,
+      `Launching Fixture ${runtime.fixtureName ?? "workbench"} at http://${displayHost(args.host)}:${args.port}`,
     );
     return runtime.runInherited(
       runtime.bunExecutable,

--- a/apps/cli/src/surface-lab-server.test.ts
+++ b/apps/cli/src/surface-lab-server.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  createSurfaceLabHandler,
+  isLoopbackHost,
+  runSurfaceLab,
+} from "./surface-lab-server.ts";
+
+const roots: string[] = [];
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-lab-"));
+  roots.push(root);
+  await fs.mkdir(path.join(root, "assets"));
+  await fs.writeFile(path.join(root, "index.html"), "<h1>Surface lab</h1>");
+  await fs.writeFile(path.join(root, "meta.json"), '{"stories":{}}');
+  await fs.writeFile(path.join(root, "assets", "app.js"), "export {};");
+  return { root, handle: createSurfaceLabHandler(root) };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+describe("packaged surface lab server", () => {
+  test("allows only explicit loopback bind hosts", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+    expect(isLoopbackHost("192.0.2.1")).toBe(false);
+  });
+
+  test("does not announce rejected or failed binds as launched", async () => {
+    const { root } = await fixture();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    expect(
+      await runSurfaceLab({
+        root,
+        host: "0.0.0.0",
+        port: 4317,
+        stdout: (value) => stdout.push(value),
+        stderr: (value) => stderr.push(value),
+      }),
+    ).toEqual({ exitCode: 1, signal: null });
+    expect(stdout).toEqual([]);
+    expect(stderr.join("")).toContain("loopback-only");
+
+    const occupied = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response("occupied"),
+    });
+    const occupiedPort = occupied.port;
+    if (occupiedPort === undefined) throw new Error("No occupied test port.");
+    try {
+      stderr.length = 0;
+      expect(
+        await runSurfaceLab({
+          root,
+          host: "127.0.0.1",
+          port: occupiedPort,
+          stdout: (value) => stdout.push(value),
+          stderr: (value) => stderr.push(value),
+        }),
+      ).toEqual({ exitCode: 1, signal: null });
+      expect(stdout).toEqual([]);
+      expect(stderr.join("")).toContain(
+        "Could not start the packaged surface lab",
+      );
+    } finally {
+      occupied.stop(true);
+    }
+  });
+
+  test("serves the index, metadata, assets, and HEAD requests", async () => {
+    const { handle } = await fixture();
+
+    const index = await handle(new Request("http://lab.local/"));
+    expect(index.status).toBe(200);
+    expect(index.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(await index.text()).toContain("Surface lab");
+
+    const metadata = await handle(
+      new Request("http://lab.local/meta.json", { method: "HEAD" }),
+    );
+    expect(metadata.status).toBe(200);
+    expect(metadata.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(await metadata.text()).toBe("");
+
+    expect(
+      (await handle(new Request("http://lab.local/assets/app.js"))).headers.get(
+        "content-type",
+      ),
+    ).toBe("text/javascript; charset=utf-8");
+  });
+
+  test("rejects mutations, traversal, missing files, and escaped symlinks", async () => {
+    const { root, handle } = await fixture();
+    const outside = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-outside-"),
+    );
+    roots.push(outside);
+    await fs.writeFile(path.join(outside, "secret.txt"), "secret");
+    await fs.symlink(
+      path.join(outside, "secret.txt"),
+      path.join(root, "assets", "escape.txt"),
+    );
+
+    expect(
+      (await handle(new Request("http://lab.local/", { method: "POST" })))
+        .status,
+    ).toBe(405);
+    expect(
+      (
+        await handle(
+          new Request("http://lab.local/%2e%2e%2foutside%2fsecret.txt"),
+        )
+      ).status,
+    ).toBe(404);
+    expect((await handle(new Request("http://lab.local/missing"))).status).toBe(
+      404,
+    );
+    expect(
+      (await handle(new Request("http://lab.local/assets/escape.txt"))).status,
+    ).toBe(404);
+  });
+});

--- a/apps/cli/src/surface-lab-server.ts
+++ b/apps/cli/src/surface-lab-server.ts
@@ -1,0 +1,127 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { ProcessExit } from "./commands.ts";
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".webmanifest", "application/manifest+json"],
+  [".woff2", "font/woff2"],
+]);
+
+function contained(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+export function isLoopbackHost(host: string): boolean {
+  return host === "127.0.0.1" || host === "::1" || host === "localhost";
+}
+
+export function createSurfaceLabHandler(root: string) {
+  const resolvedRoot = fs.realpath(path.resolve(root));
+
+  return async (request: Request): Promise<Response> => {
+    const labRoot = await resolvedRoot;
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response(null, {
+        status: 405,
+        headers: { Allow: "GET, HEAD" },
+      });
+    }
+
+    let pathname: string;
+    try {
+      pathname = decodeURIComponent(new URL(request.url).pathname);
+    } catch {
+      return new Response("Invalid request path.\n", { status: 400 });
+    }
+    if (pathname.includes("\0")) {
+      return new Response("Invalid request path.\n", { status: 400 });
+    }
+
+    const relative = pathname === "/" ? "index.html" : pathname.slice(1);
+    const candidate = path.resolve(labRoot, relative);
+    if (!contained(labRoot, candidate)) {
+      return new Response("Not found.\n", { status: 404 });
+    }
+
+    let filePath: string;
+    try {
+      filePath = await fs.realpath(candidate);
+      const stat = await fs.stat(filePath);
+      if (!stat.isFile() || !contained(labRoot, filePath)) {
+        return new Response("Not found.\n", { status: 404 });
+      }
+    } catch {
+      return new Response("Not found.\n", { status: 404 });
+    }
+
+    const headers = new Headers({
+      "Content-Type":
+        contentTypes.get(path.extname(filePath)) ?? "application/octet-stream",
+      "Referrer-Policy": "no-referrer",
+      "X-Content-Type-Options": "nosniff",
+    });
+    return request.method === "HEAD"
+      ? new Response(null, { status: 200, headers })
+      : new Response(Bun.file(filePath), { status: 200, headers });
+  };
+}
+
+export async function runSurfaceLab(options: {
+  root: string;
+  host: string;
+  port: number;
+  stdout(value: string): void;
+  stderr(value: string): void;
+}): Promise<ProcessExit> {
+  if (!isLoopbackHost(options.host)) {
+    options.stderr(
+      "The packaged surface lab is loopback-only; use 127.0.0.1, ::1, or localhost.\n",
+    );
+    return { exitCode: 1, signal: null };
+  }
+  try {
+    await fs.access(path.join(options.root, "index.html"));
+  } catch {
+    options.stderr("Packaged surface lab assets are unavailable.\n");
+    return { exitCode: 1, signal: null };
+  }
+
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({
+      hostname: options.host,
+      port: options.port,
+      fetch: createSurfaceLabHandler(options.root),
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    options.stderr(`Could not start the packaged surface lab: ${detail}\n`);
+    return { exitCode: 1, signal: null };
+  }
+
+  const displayHost = options.host.includes(":")
+    ? `[${options.host}]`
+    : options.host;
+  options.stdout(
+    `Launching Fixture surface lab at http://${displayHost}:${options.port}\n`,
+  );
+
+  return new Promise((resolve) => {
+    const finish = (signal: NodeJS.Signals) => {
+      process.off("SIGINT", onInterrupt);
+      process.off("SIGTERM", onTerminate);
+      server.stop(true);
+      resolve({ exitCode: null, signal });
+    };
+    const onInterrupt = () => finish("SIGINT");
+    const onTerminate = () => finish("SIGTERM");
+    process.once("SIGINT", onInterrupt);
+    process.once("SIGTERM", onTerminate);
+  });
+}

--- a/apps/cli/third-party/embedded-ladle-notices.md
+++ b/apps/cli/third-party/embedded-ladle-notices.md
@@ -1,0 +1,87 @@
+## Embedded Ladle client notices
+
+The generated Ladle client includes flattened code from the following projects.
+These notices supplement the installed package licenses collected above.
+
+### Focus Lock family and React Remove Scroll
+
+Includes `react-focus-lock`, `focus-lock`, `use-callback-ref`, `use-sidecar`,
+`react-clientside-effect`, `react-remove-scroll`, `react-remove-scroll-bar`, and
+`react-style-singleton` code distributed inside the Ladle client.
+
+Upstream: <https://github.com/theKashey/react-focus-lock> and
+<https://github.com/theKashey/react-remove-scroll>
+
+MIT License
+
+Copyright (c) 2017 Anton Korzunov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### Reach UI dialog
+
+Upstream: <https://github.com/reach/reach-ui>
+
+The MIT License (MIT)
+
+Copyright (c) 2018-2024, React Training LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### PrismJS
+
+Upstream: <https://github.com/PrismJS/prism>
+
+MIT License
+
+Copyright (c) 2012 Lea Verou
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/cli/third-party/saxes-LICENSE.txt
+++ b/apps/cli/third-party/saxes-LICENSE.txt
@@ -1,0 +1,61 @@
+The ISC License
+
+Copyright (c) Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+====
+
+The following license is the one that governed sax, from which saxes
+was forked. Isaac Schlueter is not directly involved with saxes.
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+====
+
+String.fromCodePoint by Mathias Bynens is no longer used, but it can still be
+found in old commits. It was once used according to the MIT License:
+
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bun.lock
+++ b/bun.lock
@@ -12,10 +12,10 @@
       },
     },
     "apps/cli": {
-      "name": "@bb-mate/cli",
-      "version": "0.0.0",
+      "name": "bb-mate",
+      "version": "0.1.0-alpha.0",
       "bin": {
-        "bb-mate": "./src/bin.ts",
+        "bb-mate": "./dist/cli.js",
       },
       "dependencies": {
         "@bb-mate/inspection": "workspace:*",
@@ -46,10 +46,10 @@
         "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
-        "@axe-core/playwright": "^4.12.1",
+        "@axe-core/playwright": "4.12.1",
         "@happy-dom/global-registrator": "^18.0.1",
         "@ladle/react": "5.1.1",
-        "@playwright/test": "^1.62.1",
+        "@playwright/test": "1.62.1",
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -162,8 +162,6 @@
     "@base-ui/react": ["@base-ui/react@1.7.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.2", "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
-
-    "@bb-mate/cli": ["@bb-mate/cli@workspace:apps/cli"],
 
     "@bb-mate/inspection": ["@bb-mate/inspection@workspace:packages/inspection"],
 
@@ -562,6 +560,8 @@
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.12", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA=="],
 
     "bb-app": ["bb-app@0.35.1", "", { "dependencies": { "@parcel/watcher": "2.5.6", "@tailwindcss/node": "^4.3.0", "@tailwindcss/oxide": "^4.3.0", "better-sqlite3": "12.10.0", "esbuild": "^0.28.0", "hono": "^4.7.0", "jiti": "^2.6.1", "node-pty": "1.1.0", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "pino-roll": "^4.0.0", "tailwindcss": "^4.3.0", "zod": "4.3.6" }, "os": [ "linux", "darwin", ], "bin": { "bb": "dist/bb.js", "bb-app": "dist/bb-app.js", "bb-server": "dist/bb-server.js", "bb-host-daemon": "dist/bb-host-daemon.js" } }, "sha512-gY0REaRmyMMVDsPsY102r18yeYHI9qYFBPxkrh4jkD6/qII77b4ctwWg1OwmeXnAYtkxN6TSYka9IwS6KUq+ZA=="],
+
+    "bb-mate": ["bb-mate@workspace:apps/cli"],
 
     "bb-plugin-linear": ["bb-plugin-linear@workspace:plugins/linear"],
 

--- a/docs/local-package.md
+++ b/docs/local-package.md
@@ -1,0 +1,94 @@
+# Clean-room local package
+
+BB Mate can produce a private local alpha artifact for installation tests before
+any registry, repository-visibility, license, or release decision.
+
+## Artifact contract
+
+Run from a clean checkout with Bun 1.3.14 or newer and npm available:
+
+```sh
+bun install --frozen-lockfile
+bun run package:artifact
+```
+
+The command rebuilds the CLI and surface lab, creates an isolated staging
+manifest with no workspace dependencies, and writes the versioned archive:
+
+```text
+artifacts/bb-mate-0.1.0-alpha.0.tgz
+```
+
+The artifact remains `private: true`, `UNLICENSED`, and unpublishable by the
+supported workflow. The staged `files` allowlist permits only:
+
+- `package.json`;
+- `README.md`, `THIRD_PARTY_NOTICES.md`, and the generated self-contained
+  `THIRD_PARTY_LICENSES.md`;
+- `dist/cli.js`, a Bun-targeted self-contained CLI bundle;
+- `dist/lab/**`, the deterministic static 13-story surface lab.
+
+Plugin packages, source files, node_modules, Vite/Ladle servers, desktop app
+bundles, `../bb`, absolute developer paths, workspace links, secrets, and
+authenticated browser state are excluded.
+
+Inspect npm's exact dry-run file list without creating or publishing an archive:
+
+```sh
+bun run package:inspect
+```
+
+## Runtime and capability support
+
+The bin is executed by Bun, not Node. npm is supported as the local archive
+installer and inspector; the package does not claim Node CLI compatibility.
+Native bb handoffs target the macOS bb host. The deterministic Fixture-only
+artifact is additionally exercised on isolated Linux CI, so the manifest records
+macOS native support and Linux fixture CI separately instead of using an npm
+platform restriction that would make that proof impossible.
+
+`bb-mate inspect` is passive: it reads plugin manifests and generated metadata
+without importing the plugin. Missing native bb, Connect status/shares, and the
+official SDK/Harness are named independently with actionable next steps. Those
+unavailable capabilities may make inspection exit nonzero, but they do not stop
+the installed `dev` command from serving Fixture stories.
+
+Installed `dev` serves the generated lab only on `127.0.0.1`, `::1`, or
+`localhost`. The server accepts GET/HEAD, confines decoded paths and resolved
+symlinks to the packaged lab root, and never serves the plugin inspection or
+filesystem data. It does not run plugin code or install/build/reload native bb.
+
+## Reproducible lifecycle proof
+
+Run the complete temporary clean-room test:
+
+```sh
+bun run package:test
+```
+
+The test:
+
+1. performs two complete isolated builds, repacks the second staging tree, and
+   requires every resulting tarball to have the same SHA-256;
+2. checks the allowlist, absence of symlinks/workspace dependencies/source, and
+   absence of absolute developer paths;
+3. isolates HOME, TMPDIR, XDG config/cache/data/state, npm config/cache/prefix,
+   Bun install/cache, and PATH beneath a temporary root;
+4. installs only a copied tarball under that temporary prefix with npm's
+   no-save, no-package-lock mode;
+5. runs the installed bin for help and passive inspection with no `bb` on PATH;
+6. proves the fixture plugin entrypoint was not executed and missing
+   bb/Connect/SDK states are clear;
+7. starts installed `dev`, fetches metadata for all 13 packaged stories, and
+   stops it;
+8. uninstalls `bb-mate` and verifies the bin, package directory, manifest, and
+   lockfile carry no `bb-mate` residue.
+
+The temporary environment is removed after the test. The versioned archive
+under `artifacts/` is generated and ignored by version control.
+
+## Stop boundary
+
+These commands do not run `npm publish`, create a tag or release, change
+repository visibility, select a public license, or send an announcement. Those
+remain explicit owner decisions for the later release handoff.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bb-mate",
+  "name": "@bb-mate/workspace",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -15,9 +15,12 @@
     "build": "bun --filter '*' build",
     "check": "bun --filter '*' check && tsc -p scripts/tsconfig.json && bun run compatibility:check",
     "compatibility:check": "bun scripts/compatibility-check.ts",
-    "test": "bun --filter '*' test && bun test scripts",
+    "test": "bun --filter '*' test && bun test scripts && bun run package:test",
     "visual:test": "bun --filter @bb-mate/workbench visual:test",
     "visual:update": "bun --filter @bb-mate/workbench visual:update",
+    "package:artifact": "bun scripts/package-local.ts",
+    "package:inspect": "bun scripts/package-local.ts --dry-run",
+    "package:test": "bun scripts/package-clean-room.ts",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },

--- a/scripts/build-local-package.ts
+++ b/scripts/build-local-package.ts
@@ -1,0 +1,55 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const cliRoot = path.join(repositoryRoot, "apps", "cli");
+const cliDist = path.join(cliRoot, "dist");
+const workbenchRoot = path.join(repositoryRoot, "apps", "workbench");
+
+async function run(args: readonly string[], cwd = repositoryRoot) {
+  const child = Bun.spawn([...args], {
+    cwd,
+    env: process.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) {
+    throw new Error(`${args.join(" ")} exited with code ${exitCode}.`);
+  }
+}
+
+await fs.rm(cliDist, { recursive: true, force: true });
+await fs.mkdir(cliDist, { recursive: true });
+
+await run([process.execPath, "run", "stories:build"], workbenchRoot);
+await run([
+  process.execPath,
+  "build",
+  path.join(cliRoot, "src", "bin.ts"),
+  "--target=bun",
+  "--minify",
+  "--outfile",
+  path.join(cliDist, "cli.js"),
+]);
+
+await fs.cp(
+  path.join(workbenchRoot, "dist", "ladle"),
+  path.join(cliDist, "lab"),
+  {
+    recursive: true,
+  },
+);
+await fs.chmod(path.join(cliDist, "cli.js"), 0o755);
+
+const metadata = JSON.parse(
+  await fs.readFile(path.join(cliDist, "lab", "meta.json"), "utf8"),
+) as { stories?: Record<string, unknown> };
+const storyCount = Object.keys(metadata.stories ?? {}).length;
+if (storyCount !== 13) {
+  throw new Error(`Expected 13 packaged surface stories, found ${storyCount}.`);
+}
+
+console.log(`Built private BB Mate CLI and ${storyCount}-story surface lab.`);

--- a/scripts/package-clean-room.ts
+++ b/scripts/package-clean-room.ts
@@ -1,0 +1,589 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface PackResult {
+  filename: string;
+  files: Array<{ path: string }>;
+}
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const sourceManifest = JSON.parse(
+  await fs.readFile(
+    path.join(repositoryRoot, "apps", "cli", "package.json"),
+    "utf8",
+  ),
+) as { name: string; version: string };
+const artifactName = `${sourceManifest.name}-${sourceManifest.version}.tgz`;
+const artifactPath = path.join(repositoryRoot, "artifacts", artifactName);
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function declaresPackage(value: unknown, packageName: string): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const packages = record.packages;
+  if (
+    packages &&
+    typeof packages === "object" &&
+    !Array.isArray(packages) &&
+    Object.keys(packages).some((key) => {
+      const normalized = key.replaceAll("\\", "/");
+      return (
+        normalized === `node_modules/${packageName}` ||
+        normalized.endsWith(`/node_modules/${packageName}`)
+      );
+    })
+  ) {
+    return true;
+  }
+  if (record.name === packageName) return true;
+  const bin = record.bin;
+  if (
+    bin &&
+    typeof bin === "object" &&
+    !Array.isArray(bin) &&
+    Object.hasOwn(bin, packageName)
+  ) {
+    return true;
+  }
+  if (
+    typeof record.resolved === "string" &&
+    path.basename(record.resolved).startsWith(`${packageName}-`) &&
+    record.resolved.endsWith(".tgz")
+  ) {
+    return true;
+  }
+  for (const field of [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ]) {
+    const dependencies = record[field];
+    if (
+      dependencies &&
+      typeof dependencies === "object" &&
+      !Array.isArray(dependencies) &&
+      Object.hasOwn(dependencies, packageName)
+    ) {
+      return true;
+    }
+  }
+  return Object.values(record).some((child) =>
+    declaresPackage(child, packageName),
+  );
+}
+
+function verifyResidueDetector(packageName: string) {
+  for (const residue of [
+    { packages: { [`../../tmp/node_modules/${packageName}`]: {} } },
+    { packages: { "": { name: packageName } } },
+    { packages: { "": { bin: { [packageName]: "dist/cli.js" } } } },
+    {
+      packages: {
+        "": { resolved: `file:../${packageName}-0.1.0-alpha.0.tgz` },
+      },
+    },
+  ]) {
+    assert(
+      declaresPackage(residue, packageName),
+      "The uninstall-residue detector missed a known npm lockfile shape.",
+    );
+  }
+  assert(
+    !declaresPackage({ packages: { "": {} } }, packageName),
+    "The uninstall-residue detector rejected a neutral npm lockfile.",
+  );
+}
+
+async function run(
+  args: readonly string[],
+  options: {
+    cwd?: string;
+    env: NodeJS.ProcessEnv;
+    allowFailure?: boolean;
+  },
+): Promise<CommandResult> {
+  const child = Bun.spawn([...args], {
+    cwd: options.cwd ?? repositoryRoot,
+    env: options.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0 && !options.allowFailure) {
+    throw new Error(
+      `${args.join(" ")} exited with code ${exitCode}\n${stdout.trim()}\n${stderr.trim()}`,
+    );
+  }
+  return { exitCode, stdout, stderr };
+}
+
+async function sha256(file: string): Promise<string> {
+  const hash = createHash("sha256");
+  hash.update(await fs.readFile(file));
+  return hash.digest("hex");
+}
+
+async function collectFiles(root: string, relative = ""): Promise<string[]> {
+  const entries = await fs.readdir(path.join(root, relative), {
+    withFileTypes: true,
+  });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const child = path.join(relative, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Package contains a symlink: ${child}`);
+    }
+    if (entry.isDirectory()) files.push(...(await collectFiles(root, child)));
+    else if (entry.isFile()) files.push(child);
+  }
+  return files;
+}
+
+async function freePort(): Promise<number> {
+  const probe = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("probe"),
+  });
+  const port = probe.port;
+  probe.stop(true);
+  if (port === undefined) throw new Error("Could not allocate a probe port.");
+  return port;
+}
+
+const temporaryRoot = await fs.mkdtemp(
+  path.join(os.tmpdir(), "bb-mate-package-"),
+);
+let server: ReturnType<typeof Bun.spawn> | null = null;
+
+try {
+  verifyResidueDetector(sourceManifest.name);
+  const installRoot = path.join(temporaryRoot, "install");
+  const homeRoot = path.join(temporaryRoot, "home");
+  const cacheRoot = path.join(temporaryRoot, "cache");
+  const configRoot = path.join(temporaryRoot, "config");
+  const dataRoot = path.join(temporaryRoot, "data");
+  const stateRoot = path.join(temporaryRoot, "state");
+  const tempRoot = path.join(temporaryRoot, "tmp");
+  const toolRoot = path.join(temporaryRoot, "bin");
+  await Promise.all(
+    [
+      homeRoot,
+      cacheRoot,
+      configRoot,
+      dataRoot,
+      stateRoot,
+      tempRoot,
+      toolRoot,
+    ].map((root) => fs.mkdir(root, { recursive: true })),
+  );
+
+  const exactTools = {
+    bun: process.execPath,
+    node: Bun.which("node"),
+    npm: Bun.which("npm"),
+    tar: Bun.which("tar"),
+  };
+  for (const [name, executable] of Object.entries(exactTools)) {
+    assert(executable, `Required clean-room tool is unavailable: ${name}.`);
+    assert(
+      !executable.startsWith(`${repositoryRoot}${path.sep}`),
+      `Clean-room tool resolves inside the repository: ${executable}.`,
+    );
+    await fs.symlink(executable, path.join(toolRoot, name));
+  }
+  const npmUserConfig = path.join(configRoot, "npmrc");
+  await fs.writeFile(
+    npmUserConfig,
+    [
+      "audit=false",
+      "fund=false",
+      "ignore-scripts=true",
+      "package-lock=false",
+      "update-notifier=false",
+      "",
+    ].join("\n"),
+  );
+  const lifecycleEnv: NodeJS.ProcessEnv = {
+    PATH: toolRoot,
+    HOME: homeRoot,
+    TMPDIR: tempRoot,
+    XDG_CACHE_HOME: cacheRoot,
+    XDG_CONFIG_HOME: configRoot,
+    XDG_DATA_HOME: dataRoot,
+    XDG_STATE_HOME: stateRoot,
+    BUN_INSTALL: path.join(dataRoot, "bun"),
+    BUN_INSTALL_CACHE_DIR: path.join(cacheRoot, "bun"),
+    npm_config_cache: path.join(cacheRoot, "npm"),
+    npm_config_prefix: installRoot,
+    npm_config_userconfig: npmUserConfig,
+    npm_config_audit: "false",
+    npm_config_fund: "false",
+    npm_config_ignore_scripts: "true",
+    npm_config_package_lock: "false",
+    NO_UPDATE_NOTIFIER: "1",
+    BB_CLI: "",
+    CI: "1",
+    LANG: "C.UTF-8",
+  };
+
+  const firstBuild = path.join(temporaryRoot, "build-a.tgz");
+  const secondBuild = path.join(temporaryRoot, "build-b.tgz");
+  await run([process.execPath, "scripts/package-local.ts"], {
+    env: lifecycleEnv,
+  });
+  await fs.access(artifactPath, constants.R_OK);
+  await fs.copyFile(artifactPath, firstBuild);
+  await run([process.execPath, "scripts/package-local.ts"], {
+    env: lifecycleEnv,
+  });
+  await fs.copyFile(artifactPath, secondBuild);
+
+  const repackRoot = path.join(temporaryRoot, "repack");
+  await fs.mkdir(repackRoot);
+  const repack = await run(
+    [
+      "npm",
+      "pack",
+      path.join(repositoryRoot, "artifacts", "package"),
+      "--pack-destination",
+      repackRoot,
+      "--json",
+      "--ignore-scripts",
+    ],
+    { env: lifecycleEnv },
+  );
+  const parsed = JSON.parse(repack.stdout) as PackResult[];
+  assert(parsed.length === 1, "Expected one npm pack result.");
+  const packed = parsed[0]!;
+  const repackedArtifact = path.join(repackRoot, packed.filename);
+  const hashes = await Promise.all(
+    [firstBuild, secondBuild, artifactPath, repackedArtifact].map(sha256),
+  );
+  assert(
+    hashes.every((hash) => hash === hashes[0]),
+    "Two complete package builds are not byte-for-byte deterministic.",
+  );
+
+  const paths = packed.files.map((file) => file.path);
+  const unexpected = paths.filter(
+    (file) =>
+      file !== "package.json" &&
+      file !== "README.md" &&
+      file !== "THIRD_PARTY_NOTICES.md" &&
+      file !== "THIRD_PARTY_LICENSES.md" &&
+      file !== "dist/cli.js" &&
+      !file.startsWith("dist/lab/"),
+  );
+  assert(
+    unexpected.length === 0,
+    `Unexpected packed files: ${unexpected.join(", ")}`,
+  );
+
+  const extractionRoot = path.join(temporaryRoot, "extracted");
+  await fs.mkdir(extractionRoot);
+  await run(["tar", "-xzf", artifactPath, "-C", extractionRoot], {
+    env: lifecycleEnv,
+  });
+  const extractedPackage = path.join(extractionRoot, "package");
+  const extractedFiles = await collectFiles(extractedPackage);
+  assert(
+    !extractedFiles.some((file) =>
+      /(^|\/)(node_modules|plugins|src)(\/|$)/.test(file),
+    ),
+    "Artifact contains source, plugin, or node_modules content.",
+  );
+  const stagedManifest = JSON.parse(
+    await fs.readFile(path.join(extractedPackage, "package.json"), "utf8"),
+  ) as Record<string, unknown>;
+  assert(stagedManifest.private === true, "Artifact must remain private.");
+  assert(
+    stagedManifest.license === "UNLICENSED",
+    "Artifact must remain unlicensed.",
+  );
+  assert(
+    !("dependencies" in stagedManifest),
+    "Artifact must not retain workspace dependencies.",
+  );
+  const thirdPartyLicenses = await fs.readFile(
+    path.join(extractedPackage, "THIRD_PARTY_LICENSES.md"),
+    "utf8",
+  );
+  for (const required of [
+    "@ladle/react@",
+    "debug@",
+    "history@",
+    "classnames@",
+    "prism-react-renderer@",
+    "prop-types@",
+    "query-string@",
+    "react-hotkeys-hook@",
+    "react-inspector@",
+    "scheduler@",
+    "tslib@",
+    "@fontsource-variable/geist@",
+    "@fontsource-variable/inter@",
+    "Apache License",
+    "SIL OPEN FONT LICENSE",
+  ]) {
+    assert(
+      thirdPartyLicenses.includes(required),
+      `Third-party license payload is missing ${required}.`,
+    );
+  }
+
+  const textFiles = extractedFiles.filter((file) =>
+    /\.(css|html|js|json|md|svg|webmanifest)$/.test(file),
+  );
+  for (const file of textFiles) {
+    const content = await fs.readFile(
+      path.join(extractedPackage, file),
+      "utf8",
+    );
+    assert(
+      !content.includes(repositoryRoot) && !content.includes("/Users/mg/"),
+      `Artifact leaks an absolute developer path in ${file}.`,
+    );
+  }
+
+  const copiedArtifact = path.join(temporaryRoot, artifactName);
+  await fs.copyFile(artifactPath, copiedArtifact);
+  await run(
+    [
+      "npm",
+      "install",
+      "--prefix",
+      installRoot,
+      "--ignore-scripts",
+      "--no-save",
+      "--package-lock=false",
+      "--no-audit",
+      "--no-fund",
+      copiedArtifact,
+    ],
+    { env: lifecycleEnv },
+  );
+
+  const installedBin = path.join(
+    installRoot,
+    "node_modules",
+    ".bin",
+    "bb-mate",
+  );
+  await fs.access(installedBin, constants.X_OK);
+  const help = await run([installedBin, "--help"], {
+    cwd: temporaryRoot,
+    env: lifecycleEnv,
+  });
+  assert(help.stdout.includes("Usage: bb-mate"), "Installed bin help failed.");
+
+  const workspaceRoot = path.join(temporaryRoot, "workspace");
+  const pluginRoot = path.join(workspaceRoot, "plugins", "fixture");
+  await fs.mkdir(pluginRoot, { recursive: true });
+  const executionMarker = path.join(temporaryRoot, "plugin-executed");
+  await fs.writeFile(
+    path.join(pluginRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "bb-plugin-fixture",
+        version: "1.0.0",
+        engines: { bb: ">=0.35.1", bbPluginSdk: ">=0.1.0" },
+        dependencies: { "@bb/plugin-sdk": "^0.4.1" },
+        bb: {
+          name: "Fixture",
+          description: "Clean-room fixture plugin",
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+          app: "./app.tsx",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await fs.writeFile(
+    path.join(pluginRoot, "server.ts"),
+    `await Bun.write(${JSON.stringify(executionMarker)}, "executed");\n`,
+  );
+  await fs.writeFile(path.join(pluginRoot, "app.tsx"), "export default {};\n");
+
+  const inspection = await run([installedBin, "inspect", pluginRoot], {
+    cwd: workspaceRoot,
+    env: lifecycleEnv,
+    allowFailure: true,
+  });
+  assert(
+    inspection.exitCode === 1,
+    "Unavailable native capabilities must fail inspection.",
+  );
+  assert(
+    inspection.stdout.includes("Native bb executable: unavailable"),
+    "Missing native bb was not reported clearly.",
+  );
+  assert(
+    inspection.stdout.includes("Plugin: Fixture"),
+    "Installed bin did not inspect the fixture package.",
+  );
+  assert(
+    inspection.stdout.includes("Harness mode is unavailable"),
+    "Missing official SDK/Harness capability was not reported clearly.",
+  );
+  await fs.access(executionMarker).then(
+    () => {
+      throw new Error("Passive inspection executed the plugin entrypoint.");
+    },
+    () => undefined,
+  );
+
+  const port = await freePort();
+  server = Bun.spawn(
+    [
+      installedBin,
+      "dev",
+      pluginRoot,
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+    ],
+    {
+      cwd: workspaceRoot,
+      env: lifecycleEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  let exited = false;
+  void server.exited.then(() => {
+    exited = true;
+  });
+  interface SurfaceMetadata {
+    stories?: Record<string, unknown>;
+  }
+  let metadata: SurfaceMetadata | null = null;
+  for (let attempt = 0; attempt < 100 && !exited; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/meta.json`);
+      if (response.ok) {
+        metadata = (await response.json()) as SurfaceMetadata;
+        break;
+      }
+    } catch {
+      // The process is still starting.
+    }
+    await Bun.sleep(100);
+  }
+  assert(metadata, "Installed bin did not start the packaged surface lab.");
+  assert(
+    Object.keys(metadata.stories ?? {}).length === 13,
+    "Packaged surface lab does not expose all 13 catalog stories.",
+  );
+  server.kill("SIGTERM");
+  await server.exited;
+  const stdoutStream = server.stdout;
+  const stderrStream = server.stderr;
+  assert(
+    stdoutStream instanceof ReadableStream,
+    "Server stdout was not captured.",
+  );
+  assert(
+    stderrStream instanceof ReadableStream,
+    "Server stderr was not captured.",
+  );
+  const [serverStdout, serverStderr] = await Promise.all([
+    new Response(stdoutStream).text(),
+    new Response(stderrStream).text(),
+  ]);
+  assert(
+    serverStdout.includes("Launching Fixture surface lab"),
+    `Installed dev output did not identify the packaged lab.\n${serverStderr}`,
+  );
+  assert(
+    serverStdout.includes("Connect exposure: unavailable"),
+    "Missing Connect capability was not reported while Fixture remained usable.",
+  );
+  server = null;
+
+  await run(
+    [
+      "npm",
+      "uninstall",
+      "--prefix",
+      installRoot,
+      "--no-save",
+      "--package-lock=false",
+      sourceManifest.name,
+    ],
+    {
+      env: lifecycleEnv,
+    },
+  );
+  await fs.access(installedBin).then(
+    () => {
+      throw new Error("npm uninstall left the installed bb-mate bin behind.");
+    },
+    () => undefined,
+  );
+  const installedPackage = path.join(
+    installRoot,
+    "node_modules",
+    sourceManifest.name,
+  );
+  await fs.access(installedPackage).then(
+    () => {
+      throw new Error("npm uninstall left the installed package behind.");
+    },
+    () => undefined,
+  );
+  const rootManifest = path.join(installRoot, "package.json");
+  try {
+    const content = await fs.readFile(rootManifest, "utf8");
+    assert(
+      !declaresPackage(JSON.parse(content), sourceManifest.name),
+      `npm uninstall left ${sourceManifest.name} in package.json.`,
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  for (const lockPath of [
+    path.join(installRoot, "package-lock.json"),
+    path.join(installRoot, "node_modules", ".package-lock.json"),
+  ]) {
+    try {
+      const content = await fs.readFile(lockPath, "utf8");
+      assert(
+        !declaresPackage(JSON.parse(content), sourceManifest.name),
+        `npm uninstall left ${sourceManifest.name} in ${lockPath}.`,
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
+  console.log(
+    `Clean-room package passed: ${artifactName}, ${paths.length} files, sha256 ${hashes[0]}, 13 stories.`,
+  );
+} finally {
+  if (server) server.kill("SIGKILL");
+  await fs.rm(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/package-clean-room.ts
+++ b/scripts/package-clean-room.ts
@@ -202,6 +202,7 @@ try {
     node: Bun.which("node"),
     npm: Bun.which("npm"),
     tar: Bun.which("tar"),
+    gzip: Bun.which("gzip"),
   };
   for (const [name, executable] of Object.entries(exactTools)) {
     assert(executable, `Required clean-room tool is unavailable: ${name}.`);

--- a/scripts/package-local.ts
+++ b/scripts/package-local.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateThirdPartyLicenses } from "./third-party-licenses.ts";
+
+interface PackFile {
+  path: string;
+}
+
+interface PackResult {
+  filename: string;
+  files: PackFile[];
+  integrity: string;
+  shasum: string;
+}
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const artifactRoot = path.join(repositoryRoot, "artifacts");
+const stagingRoot = path.join(artifactRoot, "package");
+const cliRoot = path.join(repositoryRoot, "apps", "cli");
+const dryRun = process.argv.includes("--dry-run");
+
+async function runCapture(args: readonly string[]): Promise<string> {
+  const child = Bun.spawn([...args], {
+    cwd: repositoryRoot,
+    env: process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `${args.join(" ")} exited with code ${exitCode}: ${stderr.trim()}`,
+    );
+  }
+  if (stderr.trim()) process.stderr.write(stderr);
+  return stdout;
+}
+
+await runCapture([process.execPath, "scripts/build-local-package.ts"]);
+await fs.mkdir(artifactRoot, { recursive: true });
+await fs.rm(stagingRoot, { recursive: true, force: true });
+await fs.mkdir(stagingRoot, { recursive: true });
+
+const sourceManifest = JSON.parse(
+  await fs.readFile(path.join(cliRoot, "package.json"), "utf8"),
+) as Record<string, unknown>;
+const stagedManifest = Object.fromEntries(
+  [
+    "name",
+    "version",
+    "private",
+    "license",
+    "type",
+    "bin",
+    "files",
+    "engines",
+    "bbMate",
+  ].map((key) => [key, sourceManifest[key]]),
+);
+await Promise.all([
+  fs.writeFile(
+    path.join(stagingRoot, "package.json"),
+    `${JSON.stringify(stagedManifest, null, 2)}\n`,
+  ),
+  fs.copyFile(
+    path.join(cliRoot, "README.md"),
+    path.join(stagingRoot, "README.md"),
+  ),
+  fs.copyFile(
+    path.join(cliRoot, "THIRD_PARTY_NOTICES.md"),
+    path.join(stagingRoot, "THIRD_PARTY_NOTICES.md"),
+  ),
+  generateThirdPartyLicenses().then((licenses) =>
+    fs.writeFile(path.join(stagingRoot, "THIRD_PARTY_LICENSES.md"), licenses),
+  ),
+  fs.cp(path.join(cliRoot, "dist"), path.join(stagingRoot, "dist"), {
+    recursive: true,
+  }),
+]);
+
+const output = await runCapture([
+  "npm",
+  "pack",
+  stagingRoot,
+  "--pack-destination",
+  artifactRoot,
+  "--json",
+  "--ignore-scripts",
+  ...(dryRun ? ["--dry-run"] : []),
+]);
+const parsed = JSON.parse(output) as PackResult[];
+const result = parsed[0];
+if (!result || parsed.length !== 1) {
+  throw new Error("npm pack did not return exactly one artifact.");
+}
+
+const paths = result.files.map((file) => file.path);
+const unexpected = paths.filter(
+  (file) =>
+    file !== "package.json" &&
+    file !== "README.md" &&
+    file !== "THIRD_PARTY_NOTICES.md" &&
+    file !== "THIRD_PARTY_LICENSES.md" &&
+    file !== "dist/cli.js" &&
+    !file.startsWith("dist/lab/"),
+);
+if (unexpected.length > 0) {
+  throw new Error(`Package allowlist violation: ${unexpected.join(", ")}`);
+}
+for (const required of [
+  "package.json",
+  "README.md",
+  "THIRD_PARTY_NOTICES.md",
+  "THIRD_PARTY_LICENSES.md",
+  "dist/cli.js",
+  "dist/lab/index.html",
+  "dist/lab/meta.json",
+]) {
+  if (!paths.includes(required)) {
+    throw new Error(`Package is missing required file: ${required}`);
+  }
+}
+
+console.log(
+  JSON.stringify(
+    {
+      artifact: path.join("artifacts", result.filename),
+      dryRun,
+      files: paths.length,
+      integrity: result.integrity,
+      shasum: result.shasum,
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/third-party-licenses.ts
+++ b/scripts/third-party-licenses.ts
@@ -1,0 +1,184 @@
+import { promises as fs } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PackageManifest {
+  name: string;
+  version: string;
+  license?: string;
+  dependencies?: Record<string, string>;
+}
+
+interface PackageRecord {
+  manifest: PackageManifest;
+  manifestPath: string;
+}
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const workbenchManifest = path.join(
+  repositoryRoot,
+  "apps",
+  "workbench",
+  "package.json",
+);
+const inspectionManifest = path.join(
+  repositoryRoot,
+  "packages",
+  "inspection",
+  "package.json",
+);
+
+async function packageManifest(
+  packageName: string,
+  fromManifest: string,
+): Promise<string> {
+  const base = await fs.realpath(fromManifest);
+  return fs.realpath(
+    createRequire(base).resolve(`${packageName}/package.json`),
+  );
+}
+
+async function addPackageTree(
+  packageName: string,
+  fromManifest: string,
+  records: Map<string, PackageRecord>,
+  recurse = true,
+): Promise<string> {
+  const manifestPath = await packageManifest(packageName, fromManifest);
+  if (records.has(manifestPath)) return manifestPath;
+  const manifest = JSON.parse(
+    await fs.readFile(manifestPath, "utf8"),
+  ) as PackageManifest;
+  records.set(manifestPath, { manifest, manifestPath });
+  if (recurse) {
+    for (const dependency of Object.keys(manifest.dependencies ?? {}).sort()) {
+      await addPackageTree(dependency, manifestPath, records);
+    }
+  }
+  return manifestPath;
+}
+
+async function licenseFiles(record: PackageRecord): Promise<string[]> {
+  const packageRoot = path.dirname(record.manifestPath);
+  const files = (await fs.readdir(packageRoot))
+    .filter((name) => /^(licen[cs]e|notice|copyright)/i.test(name))
+    .sort();
+  if (files.length > 0)
+    return files.map((name) => path.join(packageRoot, name));
+
+  if (record.manifest.name === "saxes") {
+    return [
+      path.join(
+        repositoryRoot,
+        "apps",
+        "cli",
+        "third-party",
+        "saxes-LICENSE.txt",
+      ),
+    ];
+  }
+  if (record.manifest.name === "@hugeicons/core-free-icons") {
+    const manifestPath = await packageManifest(
+      "@hugeicons/react",
+      workbenchManifest,
+    );
+    return [path.join(path.dirname(manifestPath), "LICENSE.md")];
+  }
+  throw new Error(
+    `No license or notice file found for ${record.manifest.name}@${record.manifest.version}.`,
+  );
+}
+
+export async function generateThirdPartyLicenses(): Promise<string> {
+  const records = new Map<string, PackageRecord>();
+  for (const name of [
+    "@base-ui/react",
+    "@fontsource-variable/geist",
+    "@fontsource-variable/inter",
+    "@hugeicons/core-free-icons",
+    "@hugeicons/react",
+    "class-variance-authority",
+    "clsx",
+    "lucide-react",
+    "react",
+    "react-dom",
+    "tailwind-merge",
+    "tw-animate-css",
+  ]) {
+    await addPackageTree(name, workbenchManifest, records);
+  }
+
+  const ladleManifest = await addPackageTree(
+    "@ladle/react",
+    workbenchManifest,
+    records,
+    false,
+  );
+  for (const name of [
+    "@ladle/react-context",
+    "@mdx-js/react",
+    "classnames",
+    "debug",
+    "history",
+    "lodash.merge",
+    "prism-react-renderer",
+    "prop-types",
+    "query-string",
+    "react-hotkeys-hook",
+    "react-inspector",
+    "scheduler",
+    "tslib",
+  ]) {
+    await addPackageTree(name, ladleManifest, records);
+  }
+
+  for (const name of ["saxes", "semver"]) {
+    await addPackageTree(name, inspectionManifest, records);
+  }
+
+  const sections = [
+    "# Third-party licenses and copyright notices",
+    "",
+    "This generated file accompanies the flattened BB Mate CLI and surface-lab output. It reproduces the complete license and copyright files shipped by the exact installed runtime packages, followed by notices for code embedded in Ladle's distributed client. It does not license BB Mate itself.",
+    "",
+  ];
+  const sorted = [...records.values()].sort((left, right) =>
+    `${left.manifest.name}@${left.manifest.version}`.localeCompare(
+      `${right.manifest.name}@${right.manifest.version}`,
+    ),
+  );
+  for (const record of sorted) {
+    sections.push(
+      `## ${record.manifest.name}@${record.manifest.version}`,
+      "",
+      `Declared license: ${record.manifest.license ?? "not declared"}`,
+      "",
+    );
+    for (const file of await licenseFiles(record)) {
+      sections.push(
+        `### ${path.basename(file)}`,
+        "",
+        (await fs.readFile(file, "utf8")).replaceAll("\r\n", "\n").trim(),
+        "",
+      );
+    }
+  }
+
+  sections.push(
+    (
+      await fs.readFile(
+        path.join(
+          repositoryRoot,
+          "apps",
+          "cli",
+          "third-party",
+          "embedded-ladle-notices.md",
+        ),
+        "utf8",
+      )
+    ).trim(),
+    "",
+  );
+  return `${sections.join("\n")}\n`;
+}


### PR DESCRIPTION
## Context

#37 needs a private versioned local artifact that works outside the monorepo without taking ownership from native bb or publishing anything.

## What changed

- bundle the Bun CLI and deterministic 13-story Fixture surface lab into an allowlisted local tarball
- serve packaged assets through a loopback-only GET/HEAD server with decoded-path and realpath confinement
- generate exact-version third-party license and copyright payloads while keeping BB Mate private and UNLICENSED
- prove two complete builds are byte-identical in an isolated exact-tool environment
- install, inspect, serve, stop, uninstall, and verify bin/package/manifest/lock residue in a temporary prefix
- document runtime, platform, capability, security, and no-publish boundaries

## Verification

- bun run format:check
- bun run check
- bun run test
- bun run build
- bun run visual:test
- artifact: 40 files, 13 stories, SHA-256 6e8b25d89345c2e68908131eb2d8f9e4cb31ab12be1b238447f3f8f9e64afc13
- standing and targeted final reviews: 5/5, zero findings

## Risks and rollout

This is a private local-only alpha artifact. Fixture remains an approximation; Harness remains official-SDK-gated; Live remains native bb authority. No registry publish, tag, release, visibility change, public license choice, announcement, upstream edit, or native plugin/Connect mutation is included.

Linear: #37

## Issue

Implements #37 under roadmap #21.