### PR TITLE
docs: add external plugin author guidance

### DIFF
--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -171,6 +171,27 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The documented clean-checkout package path is now byte-reproducible across checkout roots, not only across repeated builds in one directory.
 - Next: Run the exact committed clean-checkout aggregate, browser gate, standing security review, and fresh targeted author-doc review.
 - Blockers: None inside the private-alpha scope; the public license remains an explicit owner gate.
+
+2026-08-07 - OS-636 committed clean-checkout gates green
+- Changed: Committed the documentation candidate and checkout-independent lab correction, then exported commit 58d72ef into a new directory with no Git metadata or pre-existing dependencies.
+- Verified: The fresh export passed frozen install, format, type/compatibility checks, all 172 tests, the 40-file/13-story package lifecycle at SHA `545ae6a…b359`, every build, all 14 Playwright/axe checks, and all 21 local Markdown link targets. The final `git diff --check` invocation was inapplicable inside the Git-less archive and returned Git usage after every repository gate had passed; the source workspace diff check is green.
+- Result: Every documented non-mutating path is backed by a clean source or isolated artifact execution. Native build/install/dev handoffs remain exact-argv tested and deliberately unexecuted because this goal forbids normal native-state mutation.
+- Next: Fix standing and targeted review findings, then complete the hosted PR loop.
+- Blockers: None.
+
+2026-08-07 - OS-636 round-one review corrections
+- Changed: Corrected the source-workbench session-endpoint disclosure, exact bb/Bun and Linux-runner support envelope, non-Linear author intake, artifact Control-C lifecycle, and aggregate plugin-script execution disclosure.
+- Verified: Standing and targeted round one each scored 3/5. All four targeted findings and both standing findings now have direct documentation corrections; the stable package implementation was independently verified by both reviewers.
+- Result: External authors can distinguish source passive HTTP inspection from the packaged static lab, identify exact verified versions/environments, reach support without private tracker access, and understand that root gates execute plugin-owned code.
+- Next: Run focused documentation checks and standing/fresh-targeted round-two review.
+- Blockers: None.
+
+2026-08-07 - OS-636 final review and aggregate green
+- Changed: Closed every standing and external-author review finding by documenting the source inspection endpoint, exact support envelope, private GitHub intake, foreground-server cleanup order, and aggregate plugin-script execution boundary.
+- Verified: Both second-round reviewers approved at 5/5 with no P0-P3 findings. The current tree passed format, compatibility/type checks, all 172 tests, every build, all 14 Playwright/axe checks, and `git diff --check`; the clean-room package contains 40 files and 13 stories at SHA-256 `b8b2f756215c01413f110cc2a31d85484fa243a2d019676aa2141d834d3c2479`.
+- Review: Standing `tmp/reviews/standing/os-636-round-2.json`; targeted `tmp/reviews/targeted-os636/round-2.json`.
+- Next: Commit the approved corrections, open the draft PR, follow hosted CI and review threads, then land and reconcile OS-636 before starting OS-637.
+- Blockers: None.
 ```
 
 ## Preparation Audits
@@ -221,6 +242,10 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | 4         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-4.json`  | 5/5        | clean             | 0          | Superseding residue reconstruction and final recheck  |
 | 4         | OS-635 standing    | `tmp/reviews/standing/os-635-round-4.json` | 5/5        | clean             | 0          | Exact gzip closure and Linux GNU tar control          |
 | 5         | OS-635 targeted    | `tmp/reviews/targeted-os635/round-5.json`  | 5/5        | clean             | 0          | Linux portability, isolation, and determinism recheck |
+| 1         | OS-636 standing    | `tmp/reviews/standing/os-636-round-1.json` | 3/5        | changes requested | 2          | HTTP trust boundary and support envelope              |
+| 1         | OS-636 targeted    | `tmp/reviews/targeted-os636/round-1.json`  | 3/5        | changes requested | 4          | Intake, versions, lifecycle, aggregate execution      |
+| 2         | OS-636 standing    | `tmp/reviews/standing/os-636-round-2.json` | 5/5        | clean             | 0          | Trust, support, lifecycle, and script closure         |
+| 2         | OS-636 targeted    | `tmp/reviews/targeted-os636/round-2.json`  | 5/5        | clean             | 0          | External-author workflow and artifact closure         |
 
 ## Verification Log
 
@@ -259,6 +284,10 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | Corrected OS-635 aggregate                                                      | OS-635 candidate     | pass                 | explicit gzip tool; artifact SHA unchanged                 |
 | Archived clean checkout quickstart                                              | OS-636 source docs   | pass                 | frozen install; story URL and metadata verified            |
 | Cross-checkout package comparison                                               | OS-636 reproducible  | pass                 | both roots SHA `545ae6a…b359`; 40 files; 13 stories        |
+| Git-less export of 58d72ef format/check/test/build                              | OS-636 clean source  | pass                 | 172 tests; compatibility and both builds green             |
+| Git-less export Playwright/axe and link audit                                   | OS-636 clean source  | pass                 | 14 browser checks; 21 Markdown files                       |
+| `bun run format:check && bun run check && bun run test && bun run build`        | OS-636 final         | pass                 | 172 tests; package SHA `b8b2f756…c2479`                    |
+| macOS Playwright/axe matrix (14 tests)                                          | OS-636 final         | pass                 | unchanged visual and accessibility baselines               |
 
 ## Prompt / Goal Alignment
 
@@ -271,17 +300,17 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 
 ## Tracker / PR Log
 
-| Item   | State       | Notes                                                  |
-| ------ | ----------- | ------------------------------------------------------ |
-| OS-627 | In Progress | Parent epic                                            |
-| OS-629 | Done        | PR #6 merged at `7f364f1`; main CI 31216658339 green   |
-| OS-633 | Done        | PR #7 merged at `7e11d89`; main CI 31218687904 green   |
-| OS-634 | Done        | PR #8 merged at `f14afd3`; main CI 31222879164 green   |
-| OS-632 | Done        | PR #9 merged at `9f2aa0c`; main CI 31226118637 green   |
-| OS-635 | Done        | PR #10 merged at `544d9b1`; main CI 31229355120 green  |
-| OS-636 | Todo        | Unblocked; finalized after artifact commands stabilize |
-| OS-637 | Todo        | Blocked by OS-632/634/635/636                          |
-| OS-638 | Todo        | Blocked by OS-629/637; final ready PR only             |
+| Item   | State       | Notes                                                 |
+| ------ | ----------- | ----------------------------------------------------- |
+| OS-627 | In Progress | Parent epic                                           |
+| OS-629 | Done        | PR #6 merged at `7f364f1`; main CI 31216658339 green  |
+| OS-633 | Done        | PR #7 merged at `7e11d89`; main CI 31218687904 green  |
+| OS-634 | Done        | PR #8 merged at `f14afd3`; main CI 31222879164 green  |
+| OS-632 | Done        | PR #9 merged at `9f2aa0c`; main CI 31226118637 green  |
+| OS-635 | Done        | PR #10 merged at `544d9b1`; main CI 31229355120 green |
+| OS-636 | In Progress | Final local candidate approved; PR and CI remain      |
+| OS-637 | Todo        | Blocked by OS-632/634/635/636                         |
+| OS-638 | Todo        | Blocked by OS-629/637; final ready PR only            |
 
 ## Follow-Ups
 

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -157,6 +157,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The package test now declares the complete external tool closure it actually needs on both macOS and Linux.
 - Next: Re-run standing and targeted review on the changed snapshot, amend the PR, and follow hosted CI to green.
 - Blockers: None.
