### PR TITLE
fix: preserve native bb handoffs in clean profiles

### DIFF
--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -206,6 +206,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: Trial finding F-1 (P1) is fixed with focused tests for selector removal and captured-child environment preservation. All 13 surfaces, ownership classifications, inert content-script behavior, and Vite HMR were verified in Chrome.
 - Next: Commit the correction and report, rerun the entire journey from a new clean archive, then complete standing and targeted review.
 - Blockers: None; Harness remains expected upstream-dependent.
+
+2026-08-07 - OS-637 independent scratch rerun green
+- Changed: Exported committed candidate e9b0f60 into a second Git-less source root with new profile, install prefix, plugin, bb data, ports, and browser servers. Repeated every source, artifact, compatibility, native, Live, and cleanup step without reusing first-run state.
+- Verified: Frozen install completed in 11.8 seconds; Chrome discovered all 13 stories, ownership classes, inert content-script behavior, and fixture HMR. The artifact reproduced SHA-256 `fc99a5161ad0890706d03306de32248174aa3ead67b3daf334932f6868214a07`; isolated bb 0.35.1 inspection and check passed; Live refused the uninstalled path with the exact handoff; packaged preview and uninstall passed.
+- Result: The F-1 P1 correction survives a true first-run environment. No P0/P1 finding remains, no plugin was installed, Connect stayed unpaired, and normal bb/plugin state was not used.
+- Next: Run the repository aggregate and standing/fresh-targeted reviews, fix all findings, then open the draft PR.
+- Blockers: None inside the private-alpha scope.
 ```
 
 ## Preparation Audits
@@ -307,6 +314,7 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-637 clean source/browser trial                                               | OS-637 first run     | pass                 | 13 stories; ownership; inert lifecycle; HMR observed       |
 | OS-637 native probe before correction                                           | OS-637 first run     | expected failure     | leaked `BB_CLI`; four five-second native timeouts          |
 | OS-637 fixed isolated native lane                                               | OS-637 correction    | pass                 | bb 0.35.1; build green; guarded Live handoff               |
+| OS-637 second scratch rerun                                                     | OS-637 final trial   | pass                 | new roots; 13 stories; HMR; native build; uninstall        |
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -192,6 +192,20 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Review: Standing `tmp/reviews/standing/os-636-round-2.json`; targeted `tmp/reviews/targeted-os636/round-2.json`.
 - Next: Commit the approved corrections, open the draft PR, follow hosted CI and review threads, then land and reconcile OS-636 before starting OS-637.
 - Blockers: None.
+
+2026-08-07 - OS-636 landed and OS-637 started
+- Changed: Promoted and merged PR #11, reconciled GitButler to a clean lane-free main, closed OS-636, and opened the Linear-recommended OS-637 branch.
+- Verified: PR CI 31230755681 and post-merge main CI 31230856034 both passed verify and visual; GitGuardian passed; PR #11 had no reviews, inline comments, or unresolved review threads.
+- Result: OS-636 is Done at merge commit `b2d5c203e7ee2f69314a5babbe2097260c87a4d0`. OS-637 is unblocked and scoped to disposable clean-room state only.
+- Next: Execute the external-author trial from a fresh temporary profile, fix all P0/P1 friction, and rerun before review.
+- Blockers: None inside the private-alpha scope.
+
+2026-08-07 - OS-637 clean-room trial found and fixed native re-exec loop
+- Changed: Ran the source, packaged, browser, compatibility, native build, and guarded Live journey from disposable state. Added an explicit environment boundary so BB Mate consumes `BB_CLI` without forwarding bb's own re-exec selector into the resolved child.
+- Verified: Before the fix, all four native probes timed out at five seconds while the same bb 0.35.1 executable succeeded directly. After the fix, the isolated native host reported bb 0.35.1 and unpaired Connect, `check` built server/app metadata at SDK 0.4.1, and `live` refused the uninstalled plugin with the exact path-install handoff.
+- Result: Trial finding F-1 (P1) is fixed with focused tests for selector removal and captured-child environment preservation. All 13 surfaces, ownership classifications, inert content-script behavior, and Vite HMR were verified in Chrome.
+- Next: Commit the correction and report, rerun the entire journey from a new clean archive, then complete standing and targeted review.
+- Blockers: None; Harness remains expected upstream-dependent.
 ```
 
 ## Preparation Audits
@@ -288,6 +302,11 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | Git-less export Playwright/axe and link audit                                   | OS-636 clean source  | pass                 | 14 browser checks; 21 Markdown files                       |
 | `bun run format:check && bun run check && bun run test && bun run build`        | OS-636 final         | pass                 | 172 tests; package SHA `b8b2f756…c2479`                    |
 | macOS Playwright/axe matrix (14 tests)                                          | OS-636 final         | pass                 | unchanged visual and accessibility baselines               |
+| Hosted CI 31230755681                                                           | OS-636 PR            | pass                 | verify, visual, and GitGuardian green                      |
+| Hosted CI 31230856034                                                           | OS-636 main          | pass                 | post-merge verify and visual green                         |
+| OS-637 clean source/browser trial                                               | OS-637 first run     | pass                 | 13 stories; ownership; inert lifecycle; HMR observed       |
+| OS-637 native probe before correction                                           | OS-637 first run     | expected failure     | leaked `BB_CLI`; four five-second native timeouts          |
+| OS-637 fixed isolated native lane                                               | OS-637 correction    | pass                 | bb 0.35.1; build green; guarded Live handoff               |
 
 ## Prompt / Goal Alignment
 
@@ -308,8 +327,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-634 | Done        | PR #8 merged at `f14afd3`; main CI 31222879164 green  |
 | OS-632 | Done        | PR #9 merged at `9f2aa0c`; main CI 31226118637 green  |
 | OS-635 | Done        | PR #10 merged at `544d9b1`; main CI 31229355120 green |
-| OS-636 | In Progress | Final local candidate approved; PR and CI remain      |
-| OS-637 | Todo        | Blocked by OS-632/634/635/636                         |
+| OS-636 | Done        | PR #11 merged at `b2d5c20`; main CI 31230856034 green |
+| OS-637 | In Progress | Clean-room external-author trial                      |
 | OS-638 | Todo        | Blocked by OS-629/637; final ready PR only            |
 
 ## Follow-Ups

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -213,6 +213,20 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The F-1 P1 correction survives a true first-run environment. No P0/P1 finding remains, no plugin was installed, Connect stayed unpaired, and normal bb/plugin state was not used.
 - Next: Run the repository aggregate and standing/fresh-targeted reviews, fix all findings, then open the draft PR.
 - Blockers: None inside the private-alpha scope.