+
+2026-08-07 - OS-635 landed and OS-636 started
+- Changed: Corrected the Linux clean-room tool closure, merged OS-635 in PR #10, reconciled its GitButler lane, moved Linear to Done, and opened the recommended OS-636 documentation branch from clean main.
+- Verified: Corrected PR run 31229243221 and post-merge main run 31229355120 both passed verify and visual; GitGuardian passed; merge commit 544d9b1; no review threads; clean lane-free workspace.
+- Result: The private local artifact is now the verified baseline for the external author guide, trust model, and support policy.
+- Next: Verify every documented command from a clean checkout or installed artifact, then complete security and targeted documentation review.
+- Blockers: A public license choice remains an explicit owner decision and is not authorized by this goal; the docs must make the private `UNLICENSED` boundary and pre-public-release gate explicit.
 ```
 
 ## Preparation Audits
@@ -262,7 +269,7 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-633 | Done        | PR #7 merged at `7e11d89`; main CI 31218687904 green   |
 | OS-634 | Done        | PR #8 merged at `f14afd3`; main CI 31222879164 green   |
 | OS-632 | Done        | PR #9 merged at `9f2aa0c`; main CI 31226118637 green   |
-| OS-635 | In Progress | Local package implementation and review                |
+| OS-635 | Done        | PR #10 merged at `544d9b1`; main CI 31229355120 green  |
 | OS-636 | Todo        | Unblocked; finalized after artifact commands stabilize |
 | OS-637 | Todo        | Blocked by OS-632/634/635/636                          |
 | OS-638 | Todo        | Blocked by OS-629/637; final ready PR only             |

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -164,6 +164,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The private local artifact is now the verified baseline for the external author guide, trust model, and support policy.
 - Next: Verify every documented command from a clean checkout or installed artifact, then complete security and targeted documentation review.
 - Blockers: A public license choice remains an explicit owner decision and is not authorized by this goal; the docs must make the private `UNLICENSED` boundary and pre-public-release gate explicit.
+
+2026-08-07 - OS-636 external guide candidate and clean-checkout correction
+- Changed: Added the five-minute Fixture path, external author guide, full-trust operation matrix, CONTRIBUTING, SECURITY, and support/deprecation/license policies. During clean-checkout verification, fixed Ladle's default cwd-derived application ID by overriding it with the stable `bb-mate-surface-lab-v1` ID and added an artifact assertion for that boundary.
+- Verified: A fresh archive of commit fa6fd86 installed with the frozen lockfile, served the documented loopback story URL, exposed the expected story in `meta.json`, and stopped cleanly. Before the fix, the source and fresh checkout each built internally stable archives but differed because Ladle embedded a hash of `process.cwd()`. With the stable ID, both independent checkout paths produce the same 40-file, 13-story SHA-256 `545ae6a9d4e30caf2b6099b90f087ad1e026b5e089b2cb13cbb7ea8534d5b359`.
+- Result: The documented clean-checkout package path is now byte-reproducible across checkout roots, not only across repeated builds in one directory.
+- Next: Run the exact committed clean-checkout aggregate, browser gate, standing security review, and fresh targeted author-doc review.
+- Blockers: None inside the private-alpha scope; the public license remains an explicit owner gate.
 ```
 
 ## Preparation Audits
@@ -250,6 +257,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | macOS Playwright/axe matrix (14 tests)                                          | OS-635 regression    | pass                 | unchanged fixture baselines and accessibility matrix       |
 | Hosted CI 31228900314                                                           | OS-635 Linux probe   | expected failure     | visual green; clean-room tar PATH lacked external gzip     |
 | Corrected OS-635 aggregate                                                      | OS-635 candidate     | pass                 | explicit gzip tool; artifact SHA unchanged                 |
+| Archived clean checkout quickstart                                              | OS-636 source docs   | pass                 | frozen install; story URL and metadata verified            |
+| Cross-checkout package comparison                                               | OS-636 reproducible  | pass                 | both roots SHA `545ae6a…b359`; 40 files; 13 stories        |
 
 ## Prompt / Goal Alignment
 

--- a/.agents/plans/2026-08-07-os-635-clean-room-package.md
+++ b/.agents/plans/2026-08-07-os-635-clean-room-package.md
@@ -50,7 +50,7 @@ separate owner decision.
 - [x] Add deterministic package inspection and clean-room lifecycle proof.
 - [x] Document the supported runtime/capability and no-publish boundary.
 - [x] Complete aggregate gates and standing/fresh-targeted review.
-- [ ] Land the PR, verify main CI, and move OS-635 to Done.
+- [x] Land the PR, verify main CI, and move OS-635 to Done.
 
 ## Completion
 

--- a/.agents/plans/2026-08-07-os-636-author-guide-trust-support.md
+++ b/.agents/plans/2026-08-07-os-636-author-guide-trust-support.md
@@ -54,8 +54,8 @@ compatibility, mutation, support, and private-license boundaries unambiguous.
 - [x] Inventory and reconcile existing author-facing documentation.
 - [x] Add the external author, trust/mutation, compatibility/support, and
       contribution/security documents.
-- [ ] Verify every copyable command in clean source and artifact environments.
-- [ ] Complete aggregate gates and standing/fresh-targeted review.
+- [x] Verify every copyable command in clean source and artifact environments.
+- [x] Complete aggregate gates and standing/fresh-targeted review.
 - [ ] Land the PR, verify main CI, and move OS-636 to Done.
 
 ## Completion

--- a/.agents/plans/2026-08-07-os-636-author-guide-trust-support.md
+++ b/.agents/plans/2026-08-07-os-636-author-guide-trust-support.md
@@ -1,0 +1,66 @@
+# OS-636 author guide, trust model, and support policy
+
+## Outcome
+
+Give an external plugin author a self-contained, verified path from prerequisites
+to a first deterministic Fixture story, while making BB Mate's trust,
+compatibility, mutation, support, and private-license boundaries unambiguous.
+
+## Slice
+
+1. Restructure the root entrypoint around a five-minute source-checkout path and
+   link a package-artifact path that works without private Grid/Patch context.
+2. Add an author guide covering package layout, public-SDK adapters, CLI and
+   surface-lab workflows, and the Fixture/Harness/Live confidence model.
+3. Add one operation matrix naming code-execution, filesystem/network/secret
+   access, and native bb/Connect mutation boundaries for each supported command.
+4. Add compatibility, support, deprecation, release, and upstream-adoption
+   policies that preserve native bb ownership and make Live bb the visual
+   authority.
+5. Add CONTRIBUTING and SECURITY guidance with private reporting expectations,
+   and document that `UNLICENSED` grants no public-use permission until the
+   owner explicitly selects a license before any visibility or publication
+   change.
+6. Run every copyable command from an isolated clean checkout or the installed
+   local artifact; keep durable verification evidence in the docs/goal record.
+
+## Boundaries
+
+- No publish, tag, release, repository-visibility change, announcement, public
+  license choice, or upstream bb edit.
+- No normal plugin install/build/dev operation and no Connect expose/pair state
+  mutation during verification; use deterministic fixtures and isolated copies.
+- Harness remains unavailable until the official public testing package and a
+  BB Mate upstream-backed adapter both resolve.
+- BB Mate remains deletable: native bb owns scaffold, declaration refresh,
+  build, install, dev/reload, and runtime.
+- Security guidance treats plugins as full-trust local code and content-script
+  fixtures as inert; it does not promise a sandbox BB Mate does not provide.
+
+## Verification
+
+- Clean-checkout quickstart commands execute exactly as written.
+- Copied local artifact installs, runs help/inspection/lab, and uninstalls in an
+  isolated temporary environment.
+- Documentation link and copyable-command audit.
+- `bun run format:check && bun run check && bun run test && bun run build`.
+- Standing security/trust review plus a fresh targeted external-author docs
+  review; fix every P0-P2 and reasonable P3.
+- Draft PR, hosted CI and review-thread audit, ready/merge, post-merge main CI,
+  and Linear Done.
+
+## Progress
+
+- [x] Inventory and reconcile existing author-facing documentation.
+- [x] Add the external author, trust/mutation, compatibility/support, and
+      contribution/security documents.
+- [ ] Verify every copyable command in clean source and artifact environments.
+- [ ] Complete aggregate gates and standing/fresh-targeted review.
+- [ ] Land the PR, verify main CI, and move OS-636 to Done.
+
+## Completion
+
+Complete when a new author can reach a first Fixture story without private
+context, correctly predict which commands execute code or mutate native state,
+understand compatibility/support and fidelity claims, and see the explicit
+owner approval gates that still block public licensing and release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,12 @@ workflow instead of recreating it here.
 
 1. Read [AGENTS.md](AGENTS.md), [README.md](README.md), and
    [docs/architecture.md](docs/architecture.md).
-2. Use the Linear issue as the source of truth. For non-trivial work, add or
-   update a plan under `.agents/plans/` before implementation.
-3. Create the Linear-recommended non-main branch with GitButler.
+2. Maintainers use the Linear issue as the source of truth. If you do not have
+   Outfitter Linear access, open a private repository GitHub Issue with the
+   context and desired outcome; a maintainer will link or create the Linear
+   issue and give you its branch slug before implementation.
+3. Create that Linear-recommended non-main branch with GitButler. For
+   non-trivial work, add or update a plan under `.agents/plans/` first.
 4. Install exactly the locked dependencies:
 
    ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to BB Mate
+
+BB Mate is currently a private alpha. Contributions should keep it downstream,
+small, and removable: when native bb owns a workflow, call or document that
+workflow instead of recreating it here.
+
+## Start here
+
+1. Read [AGENTS.md](AGENTS.md), [README.md](README.md), and
+   [docs/architecture.md](docs/architecture.md).
+2. Use the Linear issue as the source of truth. For non-trivial work, add or
+   update a plan under `.agents/plans/` before implementation.
+3. Create the Linear-recommended non-main branch with GitButler.
+4. Install exactly the locked dependencies:
+
+   ```sh
+   bun install --frozen-lockfile
+   ```
+
+## Change boundaries
+
+- `apps/workbench` is browser-only Fixture tooling and must work without bb.
+- `plugins/<name>` packages are independently versioned and use only public
+  plugin contracts.
+- `../bb` is read-only reference material unless an issue explicitly targets
+  upstream.
+- Native bb owns scaffold, declaration refresh, build, install, dev/reload, and
+  runtime. BB Mate may inspect, explain, orchestrate, and hand off.
+- Harness code must come from the selected plugin's official
+  `@bb/plugin-sdk/testing` dependencies. Do not copy it or import it from the
+  sibling checkout.
+- Fixtures are deterministic approximations; Live bb remains the visual
+  authority.
+- Never commit secrets, authenticated browser state, customer data, or local
+  absolute paths.
+
+Review [docs/trust-model.md](docs/trust-model.md) before changing command or
+execution boundaries. Document any new filesystem, network, secret, or
+external-service access.
+
+## Verification
+
+Run the smallest relevant check while iterating, then the complete repository
+gate before pushing:
+
+```sh
+bun run format:check
+bun run check
+bun run test
+bun run build
+```
+
+UI changes also require the bounded browser gate:
+
+```sh
+bun run visual:test
+```
+
+Use `bun run package:test` when local package contents or lifecycle behavior can
+change. That command is already included in the complete test gate.
+
+New behavior needs focused tests. Documentation commands must be copyable and
+verified in a clean checkout, an isolated artifact installation, or an exact
+argv unit test when executing the command would mutate native state. Record any
+deliberately unexecuted mutation handoff.
+
+## Pull requests
+
+Keep the PR draft until CI is green. Use a Conventional Commit title and include
+context, changes, verification, and risk/rollout notes. Resolve every review
+thread or explain the disagreement. Update Linear at phase boundaries and note
+any divergence from its acceptance criteria.
+
+Do not publish a package, create a tag or release, change repository visibility,
+announce availability, or select a public license as part of ordinary feature
+work. Those are separate owner-approved release actions.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ The browser workbench lives in `apps/workbench`. Installable bb plugins live in 
 
 ## Five-minute Fixture quickstart
 