+
+2026-08-07 - OS-637 round-one review found a source native-selection regression
+- Changed: Standing and fresh targeted reviewers traced the full production runtime and reproduced that the first F-1 correction stripped canonical `BB_CLI` from the non-native source Vite child. Both also found that the durable report did not fully define the isolated native setup; targeted review additionally requested explicit uninstall-residue evidence.
+- Verified: Both reviewers scored the branch 2/5 and blocked readiness. Standing reproduced terminal bb 0.35.1 preflight followed by blocked browser inspection with no bb version. Targeted confirmed the aggregate remained green at 174 tests, 40 files, 13 stories, and SHA-256 `fc99a5161ad0890706d03306de32248174aa3ead67b3daf334932f6868214a07`.
+- Review: Standing `tmp/reviews/standing/os-637-round-1.json`; targeted `tmp/reviews/targeted-os637/round-1.json`.
+- Next: Consume selectors only at native invocations, preserve canonical bb for Vite, commit the complete clean-room runbook and uninstall evidence, rerun isolated source/native paths, and request round two.
+- Blockers: OS-637 remains blocked by the open P1 until the corrected production path and reviews pass.
+
+2026-08-07 - OS-637 review corrections and isolated rerun green
+- Changed: Moved selector consumption into the shared native invocation boundary, preserved a freshly resolved canonical `BB_CLI` for the source Vite child, added direct source/check/live environment assertions, and committed the complete clean-profile/native runbook plus uninstall-residue evidence.
+- Verified: With `BB_CLI_REEXEC=1` deliberately present, terminal preflight and the source `/bb-mate-session.json` both reported isolated bb 0.35.1 and unpaired Connect. Native check rebuilt SDK 0.4.1 metadata; Live refused the uninstalled plugin with the exact handoff; isolated inventory remained eight builtins only. The aggregate passed 175 tests, all builds, all 14 Playwright/axe checks, and produced a 40-file/13-story artifact at SHA-256 `0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e`.
+- Result: Both round-one P1/P2 findings and the targeted P3 are corrected in code, tests, durable procedure, and current runtime evidence. No normal plugin or Connect state was used or changed.
+- Next: Commit the corrections and request standing plus fresh-targeted round-two approval.
+- Blockers: None pending independent review.
 ```
 
 ## Preparation Audits
@@ -315,6 +329,9 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-637 native probe before correction                                           | OS-637 first run     | expected failure     | leaked `BB_CLI`; four five-second native timeouts          |
 | OS-637 fixed isolated native lane                                               | OS-637 correction    | pass                 | bb 0.35.1; build green; guarded Live handoff               |
 | OS-637 second scratch rerun                                                     | OS-637 final trial   | pass                 | new roots; 13 stories; HMR; native build; uninstall        |
+| OS-637 standing review round one                                                | OS-637 review        | changes requested    | 2/5; P1 source selector; P2 missing runbook                |
+| OS-637 targeted review round one                                                | OS-637 review        | changes requested    | 2/5; same P1/P2 plus P3 uninstall evidence                 |
+| OS-637 corrected production source/native rerun                                 | OS-637 correction    | pass                 | browser bb 0.35.1; 175 tests; SHA `0e5503f…d00e`           |
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -227,6 +227,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: Both round-one P1/P2 findings and the targeted P3 are corrected in code, tests, durable procedure, and current runtime evidence. No normal plugin or Connect state was used or changed.
 - Next: Commit the corrections and request standing plus fresh-targeted round-two approval.
 - Blockers: None pending independent review.
+
+2026-08-07 - OS-637 final standing and targeted review clean
+- Changed: Iterated the executable clean-room runbook through literal clean-archive probes: exact GitButler branch provenance, complete empty-shell tool paths, five endpoint assignments, source/package readiness polling, hidden npm lock semantics, and reliable process-tree teardown with TERM grace plus KILL fallback.
+- Verified: Standing round three and targeted round four approved exact head `0fefc5535320ae3f0b01398c9520d673e1ca2700` at 5/5 with zero P0-P3 findings. Both reproduced the 13-story Bun/Ladle lane and verified the wrapper/child exited, `wait` settled, and port 61047 closed. All six OS-637 acceptance criteria pass; the unchanged production tree remains green at 175 tests, all builds, 14 Playwright/axe checks, and artifact SHA-256 `0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e`.
+- Review: Standing `tmp/reviews/standing/os-637-round-3.json`; targeted `tmp/reviews/targeted-os637/round-4.json`.
+- Next: Open the draft PR, follow hosted CI and all review threads, then ready/land and reconcile Linear.
+- Blockers: None.
 ```
 
 ## Preparation Audits
@@ -332,6 +339,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-637 standing review round one                                                | OS-637 review        | changes requested    | 2/5; P1 source selector; P2 missing runbook                |
 | OS-637 targeted review round one                                                | OS-637 review        | changes requested    | 2/5; same P1/P2 plus P3 uninstall evidence                 |
 | OS-637 corrected production source/native rerun                                 | OS-637 correction    | pass                 | browser bb 0.35.1; 175 tests; SHA `0e5503f…d00e`           |
+| OS-637 standing review round three                                              | OS-637 final review  | 5/5 clean            | zero P0-P3; literal process-tree shutdown passed           |
+| OS-637 targeted review round four                                               | OS-637 final review  | 5/5 clean            | all six acceptance criteria passed                         |
 
 ## Prompt / Goal Alignment
 

--- a/.agents/plans/2026-08-07-os-636-author-guide-trust-support.md
+++ b/.agents/plans/2026-08-07-os-636-author-guide-trust-support.md
@@ -56,7 +56,7 @@ compatibility, mutation, support, and private-license boundaries unambiguous.
       contribution/security documents.
 - [x] Verify every copyable command in clean source and artifact environments.
 - [x] Complete aggregate gates and standing/fresh-targeted review.
-- [ ] Land the PR, verify main CI, and move OS-636 to Done.
+- [x] Land the PR, verify main CI, and move OS-636 to Done.
 
 ## Completion
 

--- a/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
+++ b/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
@@ -1,0 +1,69 @@
+# OS-637 clean-room external-author alpha trial
+
+## Outcome
+
+Prove that a first-time plugin author can use the private local alpha from a
+fresh, reproducible environment by following only the author-facing docs, and
+turn every material point of friction into a verified fix or an explicit
+release blocker.
+
+## Slice
+
+1. Build and install the local artifact into an isolated temporary prefix with
+   no sibling bb checkout, BB Mate symlink, saved secret, or inherited project
+   configuration.
+2. Create a deterministic example plugin outside the repository and exercise
+   discovery, inspection, all catalog surfaces, URL-backed fixture controls,
+   and fixture edit/reload.
+3. Run compatibility and native checks with an explicitly provisioned bb
+   0.35.1 binary. Keep native build/live activity confined to the temporary
+   fixture plugin and record expected unavailable states as actionable output.
+4. Capture elapsed milestones, commands, versions, successes, failures,
+   terminology friction, undocumented assumptions, and decisions in a concise
+   sanitized report.
+5. Fix every P0/P1 finding, rerun the trial from a new temporary root, and
+   obtain standing plus fresh targeted external-author review before landing.
+
+## Boundaries
+
+- No publish, tag, release, repository-visibility change, announcement, public
+  license choice, or upstream bb edit.
+- No existing user plugin, normal bb configuration, saved secret, or Connect
+  expose/pair/share state may be changed.
+- Native operations may target only the disposable trial plugin and disposable
+  configuration created for this issue; no plugin installation is required to
+  prove an actionable Live handoff.
+- Harness remains expected unavailable until the official public testing
+  package and a BB Mate adapter resolve.
+- Live bb remains the visual authority; fixture discovery is not parity proof.
+
+## Verification
+
+- Run the exact documented setup from a fresh temporary root.
+- Prove the installed archive, source checkout, sibling bb checkout, secrets,
+  and implicit shell configuration are absent from the trial root.
+- Discover all 13 catalog surfaces and distinguish host-owned, plugin-owned,
+  lifecycle-only, and unavailable surfaces.
+- Modify a deterministic fixture, observe served output change, then restore
+  or discard the disposable workspace.
+- Exercise compatibility, inspection, check, and Live handoff outcomes against
+  only the disposable plugin.
+- Run `bun run format:check && bun run check && bun run test && bun run build`
+  and all 14 Playwright/axe checks.
+- Complete standing and fresh targeted review, then draft PR, hosted CI/thread
+  audit, ready/merge, post-merge main CI, and Linear Done.
+
+## Progress
+
+- [x] Build the reproducible clean-room trial harness and sanitized report.
+- [x] Run the first-time author journey and triage every finding.
+- [ ] Fix all P0/P1 and reasonable P2/P3 friction, then rerun from scratch.
+- [ ] Complete aggregate gates and standing/fresh-targeted review.
+- [ ] Land the PR, verify main CI, and move OS-637 to Done.
+
+## Completion
+
+Complete when the clean-room report proves the documented alpha journey from a
+fresh environment, contains no private path or secret, has no open P0/P1
+finding, and leaves expected upstream-dependent modes as clear actionable
+handoffs rather than dead ends.

--- a/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
+++ b/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
@@ -57,7 +57,7 @@ release blocker.
 
 - [x] Build the reproducible clean-room trial harness and sanitized report.
 - [x] Run the first-time author journey and triage every finding.
-- [ ] Fix all P0/P1 and reasonable P2/P3 friction, then rerun from scratch.
+- [x] Fix all P0/P1 and reasonable P2/P3 friction, then rerun from scratch.
 - [ ] Complete aggregate gates and standing/fresh-targeted review.
 - [ ] Land the PR, verify main CI, and move OS-637 to Done.
 

--- a/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
+++ b/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
@@ -58,7 +58,7 @@ release blocker.
 - [x] Build the reproducible clean-room trial harness and sanitized report.
 - [x] Run the first-time author journey and triage every finding.
 - [x] Fix all P0/P1 and reasonable P2/P3 friction, then rerun from scratch.