-Prerequisites: repository access, Bun 1.3.14 or newer, and npm. Native bb,
-Connect, credentials, and the unpublished plugin SDK are not required for
-Fixture stories.
+Prerequisites: repository access and the currently verified Bun 1.3.14. Newer
+engine-compatible Bun versions are best-effort until added to CI. npm is needed
+only for the local-artifact workflow. Native bb, Connect, credentials, and the
+unpublished plugin SDK are not required for Fixture stories.
 
 From a fresh checkout:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ BB Mate is a private Bun monorepo for designing, prototyping, and shipping exten
 
 The browser workbench lives in `apps/workbench`. Installable bb plugins live in `plugins/<name>` as independent workspace packages with their own manifests and release versions.
 
+## Five-minute Fixture quickstart
+
+Prerequisites: repository access, Bun 1.3.14 or newer, and npm. Native bb,
+Connect, credentials, and the unpublished plugin SDK are not required for
+Fixture stories.
+
+From a fresh checkout:
+
+```sh
+bun install --frozen-lockfile
+bun --filter @bb-mate/workbench stories --host 127.0.0.1 --port 61000
+```
+
+Open
+<http://127.0.0.1:61000/?story=surfaces--sidebar-thread-list--catalog-fixtures>.
+That story is deterministic browser state. Starting it executes BB Mate's
+checked-out development dependencies and opens a loopback server, but it does
+not import or execute a selected plugin, contact bb/Connect, or mutate native
+plugin state.
+
+Continue with the [external plugin-author guide](docs/plugin-author-guide.md),
+then read the [trust and operation model](docs/trust-model.md) before pointing
+BB Mate at third-party code. Project expectations live in
+[CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), and
+[SUPPORT.md](SUPPORT.md).
+
 ## Commands
 
 ```sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Do not open a public issue or include exploit details, credentials, customer
+data, or local paths in ordinary logs or comments.
+
+Use the repository's GitHub **Security → Report a vulnerability** flow to open a
+private security advisory. Include the affected commit or package version,
+reproduction steps using fake data, impact, and any known workaround. If the
+private advisory flow is unavailable, contact a repository maintainer through
+the same private channel that granted repository access and ask for a secure
+reporting path before sharing details.
+
+Maintainers will acknowledge a report when the private project is actively
+staffed, reproduce and triage it, coordinate a fix and disclosure boundary, and
+credit the reporter if requested. This private alpha has no public response-time
+or remediation SLA; see [SUPPORT.md](SUPPORT.md).
+
+## Supported security surface
+
+Only the current `main` snapshot and the exact local alpha artifact identified
+in repository documentation are considered for security fixes. Old commits,
+locally modified artifacts, unpublished branches, unsupported bb/SDK versions,
+and third-party plugins are not maintained release lines.
+
+BB Mate does not sandbox plugins. Full-trust execution, passive inspection,
+native mutation boundaries, content-script handling, and secret expectations
+are documented in [docs/trust-model.md](docs/trust-model.md). A report that a
+third-party plugin intentionally reads files or uses the network is normally a
+plugin issue; a report that BB Mate executes a plugin during passive inspection,
+leaks redacted paths, crosses its server confinement, or runs a native mutation
+without an explicit terminal handoff is a BB Mate security issue.
+
+## Handling fixes
+
+- Use fake deterministic fixtures and isolated profiles for reproduction.
+- Do not remove/reinstall a managed path plugin if that could discard settings
+  or secrets.
+- Keep advisory branches and artifacts private until the owner approves
+  disclosure.
+- Verify the smallest fix plus the full repository and relevant browser/package
+  gates before release consideration.
+- Publication, tagging, visibility, disclosure timing, and credential rotation
+  require explicit owner decisions.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,90 @@
+# Support and compatibility policy
+
+BB Mate is a private `0.1.0-alpha.0` development tool. It has no public support
+commitment, stable API guarantee, or response-time SLA. Access does not imply a
+license grant or permission to redistribute it.
+
+## Supported line
+
+- Source: the current green `main` snapshot.
+- Local package: the exact private alpha artifact produced and verified by that
+  snapshot.
+- Toolchain: the Bun version pinned by `packageManager` and the npm installer
+  path documented in [docs/local-package.md](docs/local-package.md).
+- Native integration: the one bb release recorded in
+  `compatibility/bb-target.json`, plus plugin engine ranges that honestly include
+  that release.
+- Platforms: macOS for native bb handoffs; macOS and the pinned Linux CI image
+  for deterministic Fixture/package checks as documented.
+
+Old source snapshots, modified tarballs, alternate runtimes, undeclared bb/SDK
+versions, and third-party plugin behavior are best-effort only.
+
+Run the current compatibility measurement before diagnosing a native mismatch:
+
+```sh
+bun run compatibility:check
+```
+
+The report fails closed when its public upstream evidence cannot be verified.
+An outage or unavailable probe is not evidence of compatibility. Follow
+[docs/compatibility-target.md](docs/compatibility-target.md) to update the
+recorded target deliberately.
+
+## Fidelity support
+
+- Fixture issues cover deterministic BB Mate stories and adapters only.
+- Harness issues are in scope only after the selected plugin resolves the
+  official testing package and BB Mate ships an upstream-backed adapter.
+- Live bb issues must be reproduced against the recorded target. Live bb is the
+  visual/integration authority; Fixture screenshots cannot overrule host
+  behavior.
+
+When the problem is native scaffolding, build/install/dev behavior, host chrome,
+routing, or runtime, report it upstream to bb with a minimal reproduction. BB
+Mate may improve its diagnosis or handoff but will not maintain a competing
+implementation.
+
+## Changes and deprecation
+
+Private alpha commands, fixtures, and package contents may change between green
+`main` snapshots. When a supported BB Mate path is replaced, changes should:
+
+1. name the replacement in the issue, changelog/release handoff, or command
+   diagnostic;
+2. keep one clear path rather than parallel permanent modes;
+3. preserve the old path for at least one planned alpha handoff when practical;
+4. remove it immediately when retention would create a security or data-loss
+   risk, with that exception documented.
+
+When upstream bb adds a native capability that replaces a BB Mate seam, BB Mate
+adopts it and deletes or deprecates the duplicate. The downstream tool is
+designed to be removable, not to freeze older native workflows.
+
+## Asking for help
+
+Use a Linear issue in the Outfitter workspace for private project work. Include
+the BB Mate commit, artifact version if applicable, `bun --version`, native
+`bb --version` when used, the selected plugin's engine ranges, the exact command
+and exit status, and sanitized diagnostics. Do not attach secrets, authenticated
+state, customer data, or unredacted local paths.
+
+Potential vulnerabilities follow [SECURITY.md](SECURITY.md), not the ordinary
+support queue.
+
+## Release and license gate
+
+The repository and local package are currently private and `UNLICENSED`. No
+public-use, modification, redistribution, or publication permission is granted.
+Before any repository-visibility or registry-publication change, the owner must
+explicitly approve:
+
+- a public license and corresponding repository/package metadata;
+- supported versions and platforms;
+- release channel, version, provenance, and rollback plan;
+- security contact and disclosure expectations;
+- announcement text and audience.
+
+Until those decisions are recorded, do not publish, tag, create a release,
+change visibility, or announce availability. The alpha release handoff may make
+these decisions ready for approval, but it does not approve or execute them.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,13 +9,15 @@ license grant or permission to redistribute it.
 - Source: the current green `main` snapshot.
 - Local package: the exact private alpha artifact produced and verified by that
   snapshot.
-- Toolchain: the Bun version pinned by `packageManager` and the npm installer
-  path documented in [docs/local-package.md](docs/local-package.md).
+- Toolchain: Bun 1.3.14, pinned by `packageManager`, and the npm installer path
+  documented in [docs/local-package.md](docs/local-package.md). Newer versions
+  accepted by the package engine are best-effort until added to CI.
 - Native integration: the one bb release recorded in
   `compatibility/bb-target.json`, plus plugin engine ranges that honestly include
   that release.
-- Platforms: macOS for native bb handoffs; macOS and the pinned Linux CI image
-  for deterministic Fixture/package checks as documented.
+- Platforms: macOS for native bb handoffs; macOS and GitHub's moving
+  `ubuntu-latest` runner for aggregate/package checks; and the versioned
+  Playwright 1.62.1 Noble container for Linux Fixture visual baselines.
 
 Old source snapshots, modified tarballs, alternate runtimes, undeclared bb/SDK
 versions, and third-party plugin behavior are best-effort only.
@@ -63,11 +65,14 @@ designed to be removable, not to freeze older native workflows.
 
 ## Asking for help
 
-Use a Linear issue in the Outfitter workspace for private project work. Include
-the BB Mate commit, artifact version if applicable, `bun --version`, native
-`bb --version` when used, the selected plugin's engine ranges, the exact command
-and exit status, and sanitized diagnostics. Do not attach secrets, authenticated
-state, customer data, or unredacted local paths.
+If you have Outfitter Linear access, use the linked Linear issue for private
+project work. Otherwise open a private issue in this GitHub repository; a
+maintainer will triage it into Linear and keep the repository issue as the
+author-facing thread. Include the BB Mate commit, artifact version if
+applicable, `bun --version`, native `bb --version` when used, the selected
+plugin's engine ranges, the exact command and exit status, and sanitized
+diagnostics. Do not attach secrets, authenticated state, customer data, or
+unredacted local paths.
 
 Potential vulnerabilities follow [SECURITY.md](SECURITY.md), not the ordinary
 support queue.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -6,7 +6,8 @@ plugin packages, a copied plugin SDK, or authenticated host state.
 
 ## Runtime support
 
-- Bun 1.3.14 or newer executes the `bb-mate` bin.
+- Bun 1.3.14 is the verified `bb-mate` runtime. Newer engine-compatible Bun
+  versions are best-effort until added to CI.
 - npm may install or inspect the tarball, but Node is not a supported CLI
   runtime.
 - Native bb handoffs target the supported macOS bb host. Fixture inspection and
@@ -34,12 +35,19 @@ bundled CLI, and static lab assets.
 Choose an empty prefix and install the generated file without publishing:
 
 ```sh
+plugin="/absolute/path/to/plugin"
 prefix="$(mktemp -d)"
 npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.0.tgz
 export PATH="$prefix/node_modules/.bin:$PATH"
 bb-mate --help
-bb-mate inspect ./path/to/plugin
-bb-mate dev ./path/to/plugin
+bb-mate inspect "$plugin"
+bb-mate dev "$plugin"
+```
+
+Open the printed loopback URL, then stop the foreground server with Control-C
+before uninstalling in the same shell:
+
+```sh
 npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 ```
 

--- a/apps/workbench/.ladle/vite.config.ts
+++ b/apps/workbench/.ladle/vite.config.ts
@@ -5,6 +5,11 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [tailwindcss()],
+  define: {
+    "import.meta.env.VITE_LADLE_APP_ID": JSON.stringify(
+      "bb-mate-surface-lab-v1",
+    ),
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("../src", import.meta.url)),

--- a/docs/local-package.md
+++ b/docs/local-package.md
@@ -5,7 +5,8 @@ any registry, repository-visibility, license, or release decision.
 
 ## Artifact contract
 
-Run from a clean checkout with Bun 1.3.14 or newer and npm available:
+Run from a clean checkout with the verified Bun 1.3.14 and npm available.
+Newer engine-compatible Bun versions are best-effort until added to CI:
 
 ```sh
 bun install --frozen-lockfile

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -8,10 +8,13 @@ dev/reload, and the live runtime.
 ## Prerequisites
 
 - access to this private repository;
-- Bun 1.3.14 or newer;
+- Bun 1.3.14, the currently verified version; newer engine-compatible versions
+  are best-effort until added to CI;
 - npm for inspecting and temporarily installing the local alpha archive;
 - an existing bb plugin when you want inspection or native handoff guidance;
-- native bb 0.35.x only for native inspection, build, or Live handoffs.
+- native bb 0.35.1, the currently recorded target, for supported native
+  inspection, build, or Live handoffs. Other versions may still produce useful
+  diagnostics but are best-effort until the compatibility target is updated.
 
 Fixture exploration does not require native bb, Connect, secrets, a sibling
 `../bb` checkout, or a published `@bb/plugin-sdk` package.
@@ -107,6 +110,12 @@ prefix="$(mktemp -d)"
 npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.0.tgz
 "$prefix/node_modules/.bin/bb-mate" --help
 "$prefix/node_modules/.bin/bb-mate" dev "$plugin"