-- [ ] Complete aggregate gates and standing/fresh-targeted review.
+- [x] Complete aggregate gates and standing/fresh-targeted review.
 - [ ] Land the PR, verify main CI, and move OS-637 to Done.
 
 ## Completion

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -45,11 +45,7 @@ const runtime: CliRuntime = {
     runCapturedCommand(executable, args, cwd, {
       env: nativeCommandEnv(process.env),
     }),
-  runInherited: (executable, args, options) =>
-    runInheritedCommand(executable, args, {
-      ...options,
-      env: nativeCommandEnv(options.env),
-    }),
+  runInherited: runInheritedCommand,
 };
 
 const result = await runCli(process.argv.slice(2), runtime);

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runCli, type CliRuntime } from "./commands.ts";
 import {
+  nativeCommandEnv,
   resolveBbExecutable,
   runCapturedCommand,
   runInheritedCommand,
@@ -40,8 +41,15 @@ const runtime: CliRuntime = {
   stderr: (value) => process.stderr.write(value),
   resolveBb: () =>
     resolveBbExecutable({ cwd: process.cwd(), env: process.env }),
-  runCaptured: runCapturedCommand,
-  runInherited: runInheritedCommand,
+  runCaptured: (executable, args, cwd) =>
+    runCapturedCommand(executable, args, cwd, {
+      env: nativeCommandEnv(process.env),
+    }),
+  runInherited: (executable, args, options) =>
+    runInheritedCommand(executable, args, {
+      ...options,
+      env: nativeCommandEnv(options.env),
+    }),
 };
 
 const result = await runCli(process.argv.slice(2), runtime);

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -195,6 +195,11 @@ describe("bb-mate CLI", () => {
       options: { cwd: string; env: NodeJS.ProcessEnv };
     }> = [];
     const testRuntime = runtime(root, nativeOutput(pluginRoot), {
+      env: {
+        BB_CLI: "/daemon/managed/bb",
+        BB_CLI_REEXEC: "1",
+        BB_MATE_SENTINEL: "preserved",
+      },
       runInherited: async (executable, args, options) => {
         launches.push({ executable, args, options });
         return { exitCode: 0, signal: null };
@@ -227,6 +232,7 @@ describe("bb-mate CLI", () => {
           env: {
             BB_CLI: "/fake/bin/bb",
             BB_MATE_PLUGIN: pluginRoot,
+            BB_MATE_SENTINEL: "preserved",
             BB_MATE_WORKSPACE: root,
           },
         },
@@ -434,10 +440,21 @@ describe("bb-mate CLI", () => {
       executable: string;
       args: readonly string[];
       cwd: string;
+      env: NodeJS.ProcessEnv;
     }> = [];
     const testRuntime = runtime(pluginRoot, nativeOutput(pluginRoot), {
+      env: {
+        BB_CLI: "/daemon/managed/bb",
+        BB_CLI_REEXEC: "1",
+        BB_MATE_SENTINEL: "preserved",
+      },
       runInherited: async (executable, args, options) => {
-        delegated.push({ executable, args, cwd: options.cwd });
+        delegated.push({
+          executable,
+          args,
+          cwd: options.cwd,
+          env: options.env,
+        });
         await fs.mkdir(path.join(pluginRoot, "dist"));
         await fs.writeFile(
           path.join(pluginRoot, "dist", "server.meta.json"),
@@ -462,6 +479,7 @@ describe("bb-mate CLI", () => {
         executable: "/fake/bin/bb",
         args: ["plugin", "build", "."],
         cwd: pluginRoot,
+        env: { BB_MATE_SENTINEL: "preserved" },
       },
     ]);
     expect(testRuntime.stdout.join("")).toContain("Running: bb plugin build .");
@@ -486,10 +504,19 @@ describe("bb-mate CLI", () => {
 
   test("hands an installed path plugin to native live development", async () => {
     const { pluginRoot } = await createPlugin();
-    const delegated: Array<{ args: readonly string[]; cwd: string }> = [];
+    const delegated: Array<{
+      args: readonly string[];
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+    }> = [];
     const testRuntime = runtime(pluginRoot, nativeOutput(pluginRoot, true), {
+      env: {
+        BB_CLI: "/daemon/managed/bb",
+        BB_CLI_REEXEC: "1",
+        BB_MATE_SENTINEL: "preserved",
+      },
       runInherited: async (_executable, args, options) => {
-        delegated.push({ args, cwd: options.cwd });
+        delegated.push({ args, cwd: options.cwd, env: options.env });
         return { exitCode: null, signal: "SIGTERM" };
       },
     });
@@ -498,7 +525,11 @@ describe("bb-mate CLI", () => {
 
     expect(result).toEqual({ exitCode: null, signal: "SIGTERM" });
     expect(delegated).toEqual([
-      { args: ["plugin", "dev", "."], cwd: pluginRoot },
+      {
+        args: ["plugin", "dev", "."],
+        cwd: pluginRoot,
+        env: { BB_MATE_SENTINEL: "preserved" },
+      },
     ]);
     expect(testRuntime.stdout.join("")).toContain("Running: bb plugin dev .");
   });

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -4,6 +4,7 @@ import {
   discoverPluginRoots,
   formatInspection,
   inspectPlugin,
+  nativeCommandEnv,
   type CommandResult,
   type PluginInspection,
 } from "@bb-mate/inspection";
@@ -228,7 +229,7 @@ export async function runCli(
       {
         cwd: runtime.workspaceRoot,
         env: {
-          ...runtime.env,
+          ...nativeCommandEnv(runtime.env),
           BB_MATE_WORKSPACE: runtime.cwd,
           ...(pluginRoot ? { BB_MATE_PLUGIN: pluginRoot } : {}),
           ...(context.bbExecutable ? { BB_CLI: context.bbExecutable } : {}),
@@ -245,7 +246,7 @@ export async function runCli(
     const build = await runtime.runInherited(
       context.bbExecutable,
       ["plugin", "build", "."],
-      { cwd: pluginRoot, env: runtime.env },
+      { cwd: pluginRoot, env: nativeCommandEnv(runtime.env) },
     );
     if (build.signal || build.exitCode !== 0) return build;
     const refreshed = await inspectSelection(runtime, pluginRoot);
@@ -272,7 +273,7 @@ export async function runCli(
     line(runtime.stdout, "Running: bb plugin dev .");
     return runtime.runInherited(context.bbExecutable, ["plugin", "dev", "."], {
       cwd: pluginRoot,
-      env: runtime.env,
+      env: nativeCommandEnv(runtime.env),
     });
   }
 

--- a/apps/cli/src/native.test.ts
+++ b/apps/cli/src/native.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  nativeCommandEnv,
   resolveBbExecutable,
   runCapturedCommand,
   runInheritedCommand,
@@ -68,6 +69,40 @@ describe("native command boundary", () => {
         env: { BB_CLI: "./missing-bb", PATH: fallback.root },
       }),
     ).toBe(await fs.realpath(fallback.file));
+  });
+
+  test("removes bb re-exec selectors from delegated native commands", () => {
+    expect(
+      nativeCommandEnv({
+        BB_CLI: "/tmp/daemon-managed-bb",
+        BB_CLI_REEXEC: "1",
+        BB_SERVER_URL: "http://127.0.0.1:49161",
+        PATH: "/usr/bin",
+      }),
+    ).toEqual({
+      BB_SERVER_URL: "http://127.0.0.1:49161",
+      PATH: "/usr/bin",
+    });
+  });
+
+  test("passes an explicit environment to captured native commands", async () => {
+    const fixture = await executable(
+      "env-probe",
+      '#!/bin/sh\nprintf \'%s|%s\' "${BB_CLI-unset}" "${BB_MATE_SENTINEL-unset}"\n',
+    );
+
+    expect(
+      await runCapturedCommand(fixture.file, [], fixture.root, {
+        env: nativeCommandEnv({
+          BB_CLI: fixture.file,
+          BB_MATE_SENTINEL: "preserved",
+        }),
+      }),
+    ).toEqual({
+      stdout: "unset|preserved",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("preserves a delegated process signal", async () => {

--- a/apps/cli/src/native.ts
+++ b/apps/cli/src/native.ts
@@ -6,6 +6,13 @@ import type { ProcessExit } from "./commands.ts";
 
 export { runCapturedCommand } from "@bb-mate/inspection";
 
+export function nativeCommandEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const childEnv = { ...env };
+  delete childEnv.BB_CLI;
+  delete childEnv.BB_CLI_REEXEC;
+  return childEnv;
+}
+
 async function executablePath(candidate: string): Promise<string | null> {
   try {
     await fs.access(candidate, constants.X_OK);

--- a/apps/cli/src/native.ts
+++ b/apps/cli/src/native.ts
@@ -4,14 +4,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { ProcessExit } from "./commands.ts";
 
-export { runCapturedCommand } from "@bb-mate/inspection";
-
-export function nativeCommandEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const childEnv = { ...env };
-  delete childEnv.BB_CLI;
-  delete childEnv.BB_CLI_REEXEC;
-  return childEnv;
-}
+export { nativeCommandEnv, runCapturedCommand } from "@bb-mate/inspection";
 
 async function executablePath(candidate: string): Promise<string | null> {
   try {

--- a/docs/alpha-trial-report.md
+++ b/docs/alpha-trial-report.md
@@ -69,20 +69,20 @@ host, so no normal plugin inventory or Connect state was used or changed.
 
 ## Results
 
-| Milestone                | Result               | Evidence                                                                                                    |
-| ------------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.8 s                                                                     |
-| First Fixture preview    | pass                 | documented story visible about 13 s after beginning install                                                 |
-| Catalog discovery        | pass                 | all 13 story IDs returned by `meta.json`                                                                    |
-| Ownership vocabulary     | pass                 | plugin component, host action, mixed/bb-owned seam, and content-script lifecycle inspected in-browser       |
-| Fixture edit/reload      | pass                 | disposable `Agent focus` name changed; Vite reported HMR and Chrome showed the new value without restart    |
-| Artifact build/install   | pass                 | 40-file archive; installed with npm outside the source checkout                                             |
-| Packaged preview         | pass                 | exact documented story visible; all 13 packaged stories present                                             |
-| Compatibility drift      | pass                 | all 18 target, version, registry, dependency, token, and registration checks passed                         |
-| Passive inspection       | pass                 | bb 0.35.1, unpaired Connect, missing SDK/Harness, and uninstalled plugin reported independently             |
-| Native check             | pass                 | delegated `bb plugin build .`; server/app metadata refreshed at SDK 0.4.1                                   |
-| Live handoff             | expected unavailable | no install performed; printed the exact native path-install command and exited 1                            |
-| Cleanup                  | pass                 | servers stopped; bb-mate package, bin, and lock residue absent; only disposable plugin build output changed |
+| Milestone                | Result               | Evidence                                                                                                            |
+| ------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.8 s                                                                             |
+| First Fixture preview    | pass                 | documented story visible about 13 s after beginning install                                                         |
+| Catalog discovery        | pass                 | all 13 story IDs returned by `meta.json`                                                                            |
+| Ownership vocabulary     | pass                 | plugin component, host action, mixed/bb-owned seam, and content-script lifecycle inspected in-browser               |
+| Fixture edit/reload      | pass                 | disposable `Agent focus` name changed; Vite reported HMR and Chrome showed the new value without restart            |
+| Artifact build/install   | pass                 | 40-file archive; installed with npm outside the source checkout                                                     |
+| Packaged preview         | pass                 | exact documented story visible; all 13 packaged stories present                                                     |
+| Compatibility drift      | pass                 | all 18 target, version, registry, dependency, token, and registration checks passed                                 |
+| Passive inspection       | pass                 | bb 0.35.1, unpaired Connect, missing SDK/Harness, and uninstalled plugin reported independently                     |
+| Native check             | pass                 | delegated `bb plugin build .`; server/app metadata refreshed at SDK 0.4.1                                           |
+| Live handoff             | expected unavailable | no install performed; printed the exact native path-install command and exited 1                                    |
+| Cleanup                  | pass                 | servers stopped; bb-mate package, bin, manifest, and lock entry absent; only disposable plugin build output changed |
 
 The timed values are command milestones, not a usability benchmark. Browser
 automation used an ordinary installed Chrome because a first-time author needs

--- a/docs/alpha-trial-report.md
+++ b/docs/alpha-trial-report.md
@@ -65,8 +65,8 @@ host, so no normal plugin inventory or Connect state was used or changed.
 
 | Milestone                | Result               | Evidence                                                                                                 |
 | ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------- |
-| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.0 s                                                                  |
-| First Fixture preview    | pass                 | documented story visible about 12 s after beginning install                                              |
+| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.8 s                                                                  |
+| First Fixture preview    | pass                 | documented story visible about 13 s after beginning install                                              |
 | Catalog discovery        | pass                 | all 13 story IDs returned by `meta.json`                                                                 |
 | Ownership vocabulary     | pass                 | plugin component, host action, mixed/bb-owned seam, and content-script lifecycle inspected in-browser    |
 | Fixture edit/reload      | pass                 | disposable `Agent focus` name changed; Vite reported HMR and Chrome showed the new value without restart |

--- a/docs/alpha-trial-report.md
+++ b/docs/alpha-trial-report.md
@@ -3,7 +3,7 @@
 ## Decision
 
 The private local alpha is ready to advance to the release-handoff review after
-one P1 native-integration defect was fixed and the complete trial was rerun.
+the native-integration defects were fixed and the complete trial was rerun.
 There are no open P0 or P1 findings. Publication, licensing, visibility, and
 announcement decisions remain outside this trial.
 
@@ -19,12 +19,17 @@ announcement decisions remain outside this trial.
 | BB Mate artifact | `bb-mate-0.1.0-alpha.0.tgz`                                        |
 | Artifact files   | 40                                                                 |
 | Catalog stories  | 13                                                                 |
-| Artifact SHA-256 | `fc99a5161ad0890706d03306de32248174aa3ead67b3daf334932f6868214a07` |
+| Artifact SHA-256 | `0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e` |
 
 The final commit and hosted-run identifiers are added to the OS-637 Linear
 landing comment because they do not exist until the report itself lands.
 
 ## Reproducible setup
+
+The exact sanitized procedure is committed in the
+[clean-room alpha trial runbook](alpha-trial-runbook.md). It defines every path,
+fixture file, environment variable, native process, isolation assertion, and
+teardown step used below.
 
 The trial used a newly created temporary root with these disjoint children:
 
@@ -54,6 +59,7 @@ npm install --prefix "$prefix" --no-save --package-lock=false "$artifact"
 "$prefix/node_modules/.bin/bb-mate" dev "$plugin" --host 127.0.0.1 --port 61038
 "$prefix/node_modules/.bin/bb-mate" check "$plugin"
 "$prefix/node_modules/.bin/bb-mate" live "$plugin"
+npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 ```
 
 Native bb was provisioned separately into the disposable prefix for the native
@@ -63,20 +69,20 @@ host, so no normal plugin inventory or Connect state was used or changed.
 
 ## Results
 
-| Milestone                | Result               | Evidence                                                                                                 |
-| ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------- |
-| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.8 s                                                                  |
-| First Fixture preview    | pass                 | documented story visible about 13 s after beginning install                                              |
-| Catalog discovery        | pass                 | all 13 story IDs returned by `meta.json`                                                                 |
-| Ownership vocabulary     | pass                 | plugin component, host action, mixed/bb-owned seam, and content-script lifecycle inspected in-browser    |
-| Fixture edit/reload      | pass                 | disposable `Agent focus` name changed; Vite reported HMR and Chrome showed the new value without restart |
-| Artifact build/install   | pass                 | 40-file archive; installed with npm outside the source checkout                                          |
-| Packaged preview         | pass                 | exact documented story visible; all 13 packaged stories present                                          |
-| Compatibility drift      | pass                 | all 18 target, version, registry, dependency, token, and registration checks passed                      |
-| Passive inspection       | pass                 | bb 0.35.1, unpaired Connect, missing SDK/Harness, and uninstalled plugin reported independently          |
-| Native check             | pass                 | delegated `bb plugin build .`; server/app metadata refreshed at SDK 0.4.1                                |
-| Live handoff             | expected unavailable | no install performed; printed the exact native path-install command and exited 1                         |
-| Cleanup                  | pass                 | Fixture/native servers stopped; only disposable plugin build output changed                              |
+| Milestone                | Result               | Evidence                                                                                                    |
+| ------------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.8 s                                                                     |
+| First Fixture preview    | pass                 | documented story visible about 13 s after beginning install                                                 |
+| Catalog discovery        | pass                 | all 13 story IDs returned by `meta.json`                                                                    |
+| Ownership vocabulary     | pass                 | plugin component, host action, mixed/bb-owned seam, and content-script lifecycle inspected in-browser       |
+| Fixture edit/reload      | pass                 | disposable `Agent focus` name changed; Vite reported HMR and Chrome showed the new value without restart    |
+| Artifact build/install   | pass                 | 40-file archive; installed with npm outside the source checkout                                             |
+| Packaged preview         | pass                 | exact documented story visible; all 13 packaged stories present                                             |
+| Compatibility drift      | pass                 | all 18 target, version, registry, dependency, token, and registration checks passed                         |
+| Passive inspection       | pass                 | bb 0.35.1, unpaired Connect, missing SDK/Harness, and uninstalled plugin reported independently             |
+| Native check             | pass                 | delegated `bb plugin build .`; server/app metadata refreshed at SDK 0.4.1                                   |
+| Live handoff             | expected unavailable | no install performed; printed the exact native path-install command and exited 1                            |
+| Cleanup                  | pass                 | servers stopped; bb-mate package, bin, and lock residue absent; only disposable plugin build output changed |
 
 The timed values are command milestones, not a usability benchmark. Browser
 automation used an ordinary installed Chrome because a first-time author needs
@@ -89,6 +95,7 @@ a browser, not a Playwright browser cache.
 | F-1 | P1       | `BB_CLI` selected the correct executable but was forwarded into that child; bb treated it as another re-exec request and all native probes timed out. | Fixed. BB Mate consumes and removes `BB_CLI`/`BB_CLI_REEXEC` at the native delegation boundary while preserving other environment values. Captured probes and inherited build/live handoffs share the correction. |
 | F-2 | P3       | The guide named native bb as a prerequisite without saying that the local BB Mate archive does not install it.                                        | Fixed with an explicit native-owned installation boundary in the author guide.                                                                                                                                    |
 | F-3 | Note     | Harness remained unavailable because the official SDK testing package is unpublished.                                                                 | Expected and actionable: the report names get-bb/bb#1134 and keeps Fixture usable.                                                                                                                                |
+| F-4 | P1       | The first F-1 correction sanitized every inherited child and removed the canonical selected bb from the source Vite session.                          | Fixed by consuming re-exec selectors at native invocation sites while passing the resolved canonical `BB_CLI` into Vite. Terminal and browser inspection now report the same isolated bb 0.35.1 host.             |
 
 ## Decisions and remaining gates
 

--- a/docs/alpha-trial-report.md
+++ b/docs/alpha-trial-report.md
@@ -1,0 +1,102 @@
+# Clean-room external-author alpha trial
+
+## Decision
+
+The private local alpha is ready to advance to the release-handoff review after
+one P1 native-integration defect was fixed and the complete trial was rerun.
+There are no open P0 or P1 findings. Publication, licensing, visibility, and
+announcement decisions remain outside this trial.
+
+## Candidate
+
+| Field            | Value                                                              |
+| ---------------- | ------------------------------------------------------------------ |
+| Issue            | OS-637                                                             |
+| Platform         | macOS arm64                                                        |
+| Bun              | 1.3.14                                                             |
+| npm              | 11.12.1                                                            |
+| Native bb        | 0.35.1                                                             |
+| BB Mate artifact | `bb-mate-0.1.0-alpha.0.tgz`                                        |
+| Artifact files   | 40                                                                 |
+| Catalog stories  | 13                                                                 |
+| Artifact SHA-256 | `fc99a5161ad0890706d03306de32248174aa3ead67b3daf334932f6868214a07` |
+
+The final commit and hosted-run identifiers are added to the OS-637 Linear
+landing comment because they do not exist until the report itself lands.
+
+## Reproducible setup
+
+The trial used a newly created temporary root with these disjoint children:
+
+```text
+source/         clean archive of the candidate, no .git or node_modules
+profile/        empty child-process home, XDG, cache, state, data, and temp
+install/        npm prefix for the local BB Mate archive and bb 0.35.1
+plugin/         disposable external plugin, outside the BB Mate checkout
+```
+
+No sibling bb source checkout, BB Mate symlink, dotenv file, saved credential,
+or inherited bb data directory was present. Child commands received only the
+documented tools plus profile-local home, XDG, npm, Bun, temp, bb data, and
+loopback server values. The isolated native server used its own data directory
+and ports and was stopped at the end of the trial.
+
+From the clean source archive, the author-facing sequence was:
+
+```sh
+bun install --frozen-lockfile
+bun --filter @bb-mate/workbench stories --host 127.0.0.1 --port 61037
+bun run compatibility:check
+bun run package:artifact
+npm install --prefix "$prefix" --no-save --package-lock=false "$artifact"
+"$prefix/node_modules/.bin/bb-mate" --help
+"$prefix/node_modules/.bin/bb-mate" inspect "$plugin"
+"$prefix/node_modules/.bin/bb-mate" dev "$plugin" --host 127.0.0.1 --port 61038
+"$prefix/node_modules/.bin/bb-mate" check "$plugin"
+"$prefix/node_modules/.bin/bb-mate" live "$plugin"
+```
+
+Native bb was provisioned separately into the disposable prefix for the native
+lane. It is not part of the BB Mate artifact. The trial set `BB_CLI` to that
+exact executable and `BB_SERVER_URL`/bb data values to the isolated loopback
+host, so no normal plugin inventory or Connect state was used or changed.
+
+## Results
+
+| Milestone                | Result               | Evidence                                                                                                 |
+| ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------- |
+| Fresh dependency install | pass                 | frozen lockfile; 1,536 packages; 11.0 s                                                                  |
+| First Fixture preview    | pass                 | documented story visible about 12 s after beginning install                                              |
+| Catalog discovery        | pass                 | all 13 story IDs returned by `meta.json`                                                                 |
+| Ownership vocabulary     | pass                 | plugin component, host action, mixed/bb-owned seam, and content-script lifecycle inspected in-browser    |
+| Fixture edit/reload      | pass                 | disposable `Agent focus` name changed; Vite reported HMR and Chrome showed the new value without restart |
+| Artifact build/install   | pass                 | 40-file archive; installed with npm outside the source checkout                                          |
+| Packaged preview         | pass                 | exact documented story visible; all 13 packaged stories present                                          |
+| Compatibility drift      | pass                 | all 18 target, version, registry, dependency, token, and registration checks passed                      |
+| Passive inspection       | pass                 | bb 0.35.1, unpaired Connect, missing SDK/Harness, and uninstalled plugin reported independently          |
+| Native check             | pass                 | delegated `bb plugin build .`; server/app metadata refreshed at SDK 0.4.1                                |
+| Live handoff             | expected unavailable | no install performed; printed the exact native path-install command and exited 1                         |
+| Cleanup                  | pass                 | Fixture/native servers stopped; only disposable plugin build output changed                              |
+
+The timed values are command milestones, not a usability benchmark. Browser
+automation used an ordinary installed Chrome because a first-time author needs
+a browser, not a Playwright browser cache.
+
+## Findings
+
+| ID  | Severity | Finding                                                                                                                                               | Resolution                                                                                                                                                                                                        |
+| --- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F-1 | P1       | `BB_CLI` selected the correct executable but was forwarded into that child; bb treated it as another re-exec request and all native probes timed out. | Fixed. BB Mate consumes and removes `BB_CLI`/`BB_CLI_REEXEC` at the native delegation boundary while preserving other environment values. Captured probes and inherited build/live handoffs share the correction. |
+| F-2 | P3       | The guide named native bb as a prerequisite without saying that the local BB Mate archive does not install it.                                        | Fixed with an explicit native-owned installation boundary in the author guide.                                                                                                                                    |
+| F-3 | Note     | Harness remained unavailable because the official SDK testing package is unpublished.                                                                 | Expected and actionable: the report names get-bb/bb#1134 and keeps Fixture usable.                                                                                                                                |
+
+## Decisions and remaining gates
+
+- Fixture mode requires no bb server, sibling checkout, secret, or unpublished
+  SDK and is sufficient for deterministic authoring feedback.
+- Harness is not simulated or copied; upstream publication remains the gate.
+- Live bb is still the visual authority. This trial proved the guarded handoff,
+  not host parity and not a plugin installation.
+- The local alpha archive remains private and `UNLICENSED`.
+- OS-638 may prepare a green reviewable handoff, but must not publish, tag,
+  release, change visibility, announce, or choose a public license.

--- a/docs/alpha-trial-runbook.md
+++ b/docs/alpha-trial-runbook.md
@@ -81,7 +81,16 @@ a sibling bb checkout.
 ```sh
 cd "$source_dir"
 time bun install --frozen-lockfile
-bun --filter @bb-mate/workbench stories --host 127.0.0.1 --port 61047
+bun --filter @bb-mate/workbench stories --host 127.0.0.1 --port 61047 \
+  >"$profile/source-stories.log" 2>&1 &
+source_stories_pid=$!
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  curl -fsS http://127.0.0.1:61047/meta.json \
+    >"$profile/source-meta.json" && break
+  test "$attempt" -lt 10 || exit 1
+  sleep 0.5
+done
+test "$(jq '.stories | length' "$profile/source-meta.json")" -eq 13
 ```
 
 Open the printed URL and confirm `meta.json` exposes 13 stories. Inspect a
@@ -97,9 +106,9 @@ cp "$fixture" "$fixture.trial-backup"
 perl -pi -e 's/Agent focus/Agent focus trial/' "$fixture"
 # Observe "Agent focus trial" in the open browser without restarting Vite.
 mv "$fixture.trial-backup" "$fixture"
+kill -INT "$source_stories_pid" 2>/dev/null || true
+wait "$source_stories_pid" || true
 ```
-
-Stop the foreground server with Control-C.
 
 ## 4. Build and install the artifact
 

--- a/docs/alpha-trial-runbook.md
+++ b/docs/alpha-trial-runbook.md
@@ -2,16 +2,21 @@
 
 This runbook reproduces the OS-637 source, package, and isolated native lanes
 without a sibling bb checkout or normal bb state. It targets the verified macOS
-arm64 environment. Use two unused loopback ports and keep every generated file
+arm64 environment. Use five unused loopback ports and keep every generated file
 under one disposable root.
 
 ## 1. Export the candidate
 
-Run this from a BB Mate checkout. Record the candidate commit before exporting
-a Git-less source tree:
+Run this from the GitButler BB Mate checkout. Resolve the exact committed branch
+head rather than GitButler's synthetic workspace commit, then export a Git-less
+source tree:
 
 ```sh
-candidate="$(git rev-parse HEAD)"
+candidate_branch="${BB_MATE_CANDIDATE_BRANCH:-os-637-run-a-clean-room-external-developer-bb-mate-alpha-trial}"
+candidate="$(but status --json | jq -r --arg branch "$candidate_branch" \
+  '[.stacks[].branches[] | select(.name == $branch) | .commits[0].commitId][0] // empty')"
+test -n "$candidate"
+git cat-file -e "$candidate^{commit}"
 trial_root="$(mktemp -d "${TMPDIR:-/tmp}/bb-mate-alpha-trial.XXXXXX")"
 source_dir="$trial_root/source"
 profile="$trial_root/profile"
@@ -29,16 +34,17 @@ directory.
 
 ## 2. Enter an empty profile
 
-Capture the directory containing Bun before starting a shell that loads no user
-configuration:
+Capture the directories containing both Bun and npm before starting a shell
+that loads no user configuration:
 
 ```sh
-tool_bin="$(dirname "$(command -v bun)")"
+bun_bin="$(dirname "$(command -v bun)")"
+npm_bin="$(dirname "$(command -v npm)")"
 env -i \
   USER="${USER:-trial}" \
   LOGNAME="${LOGNAME:-trial}" \
   SHELL=/bin/zsh \
-  PATH="$tool_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  PATH="$bun_bin:$npm_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   TRIAL_ROOT="$trial_root" \
   CANDIDATE="$candidate" \
   /bin/zsh --no-rcs
@@ -64,6 +70,7 @@ export npm_config_cache="$profile/cache/npm"
 mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" \
   "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$TMPDIR"
 unset BB_CLI BB_CLI_REEXEC BB_SERVER_URL BB_DATA_DIR
+command -v bun npm git tar shasum curl perl >/dev/null
 ```
 
 The empty shell must not contain saved credentials, dotenv values, or a path to
@@ -176,6 +183,7 @@ Bind every native command to that process and wait for the isolated inventory:
 
 ```sh
 export BB_CLI="$bb"
+export BB_CLI_REEXEC=1
 export BB_SERVER_URL="http://127.0.0.1:$server_port"
 export BB_DATA_DIR="$bb_data"
 "$bb" --version
@@ -198,8 +206,19 @@ the isolated bb instance:
 
 ```sh
 cd "$source_dir"
-bun run bb-mate dev "$plugin" --host 127.0.0.1 --port 61048
-curl -fsS http://127.0.0.1:61048/bb-mate-session.json
+bun run bb-mate dev "$plugin" --host 127.0.0.1 --port 61048 \
+  >"$profile/source-dev.log" 2>&1 &
+source_dev_pid=$!
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  curl -fsS http://127.0.0.1:61048/bb-mate-session.json \
+    >"$profile/source-session.json" && break
+  test "$attempt" -lt 10 || exit 1
+  sleep 0.5
+done
+jq '{bbVersion:.inspection.native.bbVersion, connect:.inspection.native.connect.paired}' \
+  "$profile/source-session.json"
+kill -INT "$source_dev_pid" 2>/dev/null || true
+wait "$source_dev_pid" || true
 ```
 
 The session JSON must report bb 0.35.1 and unpaired Connect. Stop the source
@@ -209,13 +228,24 @@ server, then exercise the installed artifact:
 "$mate" inspect "$plugin"
 "$mate" check "$plugin"
 "$mate" live "$plugin"
-"$mate" dev "$plugin" --host 127.0.0.1 --port 61049
+"$mate" dev "$plugin" --host 127.0.0.1 --port 61049 \
+  >"$profile/package-dev.log" 2>&1 &
+package_dev_pid=$!
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  curl -fsS http://127.0.0.1:61049/meta.json \
+    >"$profile/package-meta.json" && break
+  test "$attempt" -lt 10 || exit 1
+  sleep 0.5
+done
+jq '.stories | length' "$profile/package-meta.json"
+kill -INT "$package_dev_pid" 2>/dev/null || true
+wait "$package_dev_pid" || true
 ```
 
 `check` must delegate `bb plugin build .` and refresh metadata. Because the
 plugin was intentionally not installed, `live` must exit 1 and print the exact
 `bb plugin install <path> --yes` handoff without running it. The packaged dev
-server must expose all 13 static stories. Stop it with Control-C.
+server must expose all 13 static stories.
 
 ## 8. Uninstall and teardown
 
@@ -228,7 +258,7 @@ test ! -e "$prefix/node_modules/.bin/bb-mate"
 test ! -e "$prefix/package-lock.json"
 ```
 
-Verify all four chosen ports are closed and review the trial root before
+Verify all five chosen ports are closed and review the trial root before
 removing that exact temporary directory. The only plugin mutation should be
 `plugin/dist` from the native build. Do not install the plugin, pair or expose
 Connect, publish the artifact, or reuse normal bb state during this trial.

--- a/docs/alpha-trial-runbook.md
+++ b/docs/alpha-trial-runbook.md
@@ -70,7 +70,28 @@ export npm_config_cache="$profile/cache/npm"
 mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" \
   "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$TMPDIR"
 unset BB_CLI BB_CLI_REEXEC BB_SERVER_URL BB_DATA_DIR
-command -v bun npm git tar shasum curl perl >/dev/null
+command -v bun npm git tar shasum curl perl pgrep >/dev/null
+
+stop_trial_process() {
+  local root_pid="$1"
+  local process alive attempt
+  local -a processes
+  processes=("$root_pid" "${(@f)$(pgrep -P "$root_pid" 2>/dev/null)}")
+  kill -TERM "$processes[@]" 2>/dev/null || true
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    alive=0
+    for process in "$processes[@]"; do
+      kill -0 "$process" 2>/dev/null && alive=1
+    done
+    test "$alive" -eq 0 && break
+    sleep 0.2
+  done
+  for process in "$processes[@]"; do
+    kill -0 "$process" 2>/dev/null && \
+      kill -KILL "$process" 2>/dev/null || true
+  done
+  wait "$root_pid" 2>/dev/null || true
+}
 ```
 
 The empty shell must not contain saved credentials, dotenv values, or a path to
@@ -106,8 +127,7 @@ cp "$fixture" "$fixture.trial-backup"
 perl -pi -e 's/Agent focus/Agent focus trial/' "$fixture"
 # Observe "Agent focus trial" in the open browser without restarting Vite.
 mv "$fixture.trial-backup" "$fixture"
-kill -INT "$source_stories_pid" 2>/dev/null || true
-wait "$source_stories_pid" || true
+stop_trial_process "$source_stories_pid"
 ```
 
 ## 4. Build and install the artifact
@@ -226,8 +246,7 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
 done
 jq '{bbVersion:.inspection.native.bbVersion, connect:.inspection.native.connect.paired}' \
   "$profile/source-session.json"
-kill -INT "$source_dev_pid" 2>/dev/null || true
-wait "$source_dev_pid" || true
+stop_trial_process "$source_dev_pid"
 ```
 
 The session JSON must report bb 0.35.1 and unpaired Connect. Stop the source
@@ -247,8 +266,7 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
   sleep 0.5
 done
 jq '.stories | length' "$profile/package-meta.json"
-kill -INT "$package_dev_pid" 2>/dev/null || true
-wait "$package_dev_pid" || true
+stop_trial_process "$package_dev_pid"
 ```
 
 `check` must delegate `bb plugin build .` and refresh metadata. Because the
@@ -259,8 +277,7 @@ server must expose all 13 static stories.
 ## 8. Uninstall and teardown
 
 ```sh
-kill -INT "$bb_app_pid"
-wait "$bb_app_pid"
+stop_trial_process "$bb_app_pid"
 npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 test ! -e "$prefix/node_modules/bb-mate"
 test ! -e "$prefix/node_modules/.bin/bb-mate"

--- a/docs/alpha-trial-runbook.md
+++ b/docs/alpha-trial-runbook.md
@@ -1,0 +1,216 @@
+# Clean-room alpha trial runbook
+
+This runbook reproduces the OS-637 source, package, and isolated native lanes
+without a sibling bb checkout or normal bb state. It targets the verified macOS
+arm64 environment. Use two unused loopback ports and keep every generated file
+under one disposable root.
+
+## 1. Export the candidate
+
+Run this from a BB Mate checkout. Record the candidate commit before exporting
+a Git-less source tree:
+
+```sh
+candidate="$(git rev-parse HEAD)"
+trial_root="$(mktemp -d "${TMPDIR:-/tmp}/bb-mate-alpha-trial.XXXXXX")"
+source_dir="$trial_root/source"
+profile="$trial_root/profile"
+prefix="$trial_root/install"
+plugin="$trial_root/plugin"
+mkdir -p "$source_dir" "$profile" "$prefix" "$plugin"
+git archive --format=tar "$candidate" | tar -xf - -C "$source_dir"
+test ! -e "$source_dir/.git"
+test ! -e "$source_dir/node_modules"
+```
+
+Save `trial_root`, `candidate`, and the two chosen ports in the trial notes. Do
+not point any later variable at an existing plugin, home directory, or bb data
+directory.
+
+## 2. Enter an empty profile
+
+Capture the directory containing Bun before starting a shell that loads no user
+configuration:
+
+```sh
+tool_bin="$(dirname "$(command -v bun)")"
+env -i \
+  USER="${USER:-trial}" \
+  LOGNAME="${LOGNAME:-trial}" \
+  SHELL=/bin/zsh \
+  PATH="$tool_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  TRIAL_ROOT="$trial_root" \
+  CANDIDATE="$candidate" \
+  /bin/zsh --no-rcs
+```
+
+Inside that shell, reconstruct only trial-local values:
+
+```sh
+trial_root="$TRIAL_ROOT"
+candidate="$CANDIDATE"
+source_dir="$trial_root/source"
+profile="$trial_root/profile"
+prefix="$trial_root/install"
+plugin="$trial_root/plugin"
+export HOME="$profile/home"
+export XDG_CONFIG_HOME="$profile/config"
+export XDG_CACHE_HOME="$profile/cache"
+export XDG_STATE_HOME="$profile/state"
+export XDG_DATA_HOME="$profile/data"
+export TMPDIR="$profile/tmp"
+export BUN_INSTALL_CACHE_DIR="$profile/cache/bun"
+export npm_config_cache="$profile/cache/npm"
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" \
+  "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$TMPDIR"
+unset BB_CLI BB_CLI_REEXEC BB_SERVER_URL BB_DATA_DIR
+```
+
+The empty shell must not contain saved credentials, dotenv values, or a path to
+a sibling bb checkout.
+
+## 3. Verify source Fixture mode
+
+```sh
+cd "$source_dir"
+time bun install --frozen-lockfile
+bun --filter @bb-mate/workbench stories --host 127.0.0.1 --port 61047
+```
+
+Open the printed URL and confirm `meta.json` exposes 13 stories. Inspect a
+plugin component, host action, mixed/bb-owned seam, and content-script story.
+The content-script fixture must remain inert. To prove HMR, copy
+`apps/workbench/src/thread-list-fixtures.ts`, change the deterministic
+`Agent focus` label, observe the browser update without restarting, and restore
+the copied file. Stop the foreground server with Control-C.
+
+## 4. Build and install the artifact
+
+```sh
+cd "$source_dir"
+bun run compatibility:check
+bun run package:artifact
+artifact="$source_dir/artifacts/bb-mate-0.1.0-alpha.0.tgz"
+shasum -a 256 "$artifact"
+npm install --prefix "$prefix" --no-save --package-lock=false "$artifact"
+mate="$prefix/node_modules/.bin/bb-mate"
+"$mate" --help
+```
+
+For the OS-637 candidate, the archive contains 40 files and 13 stories. Record
+the checksum rather than assuming it matches an earlier candidate.
+
+## 5. Create the disposable plugin
+
+Create these three files under the empty `plugin` directory:
+
+Create `package.json` with:
+
+```json
+{
+  "name": "bb-plugin-alpha-trial",
+  "version": "1.0.0",
+  "private": true,
+  "engines": { "bb": ">=0.35.1", "bbPluginSdk": ">=0.4.1" },
+  "dependencies": { "@bb/plugin-sdk": "^0.4.1" },
+  "bb": {
+    "name": "Alpha Trial",
+    "description": "Disposable clean-room plugin",
+    "branding": { "icon": "Puzzle" },
+    "server": "./server.ts",
+    "app": "./app.tsx"
+  }
+}
+```
+
+Use this same content for `server.ts` and `app.tsx`:
+
+```ts
+export default {};
+```
+
+Fixture mode can inspect this manifest without the unpublished SDK. Native bb
+owns the later build and writes only disposable plugin output.
+
+## 6. Start isolated native bb
+
+Provision the trusted native prerequisite separately. Its install scripts are
+required for the native SQLite binding; this is not an install script from the
+BB Mate archive.
+
+```sh
+npm install --prefix "$prefix" --no-save --package-lock=false \
+  bb-app@0.35.1 "$artifact"
+bb="$prefix/node_modules/.bin/bb"
+bb_app="$prefix/node_modules/.bin/bb-app"
+bb_data="$profile/bb-data"
+server_port=49286
+daemon_port=49287
+test -x "$bb" && test -x "$bb_app"
+```
+
+Choose different unused ports when either example port is occupied. In a
+second empty-profile terminal, run the combined server and host daemon in the
+foreground:
+
+```sh
+"$bb_app" --data-dir "$bb_data" \
+  --server-port "$server_port" \
+  --host-daemon-port "$daemon_port"
+```
+
+Back in the trial shell, bind every native command to that process:
+
+```sh
+export BB_CLI="$bb"
+export BB_SERVER_URL="http://127.0.0.1:$server_port"
+export BB_DATA_DIR="$bb_data"
+"$bb" --version
+"$bb" plugin list --json
+"$bb" connect status --json
+```
+
+The version must be 0.35.1, the inventory must contain builtins only, and
+Connect must be unpaired. Stop if any normal plugin or paired Connect state is
+visible.
+
+## 7. Exercise source and packaged native handoffs
+
+From the source archive, verify that both terminal and browser inspection use
+the isolated bb instance:
+
+```sh
+cd "$source_dir"
+bun run bb-mate dev "$plugin" --host 127.0.0.1 --port 61048
+curl -fsS http://127.0.0.1:61048/bb-mate-session.json
+```
+
+The session JSON must report bb 0.35.1 and unpaired Connect. Stop the source
+server, then exercise the installed artifact:
+
+```sh
+"$mate" inspect "$plugin"
+"$mate" check "$plugin"
+"$mate" live "$plugin"
+"$mate" dev "$plugin" --host 127.0.0.1 --port 61049
+```
+
+`check` must delegate `bb plugin build .` and refresh metadata. Because the
+plugin was intentionally not installed, `live` must exit 1 and print the exact
+`bb plugin install <path> --yes` handoff without running it. The packaged dev
+server must expose all 13 static stories. Stop it with Control-C.
+
+## 8. Uninstall and teardown
+
+```sh
+npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
+test ! -e "$prefix/node_modules/bb-mate"
+test ! -e "$prefix/node_modules/.bin/bb-mate"
+test ! -e "$prefix/package-lock.json"
+```
+
+Stop the isolated `bb-app` foreground process with Control-C. Verify all four
+chosen ports are closed and review the trial root before removing that exact
+temporary directory. The only plugin mutation should be `plugin/dist` from the
+native build. Do not install the plugin, pair or expose Connect, publish the
+artifact, or reuse normal bb state during this trial.

--- a/docs/alpha-trial-runbook.md
+++ b/docs/alpha-trial-runbook.md
@@ -82,7 +82,17 @@ plugin component, host action, mixed/bb-owned seam, and content-script story.
 The content-script fixture must remain inert. To prove HMR, copy
 `apps/workbench/src/thread-list-fixtures.ts`, change the deterministic
 `Agent focus` label, observe the browser update without restarting, and restore
-the copied file. Stop the foreground server with Control-C.
+the copied file:
+
+```sh
+fixture="$source_dir/apps/workbench/src/thread-list-fixtures.ts"
+cp "$fixture" "$fixture.trial-backup"
+perl -pi -e 's/Agent focus/Agent focus trial/' "$fixture"
+# Observe "Agent focus trial" in the open browser without restarting Vite.
+mv "$fixture.trial-backup" "$fixture"
+```
+
+Stop the foreground server with Control-C.
 
 ## 4. Build and install the artifact
 
@@ -104,9 +114,8 @@ the checksum rather than assuming it matches an earlier candidate.
 
 Create these three files under the empty `plugin` directory:
 
-Create `package.json` with:
-
-```json
+```sh
+cat >"$plugin/package.json" <<'JSON'
 {
   "name": "bb-plugin-alpha-trial",
   "version": "1.0.0",
@@ -121,12 +130,14 @@ Create `package.json` with:
     "app": "./app.tsx"
   }
 }
+JSON
 ```
 
-Use this same content for `server.ts` and `app.tsx`:
+Use the same inert entrypoint for the server and app:
 
-```ts
-export default {};
+```sh
+printf 'export default {};\n' >"$plugin/server.ts"
+printf 'export default {};\n' >"$plugin/app.tsx"
 ```
 
 Fixture mode can inspect this manifest without the unpublished SDK. Native bb
@@ -149,24 +160,30 @@ daemon_port=49287
 test -x "$bb" && test -x "$bb_app"
 ```
 
-Choose different unused ports when either example port is occupied. In a
-second empty-profile terminal, run the combined server and host daemon in the
-foreground:
+Choose different unused ports when either example port is occupied. Start the
+combined server and host daemon under the disposable profile, retain its PID,
+and capture its logs:
 
 ```sh
 "$bb_app" --data-dir "$bb_data" \
   --server-port "$server_port" \
-  --host-daemon-port "$daemon_port"
+  --host-daemon-port "$daemon_port" \
+  >"$profile/bb-app.log" 2>&1 &
+bb_app_pid=$!
 ```
 
-Back in the trial shell, bind every native command to that process:
+Bind every native command to that process and wait for the isolated inventory:
 
 ```sh
 export BB_CLI="$bb"
 export BB_SERVER_URL="http://127.0.0.1:$server_port"
 export BB_DATA_DIR="$bb_data"
 "$bb" --version
-"$bb" plugin list --json
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  "$bb" plugin list --json && break
+  test "$attempt" -lt 10 || exit 1
+  sleep 0.5
+done
 "$bb" connect status --json
 ```
 
@@ -203,14 +220,15 @@ server must expose all 13 static stories. Stop it with Control-C.
 ## 8. Uninstall and teardown
 
 ```sh
+kill -INT "$bb_app_pid"
+wait "$bb_app_pid"
 npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 test ! -e "$prefix/node_modules/bb-mate"
 test ! -e "$prefix/node_modules/.bin/bb-mate"
 test ! -e "$prefix/package-lock.json"
 ```
 
-Stop the isolated `bb-app` foreground process with Control-C. Verify all four
-chosen ports are closed and review the trial root before removing that exact
-temporary directory. The only plugin mutation should be `plugin/dist` from the
-native build. Do not install the plugin, pair or expose Connect, publish the
-artifact, or reuse normal bb state during this trial.
+Verify all four chosen ports are closed and review the trial root before
+removing that exact temporary directory. The only plugin mutation should be
+`plugin/dist` from the native build. Do not install the plugin, pair or expose
+Connect, publish the artifact, or reuse normal bb state during this trial.

--- a/docs/alpha-trial-runbook.md
+++ b/docs/alpha-trial-runbook.md
@@ -28,7 +28,7 @@ test ! -e "$source_dir/.git"
 test ! -e "$source_dir/node_modules"
 ```
 
-Save `trial_root`, `candidate`, and the two chosen ports in the trial notes. Do
+Save `trial_root`, `candidate`, and the five chosen ports in the trial notes. Do
 not point any later variable at an existing plugin, home directory, or bb data
 directory.
 
@@ -255,7 +255,11 @@ wait "$bb_app_pid"
 npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 test ! -e "$prefix/node_modules/bb-mate"
 test ! -e "$prefix/node_modules/.bin/bb-mate"
+test ! -e "$prefix/package.json"
 test ! -e "$prefix/package-lock.json"
+if test -e "$prefix/node_modules/.package-lock.json"; then
+  ! grep -F 'node_modules/bb-mate' "$prefix/node_modules/.package-lock.json"
+fi
 ```
 
 Verify all five chosen ports are closed and review the trial root before

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -128,6 +128,8 @@ workbench. It binds only to loopback and does not serve inspection data. The
 archive remains private, `UNLICENSED`, and unsupported for registry publication.
 The reproducible artifact and clean-room lifecycle are specified in
 [local-package.md](local-package.md).
+Release-candidate maintainers can reproduce the source, packaged, and isolated
+native lanes with the [clean-room alpha trial runbook](alpha-trial-runbook.md).
 
 ## Plugin package boundary
 

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -16,6 +16,10 @@ dev/reload, and the live runtime.
   inspection, build, or Live handoffs. Other versions may still produce useful
   diagnostics but are best-effort until the compatibility target is updated.
 
+Install native bb through its own supported distribution before using native
+handoffs. The local BB Mate artifact does not bundle, install, configure, or
+start bb on the author's behalf.
+
 Fixture exploration does not require native bb, Connect, secrets, a sibling
 `../bb` checkout, or a published `@bb/plugin-sdk` package.
 

--- a/packages/inspection/src/captured-command.ts
+++ b/packages/inspection/src/captured-command.ts
@@ -9,6 +9,7 @@ const forcedSettlementDelayMs = 10;
 export interface CapturedCommandOptions {
   timeoutMs?: number;
   maxOutputBytes?: number;
+  env?: NodeJS.ProcessEnv;
 }
 
 export function runCapturedCommand(
@@ -21,6 +22,7 @@ export function runCapturedCommand(
     const child = spawn(executable, [...args], {
       cwd,
       detached: process.platform !== "win32",
+      env: options.env,
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/packages/inspection/src/index.ts
+++ b/packages/inspection/src/index.ts
@@ -2,6 +2,7 @@ export { inspectPlugin } from "./inspect.ts";
 export { discoverPluginRoots } from "./manifest.ts";
 export { runCapturedCommand } from "./captured-command.ts";
 export type { CapturedCommandOptions } from "./captured-command.ts";
+export { nativeCommandEnv } from "./native-env.ts";
 export {
   formatInspection,
   inspectionOutcome,

--- a/packages/inspection/src/native-env.ts
+++ b/packages/inspection/src/native-env.ts
@@ -1,0 +1,6 @@
+export function nativeCommandEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const childEnv = { ...env };
+  delete childEnv.BB_CLI;
+  delete childEnv.BB_CLI_REEXEC;
+  return childEnv;
+}

--- a/packages/inspection/src/native.test.ts
+++ b/packages/inspection/src/native.test.ts
@@ -7,10 +7,16 @@ import { defaultRunBb, readNativeState } from "./native.ts";
 
 const temporaryRoots: string[] = [];
 const originalBbCli = process.env.BB_CLI;
+const originalBbCliReexec = process.env.BB_CLI_REEXEC;
+const originalSentinel = process.env.BB_MATE_SENTINEL;
 
 afterEach(async () => {
   if (originalBbCli === undefined) delete process.env.BB_CLI;
   else process.env.BB_CLI = originalBbCli;
+  if (originalBbCliReexec === undefined) delete process.env.BB_CLI_REEXEC;
+  else process.env.BB_CLI_REEXEC = originalBbCliReexec;
+  if (originalSentinel === undefined) delete process.env.BB_MATE_SENTINEL;
+  else process.env.BB_MATE_SENTINEL = originalSentinel;
   await Promise.all(
     temporaryRoots
       .splice(0)
@@ -61,6 +67,8 @@ esac
       { mode: 0o755 },
     );
     process.env.BB_CLI = executable;
+    process.env.BB_CLI_REEXEC = "1";
+    process.env.BB_MATE_SENTINEL = "preserved";
 
     const native = await readNativeState("/workspace/plugins/notes");
 
@@ -68,6 +76,25 @@ esac
     expect(native.connect).toMatchObject({
       state: "disconnected",
       paired: false,
+    });
+  });
+
+  test("consumes native selectors before invoking the selected bb", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-bb-env-"));
+    temporaryRoots.push(root);
+    const executable = path.join(root, "selected-bb");
+    await fs.writeFile(
+      executable,
+      '#!/bin/sh\nprintf \'%s|%s|%s\' "${BB_CLI-unset}" "${BB_CLI_REEXEC-unset}" "${BB_MATE_SENTINEL-unset}"\n',
+      { mode: 0o755 },
+    );
+    process.env.BB_CLI = executable;
+    process.env.BB_CLI_REEXEC = "1";
+    process.env.BB_MATE_SENTINEL = "preserved";
+
+    expect(await defaultRunBb(["--version"])).toMatchObject({
+      stdout: "unset|unset|preserved",
+      exitCode: 0,
     });
   });
 

--- a/packages/inspection/src/native.ts
+++ b/packages/inspection/src/native.ts
@@ -4,6 +4,7 @@ import {
   runCapturedCommand,
   type CapturedCommandOptions,
 } from "./captured-command.ts";
+import { nativeCommandEnv } from "./native-env.ts";
 import type {
   CommandResult,
   InspectPluginOptions,
@@ -144,7 +145,10 @@ export function defaultRunBb(
   options: CapturedCommandOptions = {},
 ): Promise<CommandResult> {
   const executable = process.env.BB_CLI?.trim() || "bb";
-  return runCapturedCommand(executable, args, process.cwd(), options);
+  return runCapturedCommand(executable, args, process.cwd(), {
+    ...options,
+    env: nativeCommandEnv(options.env ?? process.env),
+  });
 }
 
 function boundUtf8(value: string): string {


### PR DESCRIPTION
## Context
Prove the #39 external-author alpha journey from disposable state and close all P0/P1 friction before release handoff.

## What changed
- consume BB_CLI and BB_CLI_REEXEC only at resolved native bb invocation boundaries
- preserve the canonical selected bb for source workbench browser inspection
- document and reproduce the complete clean-profile source, package, native, HMR, uninstall, and teardown trial
- record the sanitized trial report and final 5/5 standing and targeted reviews

## Verification
- bun run format:check
- bun run check
- bun run test (175 tests)
- bun run build
- bun run visual:test (14 checks)
- artifact: 40 files, 13 stories, SHA-256 0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e
- isolated bb 0.35.1 source/browser/check/guarded-Live lane; builtin inventory only; Connect unpaired

## Risk and boundaries
No plugin installation, Connect mutation, upstream bb edit, publication, release, visibility change, announcement, or public license choice.

## Issue

Implements #39 under roadmap #21.