+```
+
+Open the printed loopback URL, then stop the foreground server with Control-C
+before uninstalling in the same shell:
+
+```sh
 npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 ```
 
@@ -166,7 +175,8 @@ actual host layout, styling, routing, state, action lifecycle, and runtime.
 - Follow [CONTRIBUTING.md](../CONTRIBUTING.md) for change and verification
   requirements.
 - Use [SUPPORT.md](../SUPPORT.md) to determine whether a bb/SDK combination is
-  in scope.
+  in scope and find the repository-local intake path when you do not have
+  Outfitter Linear access.
 - Read [SECURITY.md](../SECURITY.md) before reporting a vulnerability or
   handling plugin secrets.
 

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -1,0 +1,176 @@
+# External plugin-author guide
+
+This guide assumes you have an existing bb plugin and no private knowledge of
+the repository's design history. BB Mate is an optional downstream authoring
+companion: native bb still owns scaffold, declaration refresh, build, install,
+dev/reload, and the live runtime.
+
+## Prerequisites
+
+- access to this private repository;
+- Bun 1.3.14 or newer;
+- npm for inspecting and temporarily installing the local alpha archive;
+- an existing bb plugin when you want inspection or native handoff guidance;
+- native bb 0.35.x only for native inspection, build, or Live handoffs.
+
+Fixture exploration does not require native bb, Connect, secrets, a sibling
+`../bb` checkout, or a published `@bb/plugin-sdk` package.
+
+## Reach the first Fixture story
+
+From a fresh checkout:
+
+```sh
+bun install --frozen-lockfile
+bun --filter @bb-mate/workbench stories --host 127.0.0.1 --port 61000
+```
+
+Open
+<http://127.0.0.1:61000/?story=surfaces--sidebar-thread-list--catalog-fixtures>.
+The lab has one story group for each cataloged public plugin surface. Its
+fixture, theme, and viewport controls are URL-backed, so a selected state can be
+reloaded or shared without creating plugin or bb state.
+
+The command runs repository development code and serves HTTP on loopback. Story
+discovery never imports a selected plugin, and content-script stories remain
+inert. Stop the server with Control-C.
+
+## Inspect an existing plugin
+
+Run BB Mate from this repository and pass an explicit plugin directory:
+
+```sh
+plugin="/absolute/path/to/plugin"
+bun run bb-mate --help
+bun run bb-mate inspect "$plugin"
+bun run bb-mate inspect "$plugin" --json
+```
+
+Inspection reads `package.json`, native `dist/*.meta.json`, and passive native
+bb/Connect reports. It does not import the plugin entrypoint. An unavailable bb,
+Connect, npm SDK publication, or Harness can make inspection exit nonzero; the
+report still explains each capability independently and keeps Fixture use
+available.
+
+For an interactive source-checkout workbench around that plugin:
+
+```sh
+bun run bb-mate dev "$plugin" --host 127.0.0.1 --port 5173
+```
+
+The bare form is equivalent:
+
+```sh
+bun run bb-mate "$plugin"
+```
+
+The server performs the same passive inspection before it starts. Keep the host
+on loopback unless you intentionally want the Fixture server reachable from
+another machine. BB Mate reports existing Connect shares but never exposes,
+unexposes, or pairs Connect.
+
+## Native build and Live handoffs
+
+These commands cross the passive boundary:
+
+```sh
+bun run bb-mate check "$plugin"
+bun run bb-mate live "$plugin"
+```
+
+`check` delegates exactly `bb plugin build .` in the selected plugin and then
+refreshes the compatibility report. It can execute the plugin's build toolchain
+and writes native build artifacts.
+
+`live` delegates exactly `bb plugin dev .` only after native bb proves that the
+same real plugin path is installed. If it is not installed, BB Mate prints the
+exact `bb plugin install <path> --yes` handoff and exits; it does not run the
+installation. Native dev executes full-trust plugin code and may reload the
+installed plugin. Review the [trust and operation model](trust-model.md) before
+using either command on code you do not trust.
+
+Set `BB_CLI` to an exact executable when you need to override the `bb` found on
+`PATH`:
+
+```sh
+BB_CLI=/absolute/path/to/bb bun run bb-mate inspect "$plugin"
+```
+
+## Use the local alpha artifact
+
+The private package supports Fixture exploration outside the source checkout:
+
+```sh
+bun run package:artifact
+plugin="/absolute/path/to/plugin"
+prefix="$(mktemp -d)"
+npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.0.tgz
+"$prefix/node_modules/.bin/bb-mate" --help
+"$prefix/node_modules/.bin/bb-mate" dev "$plugin"
+npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
+```
+
+The installed `dev` serves the packaged static lab rather than the source Vite
+workbench. It binds only to loopback and does not serve inspection data. The
+archive remains private, `UNLICENSED`, and unsupported for registry publication.
+The reproducible artifact and clean-room lifecycle are specified in
+[local-package.md](local-package.md).
+
+## Plugin package boundary
+
+A plugin is an independently versioned package, not a BB Mate workspace
+manifest. The expected boundary is:
+
+```text
+my-plugin/
+  package.json       name, version, engines, and public bb manifest
+  server.ts          optional server entrypoint declared by bb.server
+  app.tsx            optional frontend entrypoint declared by bb.app
+  tests/              package-owned tests
+  assets/             package-owned assets
+  dist/               native bb build metadata and bundles
+```
+
+Declare honest `engines.bb` and `engines.bbPluginSdk` ranges. Frontend adapters
+that import `@bb/plugin-sdk/app` belong inside the plugin entrypoint or a thin
+plugin-owned adapter because that runtime exists only inside bb. Reusable visual
+components should stay host-neutral; add a shared BB Mate package only after two
+real consumers need the same boundary.
+
+Do not import application internals, copy the plugin SDK or testing harness, or
+depend on `../bb`. Use native bb scaffolding and declaration refresh. If an
+official testing package cannot resolve from the selected plugin's installed
+dependencies, Harness is unavailable.
+
+## Confidence levels
+
+| Level   | What it proves                                      | What it does not prove                         |
+| ------- | --------------------------------------------------- | ---------------------------------------------- |
+| Fixture | Deterministic component state and bounded visuals   | Public SDK behavior, host CSS, or integration  |
+| Harness | Public behavior through official testing contracts  | Exact host chrome, layout, routing, or runtime |
+| Live bb | Real plugin integration inside the supported bb app | Compatibility with untested future bb releases |
+
+Fixture is intentionally an approximation. Harness stays disabled until both
+the official `@bb/plugin-sdk/testing` package resolves and BB Mate has an
+upstream-backed adapter. Live bb is the visual authority because bb owns the
+actual host layout, styling, routing, state, action lifecycle, and runtime.
+
+## Before you contribute or ask for support
+
+- Run the compatibility checker and read its target assumptions:
+
+  ```sh
+  bun run compatibility:check
+  ```
+
+- Follow [CONTRIBUTING.md](../CONTRIBUTING.md) for change and verification
+  requirements.
+- Use [SUPPORT.md](../SUPPORT.md) to determine whether a bb/SDK combination is
+  in scope.
+- Read [SECURITY.md](../SECURITY.md) before reporting a vulnerability or
+  handling plugin secrets.
+
+The copyable non-mutating paths above are covered by clean-runner CI, the
+13-story browser matrix, and the isolated package lifecycle. Native mutation
+handoffs are unit-tested for exact argv and remain user-invoked; this guide does
+not silently exercise them.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,0 +1,72 @@
+# Trust and operation model
+
+BB Mate does not sandbox plugins. A bb plugin is full-trust local code once its
+entrypoints, build toolchain, or native runtime are executed. Treat a plugin
+repository like any other program you might run on your machine: review its
+source and dependencies first, and use a disposable environment for unknown
+code.
+
+## What inspection can and cannot disclose
+
+Passive inspection reads supported manifests and generated metadata. It can
+list declared entrypoints, settings, skills, themes, capabilities, and services;
+it cannot prove that a plugin avoids general filesystem, network, secret, or
+external-service access. Those accesses remain explicitly undisclosed unless
+the plugin author documents them.
+
+Inspection may call read-only native commands for bb version, plugin state, and
+Connect status/shares, and may query the npm registry for public SDK status. It
+does not import the plugin, install it, build it, mount content scripts, expose
+Connect, or pair an account.
+
+## Operation matrix
+
+| Operation                                        | Executes code                                                                   | Reads local data                                 | Network/listener                                                           | Mutation                                                               |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `bun install --frozen-lockfile`                  | Bun and dependency install scripts permitted by the package manager             | manifests and lockfile                           | may download dependencies                                                  | writes `node_modules` and caches; no bb mutation                       |
+| `bun --filter @bb-mate/workbench stories ...`    | BB Mate and development dependencies                                            | checked-out Fixture source                       | loopback HTTP listener by default                                          | build/tool caches only; no selected plugin or bb state                 |
+| `bun run bb-mate --help`                         | BB Mate CLI                                                                     | CLI bundle/source only                           | none                                                                       | none                                                                   |
+| `bun run bb-mate inspect <path>`                 | BB Mate plus passive native bb commands; never the plugin entrypoint            | plugin manifest/build metadata and native status | may query npm; passive Connect status only                                 | none                                                                   |
+| `bun run bb-mate dev <path>`                     | passive inspection plus BB Mate's source Vite server or packaged static server  | Fixture assets and passive plugin metadata       | HTTP listener at the requested host; reports existing shares               | no install/build/reload, Connect expose/pair, or plugin entrypoint     |
+| `bun run bb-mate check <path>`                   | all of the above plus native `bb plugin build .` and the plugin build toolchain | selected plugin tree                             | whatever the build toolchain performs                                      | writes native build artifacts; does not install the plugin             |
+| `bun run bb-mate live <path>`                    | native `bb plugin dev .` and full plugin runtime                                | whatever bb and the plugin can access            | whatever bb and the plugin perform                                         | may reload the already installed path plugin and change runtime state  |
+| printed `bb plugin install <path> --yes` handoff | not executed by BB Mate                                                         | none until the author runs it                    | none until run                                                             | author-run command installs/mutates native plugin state                |
+| `bun run package:*`                              | BB Mate packaging scripts and dependency build tools                            | repository and dependency metadata               | install/test may use npm as documented                                     | writes ignored artifacts and isolated temporary state; never publishes |
+| `bun run test`, `build`, or `visual:test`        | repository/test/build code and dependencies                                     | repository Fixture/test source                   | local test servers; compatibility probes may use public upstream endpoints | build/test artifacts only; no supported native bb mutation             |
+
+`--host` on source-checkout `dev` is an explicit exposure choice for the Fixture
+server. The packaged lab rejects non-loopback hosts. Neither path authenticates
+clients, so do not serve sensitive fixture data or bind an untrusted interface.
+
+## Content scripts
+
+Content scripts are the highest-risk frontend surface because Live bb mounts
+them into the host application lifecycle. The surface lab renders only inert
+descriptions of their declared inputs and outcomes; ordinary discovery and
+Fixture rendering never call `mountPluginContentScripts` or import a plugin
+entrypoint. Only validate real content-script behavior in the official Harness
+when available or in a controlled Live bb profile.
+
+## Secrets and external services
+
+- Never put real tokens or customer data in fixtures, screenshots, issue
+  comments, logs, or test snapshots.
+- Keep secrets in native bb's supported settings/secret facilities; BB Mate
+  does not provide a second credential store.
+- Assume plugin server code can read the invoking user's files and environment
+  and can make network requests unless its implementation proves otherwise.
+- Treat copied terminal commands as code. Inspect the exact target and current
+  directory before running them.
+- Do not remove and reinstall a managed plugin merely to retarget its source;
+  that can discard settings or secrets. Use a preserve-state native route or
+  re-enter credentials intentionally.
+
+## Security boundary
+
+The browser does not receive raw plugin roots or incidental absolute paths.
+Opaque candidate keys are resolved server-side, browser reports redact path
+hierarchy, and no HTTP endpoint executes native actions. These controls reduce
+accidental disclosure; they do not turn BB Mate or plugins into untrusted-code
+sandboxes.
+
+Report suspected boundary failures using [SECURITY.md](../SECURITY.md).

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -21,22 +21,29 @@ Connect, or pair an account.
 
 ## Operation matrix
 
-| Operation                                        | Executes code                                                                   | Reads local data                                 | Network/listener                                                           | Mutation                                                               |
-| ------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `bun install --frozen-lockfile`                  | Bun and dependency install scripts permitted by the package manager             | manifests and lockfile                           | may download dependencies                                                  | writes `node_modules` and caches; no bb mutation                       |
-| `bun --filter @bb-mate/workbench stories ...`    | BB Mate and development dependencies                                            | checked-out Fixture source                       | loopback HTTP listener by default                                          | build/tool caches only; no selected plugin or bb state                 |
-| `bun run bb-mate --help`                         | BB Mate CLI                                                                     | CLI bundle/source only                           | none                                                                       | none                                                                   |
-| `bun run bb-mate inspect <path>`                 | BB Mate plus passive native bb commands; never the plugin entrypoint            | plugin manifest/build metadata and native status | may query npm; passive Connect status only                                 | none                                                                   |
-| `bun run bb-mate dev <path>`                     | passive inspection plus BB Mate's source Vite server or packaged static server  | Fixture assets and passive plugin metadata       | HTTP listener at the requested host; reports existing shares               | no install/build/reload, Connect expose/pair, or plugin entrypoint     |
-| `bun run bb-mate check <path>`                   | all of the above plus native `bb plugin build .` and the plugin build toolchain | selected plugin tree                             | whatever the build toolchain performs                                      | writes native build artifacts; does not install the plugin             |
-| `bun run bb-mate live <path>`                    | native `bb plugin dev .` and full plugin runtime                                | whatever bb and the plugin can access            | whatever bb and the plugin perform                                         | may reload the already installed path plugin and change runtime state  |
-| printed `bb plugin install <path> --yes` handoff | not executed by BB Mate                                                         | none until the author runs it                    | none until run                                                             | author-run command installs/mutates native plugin state                |
-| `bun run package:*`                              | BB Mate packaging scripts and dependency build tools                            | repository and dependency metadata               | install/test may use npm as documented                                     | writes ignored artifacts and isolated temporary state; never publishes |
-| `bun run test`, `build`, or `visual:test`        | repository/test/build code and dependencies                                     | repository Fixture/test source                   | local test servers; compatibility probes may use public upstream endpoints | build/test artifacts only; no supported native bb mutation             |
+| Operation                                        | Executes code                                                                        | Reads local data                                 | Network/listener                                                     | Mutation                                                               |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `bun install --frozen-lockfile`                  | Bun and dependency install scripts permitted by the package manager                  | manifests and lockfile                           | may download dependencies                                            | writes `node_modules` and caches; no bb mutation                       |
+| `bun --filter @bb-mate/workbench stories ...`    | BB Mate and development dependencies                                                 | checked-out Fixture source                       | loopback HTTP listener by default                                    | build/tool caches only; no selected plugin or bb state                 |
+| `bun run bb-mate --help`                         | BB Mate CLI                                                                          | CLI bundle/source only                           | none                                                                 | none                                                                   |
+| `bun run bb-mate inspect <path>`                 | BB Mate plus passive native bb commands; never the plugin entrypoint                 | plugin manifest/build metadata and native status | may query npm; passive Connect status only                           | none                                                                   |
+| `bun run bb-mate dev <path>`                     | passive inspection plus BB Mate's source Vite server or packaged static server       | Fixture assets and passive plugin metadata       | HTTP listener at the requested host; reports existing shares         | no install/build/reload, Connect expose/pair, or plugin entrypoint     |
+| `bun run bb-mate check <path>`                   | all of the above plus native `bb plugin build .` and the plugin build toolchain      | selected plugin tree                             | whatever the build toolchain performs                                | writes native build artifacts; does not install the plugin             |
+| `bun run bb-mate live <path>`                    | native `bb plugin dev .` and full plugin runtime                                     | whatever bb and the plugin can access            | whatever bb and the plugin perform                                   | may reload the already installed path plugin and change runtime state  |
+| printed `bb plugin install <path> --yes` handoff | not executed by BB Mate                                                              | none until the author runs it                    | none until run                                                       | author-run command installs/mutates native plugin state                |
+| `bun run package:*`                              | BB Mate packaging scripts and dependency build tools                                 | repository and dependency metadata               | install/test may use npm as documented                               | writes ignored artifacts and isolated temporary state; never publishes |
+| `bun run check` or `compatibility:check`         | repository check code and the passive compatibility probes                           | manifests, target record, and public metadata    | queries the immutable public upstream and npm evidence in the target | none beyond tool caches; no native bb mutation                         |
+| root `bun run test` or `bun run build`           | every workspace's scripts, including plugin-owned tests and native `bb plugin build` | repository and plugin source                     | whatever a plugin-owned test/build toolchain performs                | test/build output including plugin `dist`; no install/reload           |
+| `bun run visual:test`                            | deterministic Fixture browser/test code and dependencies                             | Fixture source and checked-in baselines          | loopback test server                                                 | test output only; no selected plugin or native bb state                |
 
-`--host` on source-checkout `dev` is an explicit exposure choice for the Fixture
-server. The packaged lab rejects non-loopback hosts. Neither path authenticates
-clients, so do not serve sensitive fixture data or bind an untrusted interface.
+`--host` on source-checkout `dev` is an explicit exposure choice. Its
+unauthenticated `/bb-mate-session.json` endpoint lets any client trigger bounded
+read-only bb version/plugin-list/Connect status/share processes and an npm SDK
+lookup, then returns redacted plugin/native/Connect metadata. Connect and share
+URLs remain URLs after path redaction. Keep source dev on loopback unless you
+intend to expose both the Fixture server and that inspection surface. The
+packaged lab is different: it rejects non-loopback hosts, serves static Fixture
+assets only, and has no session endpoint.
 
 ## Content scripts
 
@@ -64,9 +71,10 @@ when available or in a controlled Live bb profile.
 ## Security boundary
 
 The browser does not receive raw plugin roots or incidental absolute paths.
-Opaque candidate keys are resolved server-side, browser reports redact path
-hierarchy, and no HTTP endpoint executes native actions. These controls reduce
-accidental disclosure; they do not turn BB Mate or plugins into untrusted-code
-sandboxes.
+Opaque candidate keys are resolved server-side, and source-workbench reports
+redact path hierarchy. No HTTP endpoint executes a native mutation or plugin
+entrypoint; the source session endpoint does execute the bounded read-only
+inspection described above. These controls reduce accidental disclosure; they
+do not turn BB Mate or plugins into untrusted-code sandboxes.
 
 Report suspected boundary failures using [SECURITY.md](../SECURITY.md).

--- a/scripts/package-clean-room.ts
+++ b/scripts/package-clean-room.ts
@@ -365,6 +365,17 @@ try {
       `Artifact leaks an absolute developer path in ${file}.`,
     );
   }
+  const labJavaScript = (
+    await Promise.all(
+      extractedFiles
+        .filter((file) => file.startsWith("dist/lab/") && file.endsWith(".js"))
+        .map((file) => fs.readFile(path.join(extractedPackage, file), "utf8")),
+    )
+  ).join("\n");
+  assert(
+    labJavaScript.includes("bb-mate-surface-lab-v1"),
+    "Packaged Ladle must use the checkout-independent application ID.",
+  );
 
   const copiedArtifact = path.join(temporaryRoot, artifactName);
   await fs.copyFile(artifactPath, copiedArtifact);


### PR DESCRIPTION
Context
#38 needs a self-contained private-alpha path for external plugin authors plus explicit trust, support, compatibility, and licensing boundaries.

What changed
- add a five-minute Fixture quickstart and full source/artifact author workflows
- document the full-trust execution, filesystem, network, secret, native bb, and Connect boundaries
- add contribution, security, support, deprecation, and private-license policies
- make packaged Ladle output checkout-independent with a stable application ID and a clean-room regression assertion

Verification
- bun run format:check
- bun run check
- bun run test: 172 tests
- bun run build
- bun run visual:test: 14 Playwright and axe checks
- clean source and isolated artifact workflows, 40 files and 13 stories, SHA-256 b8b2f756215c01413f110cc2a31d85484fa243a2d019676aa2141d834d3c2479
- standing and targeted reviews approved 5/5 with no P0-P3 findings

Boundaries
No publication, tag, release, repository visibility change, announcement, public license selection, upstream bb edit, normal plugin mutation, or Connect mutation.

## Issue

Implements #38 under roadmap #21.