### PR TITLE
docs: prepare shareable alpha release handoff

### DIFF
--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -255,6 +255,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: A future renamed or scoped package can no longer falsely verify a stale `bb-mate` installation; placeholder identities remain explicitly non-proposals.
 - Next: Format and commit the correction, then obtain standing and targeted exact-head reapproval.
 - Blockers: None pending independent re-review.
+
+2026-08-07 - OS-638 final standing and targeted review clean
+- Changed: Closed the sole targeted P3 without changing the package, product source, or release boundary.
+- Verified: Standing and fresh targeted round-two reviews both approved exact head `e6217abb9050ec6857f1712eaa7db6f25a7b8f3e` at 5/5 with zero P0-P3. Each independently exercised a renamed/scoped-package lifecycle and confirmed the old package/bin were absent before the exact new manifest/bin verification. Formatting, links, diff hygiene, package allowlist, artifact checksum, all acceptance rows, and stop rules remain green.
+- Result: OS-638 is locally review-clean and ready for the hosted draft-PR gate.
+- Next: Commit review evidence, exact-head recheck, open the draft PR, follow hosted CI and review threads, then promote to ready and stop unmerged.
+- Blockers: None; release execution remains explicitly unauthorized.
 ```
 
 ## Preparation Audits
@@ -313,6 +320,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | 4         | OS-637 targeted    | `tmp/reviews/targeted-os637/round-4.json`  | 5/5        | clean             | 0          | All six acceptance criteria passed                    |
 | 1         | OS-638 standing    | `tmp/reviews/standing/os-638-round-1.json` | 5/5        | clean             | 0          | Full handoff, lifecycle, stop, and provenance review  |
 | 1         | OS-638 targeted    | `tmp/reviews/targeted-os638/round-1.json`  | 4/5        | changes requested | 0          | One P3 for future package-identity update handling    |
+| 2         | OS-638 standing    | `tmp/reviews/standing/os-638-round-2.json` | 5/5        | clean             | 0          | Renamed/scoped lifecycle and full non-regression      |
+| 2         | OS-638 targeted    | `tmp/reviews/targeted-os638/round-2.json`  | 5/5        | clean             | 0          | P3 fixed with literal new-identity package proof      |
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -241,6 +241,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: Every upstream-independent implementation/trial issue through OS-637 is Done. OS-638 is unblocked and explicitly stops at a green ready but unmerged PR.
 - Next: Assemble the traceable version, artifact, compatibility, limitations, lifecycle, copy, and owner-decision handoff; review and verify it without publishing or merging.
 - Blockers: Public license, repository visibility, publication, release, and announcement remain owner decisions rather than implementation blockers.
+
+2026-08-07 - OS-638 handoff and local candidate gates green
+- Changed: Added the proposed private-alpha changelog and a release handoff covering provenance, compatibility, trial evidence, known gaps, install/update/uninstall/recovery, trust/support/fidelity, draft copy, and explicit technical/owner/execution decisions.
+- Verified: Live Linear inventory shows OS-623 and OS-628 through OS-637 Done, OS-638 In Progress, and OS-639 through OS-644 Backlog with `upstream-dependent`. The exact product baseline reproduced the 40-file, 13-story archive at SHA-256 `0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e`; format/check/175 tests/build, 14 visual/accessibility checks, package inspection/lifecycle, diff hygiene, and all relative handoff links passed.
+- Result: The technical candidate is a go for explicitly authorized private local sharing and a no-go for npm/public release. OS-638 changes only handoff documentation outside the package allowlist; publication, license, visibility, merge, and announcement remain stopped.
+- Next: Complete standing and fresh-targeted review, fix every finding, then open and verify the ready-but-unmerged PR.
+- Blockers: None for the documentation PR; owner decisions intentionally block distribution execution.
 ```
 
 ## Preparation Audits
@@ -348,6 +355,11 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-637 corrected production source/native rerun                                 | OS-637 correction    | pass                 | browser bb 0.35.1; 175 tests; SHA `0e5503f…d00e`           |
 | OS-637 standing review round three                                              | OS-637 final review  | 5/5 clean            | zero P0-P3; literal process-tree shutdown passed           |
 | OS-637 targeted review round four                                               | OS-637 final review  | 5/5 clean            | all six acceptance criteria passed                         |
+| OS-638 live roadmap inventory                                                   | OS-638 handoff       | pass                 | independent Done; six upstream issues remain Backlog       |
+| OS-638 format/check/test/build aggregate                                        | OS-638 candidate     | pass                 | 175 tests; compatibility and all builds green              |
+| OS-638 Playwright/axe matrix                                                    | OS-638 candidate     | pass                 | 14 deterministic visual/accessibility checks               |
+| OS-638 package inspection and clean-room lifecycle                              | OS-638 candidate     | pass                 | 40 files; 13 stories; SHA `0e5503f...d00e`                 |
+| OS-638 relative-link, private-path, stop-rule, and diff audit                   | OS-638 handoff       | pass                 | three handoff files; documentation-only candidate          |
 
 ## Prompt / Goal Alignment
 
@@ -369,8 +381,8 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-632 | Done        | PR #9 merged at `9f2aa0c`; main CI 31226118637 green  |
 | OS-635 | Done        | PR #10 merged at `544d9b1`; main CI 31229355120 green |
 | OS-636 | Done        | PR #11 merged at `b2d5c20`; main CI 31230856034 green |
-| OS-637 | In Progress | Clean-room external-author trial                      |
-| OS-638 | Todo        | Blocked by OS-629/637; final ready PR only            |
+| OS-637 | Done        | PR #12 merged at `c8363d3`; main CI 31233902043 green |
+| OS-638 | In Progress | Handoff locally green; final ready PR remains         |
 
 ## Follow-Ups
 

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -234,6 +234,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Review: Standing `tmp/reviews/standing/os-637-round-3.json`; targeted `tmp/reviews/targeted-os637/round-4.json`.
 - Next: Open the draft PR, follow hosted CI and all review threads, then ready/land and reconcile Linear.
 - Blockers: None.
+
+2026-08-07 - OS-637 landed and OS-638 started
+- Changed: Promoted and merged PR #12, reconciled GitButler to clean lane-free main, closed OS-637, and opened the Linear-recommended OS-638 branch at the release-handoff stop boundary.
+- Verified: PR CI 31233812475 passed verify, visual, and GitGuardian with no reviews, inline comments, or unresolved threads. Post-merge main CI 31233902043 passed verify and visual at merge commit `c8363d3e80e54371f62b826a0e808268f2317038`.
+- Result: Every upstream-independent implementation/trial issue through OS-637 is Done. OS-638 is unblocked and explicitly stops at a green ready but unmerged PR.
+- Next: Assemble the traceable version, artifact, compatibility, limitations, lifecycle, copy, and owner-decision handoff; review and verify it without publishing or merging.
+- Blockers: Public license, repository visibility, publication, release, and announcement remain owner decisions rather than implementation blockers.
 ```
 
 ## Preparation Audits

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -248,6 +248,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 - Result: The technical candidate is a go for explicitly authorized private local sharing and a no-go for npm/public release. OS-638 changes only handoff documentation outside the package allowlist; publication, license, visibility, merge, and announcement remain stopped.
 - Next: Complete standing and fresh-targeted review, fix every finding, then open and verify the ready-but-unmerged PR.
 - Blockers: None for the documentation PR; owner decisions intentionally block distribution execution.
+
+2026-08-07 - OS-638 round-one review update-identity correction
+- Changed: Made the same-package update assumption explicit and added a separate remove/prove-absent/install/verify procedure for an approved future package name or scope change.
+- Verified: Standing review approved the exact candidate 5/5 with zero P0-P3. Fresh targeted review independently reproduced the exact artifact and approved every acceptance row except the prior update procedure, scoring 4/5 with one reasonable P3.
+- Result: A future renamed or scoped package can no longer falsely verify a stale `bb-mate` installation; placeholder identities remain explicitly non-proposals.
+- Next: Format and commit the correction, then obtain standing and targeted exact-head reapproval.
+- Blockers: None pending independent re-review.
 ```
 
 ## Preparation Audits
@@ -302,6 +309,10 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | 1         | OS-636 targeted    | `tmp/reviews/targeted-os636/round-1.json`  | 3/5        | changes requested | 4          | Intake, versions, lifecycle, aggregate execution      |
 | 2         | OS-636 standing    | `tmp/reviews/standing/os-636-round-2.json` | 5/5        | clean             | 0          | Trust, support, lifecycle, and script closure         |
 | 2         | OS-636 targeted    | `tmp/reviews/targeted-os636/round-2.json`  | 5/5        | clean             | 0          | External-author workflow and artifact closure         |
+| 3         | OS-637 standing    | `tmp/reviews/standing/os-637-round-3.json` | 5/5        | clean             | 0          | Final process-tree and clean-room recheck             |
+| 4         | OS-637 targeted    | `tmp/reviews/targeted-os637/round-4.json`  | 5/5        | clean             | 0          | All six acceptance criteria passed                    |
+| 1         | OS-638 standing    | `tmp/reviews/standing/os-638-round-1.json` | 5/5        | clean             | 0          | Full handoff, lifecycle, stop, and provenance review  |
+| 1         | OS-638 targeted    | `tmp/reviews/targeted-os638/round-1.json`  | 4/5        | changes requested | 0          | One P3 for future package-identity update handling    |
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
+++ b/.agents/goals/2026-08-07-os-627-independent-alpha/RETRO.md
@@ -1,8 +1,8 @@
 # Execution Retro: OS-627 upstream-independent alpha
 
 Date started: 2026-08-07
-Date finalized: Pending
-Status: Active
+Date finalized: 2026-08-08
+Status: Completed
 Spec: `.agents/goals/2026-08-07-os-627-independent-alpha/SPEC.md`
 Goal: `.agents/goals/2026-08-07-os-627-independent-alpha/GOAL.md`
 Prompt: `.agents/goals/2026-08-07-os-627-independent-alpha/PROMPT.md`
@@ -11,30 +11,36 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 ## Summary
 
 - Objective: complete OS-629 and OS-632 through OS-638 without upstream work.
-- Completion horizon: `ready-pr`; OS-629 through OS-637 merge, OS-638 stops ready.
+- Completion horizon: `ready-pr`; OS-629 through OS-637 merged and OS-638
+  reached a green ready PR before the later owner-authorized landing step.
 - Baseline: clean `main` at `a637aa0`; main CI run 31206636916 green.
 - Capability baseline: native bb 0.35.1; official `@bb/plugin-sdk` remains
   unpublished, so Harness stays accurately unavailable.
-- Forbidden actions: no publication, tag/release, visibility change,
-  announcement, public-license choice, upstream edit, normal plugin/Connect
-  mutation, or final OS-638 merge.
+- During the goal loop, forbidden actions included publication, tag/release,
+  visibility change, announcement, public-license choice, upstream edit, normal
+  plugin/Connect mutation, and the final OS-638 merge. The loop stopped at that
+  boundary before the owner separately authorized merging on 2026-08-08.
 
 ## Readiness
 
 - Prompt checked: yes; 3,604 characters and no placeholders.
 - Goal/prompt alignment checked: yes; packet doctor passes.
-- Review blockers: none in preparation.
-- Verification blockers: none in preparation.
-- Tracker blockers: dependency graph recorded in the goal.
-- Authority blockers: public license/release and OS-638 merge remain owner gates.
-- Next action: implement OS-632 and preserve execution evidence here.
+- Review blockers: none; every included implementation and handoff review closed
+  at 5/5 with zero P0-P3 before the ready-PR boundary.
+- Verification blockers: none; local and hosted gates are green.
+- Tracker blockers: only OS-639 through OS-644 remain upstream-dependent.
+- Authority blockers: public license, npm publication, repository visibility,
+  tag/release, and announcement remain owner gates.
+- Closeout action: merge PR #13 under the 2026-08-08 authorization, verify main,
+  and keep every distribution action stopped.
 
 ## Goal Amendments
 
-| Time            | Change                                | Reason                                                                 | Approved By         |
-| --------------- | ------------------------------------- | ---------------------------------------------------------------------- | ------------------- |
-| 2026-08-07 prep | Finish at ready OS-638 PR, not merged | OS-638 explicitly requires an owner gate before merging its handoff PR | Issue specification |
-| 2026-08-07 prep | Sequence OS-633 -> OS-634 -> OS-632   | Visual/a11y baselines must cover the completed launcher                | Preparation audit   |
+| Time                  | Change                                        | Reason                                                                 | Approved By         |
+| --------------------- | --------------------------------------------- | ---------------------------------------------------------------------- | ------------------- |
+| 2026-08-07 prep       | Finish at ready OS-638 PR, not merged         | OS-638 explicitly requires an owner gate before merging its handoff PR | Issue specification |
+| 2026-08-07 prep       | Sequence OS-633 -> OS-634 -> OS-632           | Visual/a11y baselines must cover the completed launcher                | Preparation audit   |
+| 2026-08-08 post-ready | Permit PR #13 merge after extra local reviews | Owner explicitly authorized merging the completed handoff work         | Matt Galligan       |
 
 ## Execution Log
 
@@ -402,7 +408,7 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 | OS-635 | Done        | PR #10 merged at `544d9b1`; main CI 31229355120 green |
 | OS-636 | Done        | PR #11 merged at `b2d5c20`; main CI 31230856034 green |
 | OS-637 | Done        | PR #12 merged at `c8363d3`; main CI 31233902043 green |
-| OS-638 | In Progress | Handoff locally green; final ready PR remains         |
+| OS-638 | In Progress | PR #13 green/ready; owner-authorized merge is next    |
 
 ## Follow-Ups
 
@@ -412,4 +418,13 @@ Refs: `.agents/goals/2026-08-07-os-627-independent-alpha/REFS.md`
 
 ## Final State
 
-Pending execution.
+The original goal reached its required green, ready, unmerged PR #13 at exact
+head `914fea203cc6de2eae29e3ef6d4818ac16b7b35a`. All upstream-independent work
+through OS-637 was already on main, and OS-638 supplied the traceable private
+local-alpha handoff without publishing or changing release state.
+
+On 2026-08-08, Matt explicitly authorized merging PR #13 after additional local
+review passes. That authorization extends only to the repository merge. Public
+licensing, npm publication, tag/release creation, repository visibility,
+announcement, upstream bb edits, and normal plugin or Connect mutation remain
+outside scope. OS-639 through OS-644 remain Backlog and `upstream-dependent`.

--- a/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
+++ b/.agents/plans/2026-08-07-os-637-clean-room-alpha-trial.md
@@ -59,7 +59,7 @@ release blocker.
 - [x] Run the first-time author journey and triage every finding.
 - [x] Fix all P0/P1 and reasonable P2/P3 friction, then rerun from scratch.
 - [x] Complete aggregate gates and standing/fresh-targeted review.
-- [ ] Land the PR, verify main CI, and move OS-637 to Done.
+- [x] Land the PR, verify main CI, and move OS-637 to Done.
 
 ## Completion
 

--- a/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
+++ b/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
@@ -47,9 +47,9 @@ and upstream limitation explicit, then leave a green ready PR unmerged for Matt.
 
 ## Progress
 
-- [ ] Inventory landed, deferred, version, license, compatibility, and support state.
-- [ ] Write the complete traceable release handoff and owner decision checklist.
-- [ ] Run candidate artifact, aggregate, visual, content, and clean-room gates.
+- [x] Inventory landed, deferred, version, license, compatibility, and support state.
+- [x] Write the complete traceable release handoff and owner decision checklist.
+- [x] Run candidate artifact, aggregate, visual, content, and clean-room gates.
 - [ ] Complete standing and fresh targeted review with no open P0-P3.
 - [ ] Open a draft PR, obtain green hosted gates, mark ready, and stop unmerged.
 

--- a/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
+++ b/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
@@ -23,8 +23,9 @@ and upstream limitation explicit, then leave a green ready PR unmerged for Matt.
 
 ## Boundaries
 
-- Do not publish to npm, tag, create a release, merge the PR, change repository
-  visibility, send an announcement, or choose a public license.
+- The original goal loop must stop before merging. Do not publish to npm, tag,
+  create a release, change repository visibility, send an announcement, or
+  choose a public license.
 - Do not edit upstream bb or implement OS-639 through OS-644 locally.
 - Do not install a plugin or mutate Connect, normal bb state, secrets, or an
   existing developer environment.
@@ -51,10 +52,18 @@ and upstream limitation explicit, then leave a green ready PR unmerged for Matt.
 - [x] Write the complete traceable release handoff and owner decision checklist.
 - [x] Run candidate artifact, aggregate, visual, content, and clean-room gates.
 - [x] Complete standing and fresh targeted review with no open P0-P3.
-- [ ] Open a draft PR, obtain green hosted gates, mark ready, and stop unmerged.
+- [x] Open a draft PR, obtain green hosted gates, mark ready, and stop unmerged.
 
 ## Completion
 
 Complete for this goal loop when OS-638 has a green ready PR with a fully
 traceable local-alpha handoff and no unresolved review thread, while the PR and
 issue remain unmerged/In Progress at the explicit owner decision boundary.
+
+## Post-ready owner authorization
+
+The original goal loop completed at its required unmerged boundary. On
+2026-08-08, Matt explicitly authorized merging PR #13 after additional local
+review passes. That later authorization does not permit npm publication, a
+public-license choice, tagging or release creation, a visibility change, an
+announcement, upstream bb edits, or normal plugin/Connect mutation.

--- a/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
+++ b/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
@@ -1,0 +1,60 @@
+# OS-638 shareable-alpha release handoff
+
+## Outcome
+
+Assemble a traceable, reviewable local-alpha candidate with every owner decision
+and upstream limitation explicit, then leave a green ready PR unmerged for Matt.
+
+## Slice
+
+1. Inventory the landed independent roadmap, current package/version/license
+   state, compatibility target, trial evidence, installation lifecycle, and
+   upstream-dependent OS-639 through OS-644 issues.
+2. Write one release-handoff document containing the version/changelog
+   proposal, candidate commit and artifact checksum, compatibility matrix,
+   limitations, lifecycle and recovery instructions, proposed release and
+   announcement copy, and explicit go/no-go decisions.
+3. Build the artifact from the exact candidate commit and run CI-equivalent,
+   static-lab, visual/accessibility, content, and clean-room lifecycle gates.
+4. Obtain standing and fresh targeted review, fix every P0-P2 and reasonable P3,
+   then open a draft PR and follow hosted CI and review threads.
+5. Promote the PR to ready only when green, then stop with it unmerged and keep
+   OS-638 In Progress pending the owner's release decisions.
+
+## Boundaries
+
+- Do not publish to npm, tag, create a release, merge the PR, change repository
+  visibility, send an announcement, or choose a public license.
+- Do not edit upstream bb or implement OS-639 through OS-644 locally.
+- Do not install a plugin or mutate Connect, normal bb state, secrets, or an
+  existing developer environment.
+- Label Fixture as approximation, Harness as unavailable pending the official
+  SDK testing package/adapter, and Live bb as visual authority.
+- Treat `UNLICENSED` as the current private-candidate state and an explicit
+  owner decision, not as a public-license selection.
+
+## Verification
+
+- Confirm every independent OS-627 sub-issue is Done and list upstream-dependent
+  issues separately with rationale.
+- Run `bun run format:check && bun run check && bun run test && bun run build`.
+- Run `bun run visual:test`, `bun run package:inspect`, and
+  `bun run package:test` from the exact candidate.
+- Record artifact version, candidate commit, file/story counts, and SHA-256.
+- Audit all handoff links, claims, lifecycle commands, rollback steps, decision
+  owners, and stop rules.
+- Complete standing and fresh targeted review, then hosted CI and thread audit.
+
+## Progress
+
+- [ ] Inventory landed, deferred, version, license, compatibility, and support state.
+- [ ] Write the complete traceable release handoff and owner decision checklist.
+- [ ] Run candidate artifact, aggregate, visual, content, and clean-room gates.
+- [ ] Complete standing and fresh targeted review with no open P0-P3.
+- [ ] Open a draft PR, obtain green hosted gates, mark ready, and stop unmerged.
+
+## Completion
+
+Complete for this goal loop when OS-638 has a green ready PR with a fully
+traceable local-alpha handoff and no unresolved review thread, while the PR and
+issue remain unmerged/In Progress at the explicit owner decision boundary.

--- a/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
+++ b/.agents/plans/2026-08-07-os-638-shareable-alpha-release-handoff.md
@@ -50,7 +50,7 @@ and upstream limitation explicit, then leave a green ready PR unmerged for Matt.
 - [x] Inventory landed, deferred, version, license, compatibility, and support state.
 - [x] Write the complete traceable release handoff and owner decision checklist.
 - [x] Run candidate artifact, aggregate, visual, content, and clean-room gates.
-- [ ] Complete standing and fresh targeted review with no open P0-P3.
+- [x] Complete standing and fresh targeted review with no open P0-P3.
 - [ ] Open a draft PR, obtain green hosted gates, mark ready, and stop unmerged.
 
 ## Completion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+BB Mate is a private alpha. This changelog records reviewable local candidates;
+it does not imply publication, a public license, or a stable support promise.
+
+## 0.1.0-alpha.0 — private local candidate
+
+### Added
+
+- Actionable plugin discovery and compatibility inspection with bounded native
+  bb evidence and explicit remediation.
+- A thin `bb-mate` CLI for Fixture launch, inspection, native checking, and Live
+  handoff without replacing bb build/install/dev ownership.
+- A 13-surface public plugin UI catalog, deterministic fixtures, Ladle stories,
+  the Mate launcher, visual regression, and accessibility coverage.
+- A reproducible 40-file local archive, external-author guide, trust/support
+  policies, compatibility drift checks, and a clean-room alpha trial.
+
+### Changed
+
+- Native bb 0.35.1 and plugin SDK metadata 0.4.1 are the recorded compatibility
+  target.
+- Source and packaged Fixture servers remain distinct: source provides bounded
+  passive inspection; the package serves loopback-only static assets.
+
+### Fixed
+
+- Clean runners resolve native `bb plugin build` from the pinned `bb-app`
+  dependency.
+- Native handoffs consume bb re-exec selectors without losing the canonical bb
+  selected for browser inspection.
+- Clean-room process shutdown terminates wrapper and child servers and verifies
+  their ports close.
+
+### Known limitations
+
+- Fixture is a deterministic approximation, not exact bb host rendering.
+- Harness remains unavailable until the official SDK testing package is
+  publicly consumable and BB Mate adds the upstream-backed adapter.
+- A real frontend reference plugin, native scaffold/check adoption,
+  multi-plugin collection manifest, sanctioned registry/style updates, and
+  complete Live parity remain upstream-dependent work.
+- The package is `private: true`, `UNLICENSED`, unpublished, and supported only
+  as the exact private local artifact identified in the release handoff.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ explicit package allowlist. Its installed `dev` command serves only loopback
 Fixture assets; source-checkout `dev` retains the interactive workbench. The
 [clean-room package workflow](docs/local-package.md) documents contents,
 runtime support, missing-capability behavior, temporary install/uninstall, and
-the no-publish boundary.
+the no-publish boundary. The
+[shareable-alpha release handoff](docs/release-handoff.md) records the exact
+candidate, known limitations, recovery path, draft copy, and owner go/no-go
+decisions.
 
 ## Layout
 

--- a/docs/release-handoff.md
+++ b/docs/release-handoff.md
@@ -1,0 +1,255 @@
+# Shareable-alpha release handoff
+
+## Decision
+
+The `0.1.0-alpha.0` candidate is a **go for private local sharing with explicitly
+authorized collaborators** and a **no-go for npm publication or public release**.
+The technical independent roadmap is green, but license, distribution name,
+repository visibility, release channel, and announcement approval remain owner
+decisions. This handoff prepares those decisions; it does not make or execute
+them.
+
+## Candidate provenance
+
+| Field                    | Candidate                                                          |
+| ------------------------ | ------------------------------------------------------------------ |
+| Product source baseline  | `c8363d3e80e54371f62b826a0e808268f2317038`                         |
+| Source PR                | [PR #12](https://github.com/galligan/bb-mate/pull/12)              |
+| Package                  | `bb-mate`                                                          |
+| Version                  | `0.1.0-alpha.0`                                                    |
+| Archive                  | `bb-mate-0.1.0-alpha.0.tgz`                                        |
+| Archive files            | 40                                                                 |
+| Catalog stories          | 13                                                                 |
+| SHA-256                  | `0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e` |
+| Current license state    | `UNLICENSED`; no public-use or redistribution grant                |
+| Current repository state | Private                                                            |
+| Current package state    | `private: true`; registry publication blocked by design            |
+
+OS-638 changes only handoff documentation outside the package allowlist. The
+product source baseline above therefore remains the source of the exact archive
+bytes. The OS-638 PR head and hosted verification are recorded in its PR and
+Linear issue so the documentation review remains independently traceable.
+
+The unscoped `bb-mate` name returned npm `E404` during preparation. That result
+does not reserve the name or prove it will be available later. The owner must
+choose and re-check the final package name/scope immediately before any approved
+registry operation.
+
+## Version and changelog proposal
+
+- Keep `0.1.0-alpha.0` for this already-verified private local archive.
+- Do not mutate or republish these bytes under different metadata.
+- If an npm release is approved later, use `0.1.0-alpha.1` after the license,
+  package name/scope, visibility, and support decisions are committed. Rebuild,
+  rerun every gate, and record a new checksum and source commit.
+- Use [CHANGELOG.md](../CHANGELOG.md) as the proposed `0.1.0-alpha.0` notes. It
+  describes current behavior and limitations without implying publication.
+
+## Independent roadmap status
+
+The independent foundation and alpha path are complete: OS-623 and OS-628
+through OS-637 are Done. OS-638 owns this handoff and stops at a green ready but
+unmerged PR. The completed path covers compatibility inspection, the CLI,
+surface catalog, Ladle lab, launcher, drift protection, visual/accessibility
+coverage, local packaging, author/security/support documentation, and the
+external-author clean-room trial.
+
+OS-624 is separate plugin-publication work and is not part of this BB Mate
+candidate.
+
+## Compatibility and confidence matrix
+
+| Surface              | Supported/verified candidate          | Confidence and boundary                                                         |
+| -------------------- | ------------------------------------- | ------------------------------------------------------------------------------- |
+| Package runtime      | Bun 1.3.14; package engine `>=1.3.14` | Bun is the CLI runtime; Node compatibility is not claimed                       |
+| Local installer      | npm 11.12.1 against a local tarball   | Install/uninstall only; no registry publication                                 |
+| Native host          | macOS arm64, bb 0.35.1                | Native build/check and guarded Live handoff verified                            |
+| Plugin metadata      | SDK 0.4.1; declared engine `^0.4.1`   | Metadata/build compatibility, not public Harness availability                   |
+| Source Fixture       | macOS and clean archive               | Deterministic approximation with HMR and bounded passive inspection             |
+| Packaged Fixture     | macOS clean room and Linux CI         | Static loopback-only lab; 13 stories; no plugin execution                       |
+| Visual/accessibility | Playwright 1.62.1 Noble container     | 14 deterministic checks; not Live visual authority                              |
+| Compatibility drift  | target `desktop-v0.35.1`; 18 checks   | Version, SDK, registry, dependency, token, and registration alarms              |
+| Harness              | Unavailable                           | Waits for official published SDK testing subpaths and adapter                   |
+| Live bb              | Handoff only for this candidate       | Live bb remains visual/integration authority; no reference plugin was installed |
+
+Run [the compatibility check](compatibility-target.md) before diagnosing or
+sharing a candidate. An unavailable public probe fails closed and is not proof
+of compatibility.
+
+## Verification record
+
+- PR #12 CI run 31233812475: verify and visual green; GitGuardian green.
+- Main CI run 31233902043 at the product baseline: verify and visual green.
+- Local aggregate: formatting, type/compatibility checks, 175 tests, and all
+  builds green.
+- Visual/accessibility: all 14 Playwright/axe/geometry checks green.
+- Package lifecycle: two reproducible builds, 40-file allowlist, 13 stories,
+  local install/help/passive inspection/static lab/uninstall, and no `bb-mate`
+  residue.
+- External-author trial: fresh source/profile/prefix/plugin/bb-data roots,
+  Fixture HMR, isolated bb 0.35.1, native build, guarded Live refusal, builtins
+  only, and unpaired Connect.
+- Final OS-637 reviews: standing and fresh targeted 5/5, zero P0-P3.
+
+Re-run the exact candidate gates before any approved distribution action:
+
+```sh
+bun install --frozen-lockfile
+bun run format:check
+bun run check
+bun run test
+bun run build
+bun run visual:test
+bun run package:inspect
+bun run package:test
+shasum -a 256 artifacts/bb-mate-0.1.0-alpha.0.tgz
+```
+
+The expected SHA-256 for this source baseline is
+`0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e`.
+
+## Install, update, uninstall, and recovery
+
+Copy the exact private archive through an approved private channel and verify
+its checksum before installation:
+
+```sh
+artifact="/approved/path/bb-mate-0.1.0-alpha.0.tgz"
+prefix="$(mktemp -d "${TMPDIR:-/tmp}/bb-mate-alpha.XXXXXX")"
+test "$(shasum -a 256 "$artifact" | awk '{print $1}')" = \
+  "0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e"
+npm install --prefix "$prefix" --no-save --package-lock=false "$artifact"
+"$prefix/node_modules/.bin/bb-mate" --help
+```
+
+Stop any foreground Fixture server before update or uninstall. A local update
+is a replacement with another explicitly checksummed archive:
+
+```sh
+next_artifact="/approved/path/bb-mate-next.tgz"
+# Verify the next handoff's recorded checksum first.
+npm install --prefix "$prefix" --no-save --package-lock=false "$next_artifact"
+"$prefix/node_modules/.bin/bb-mate" --help
+```
+
+Uninstall only BB Mate from the disposable prefix:
+
+```sh
+npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
+test ! -e "$prefix/node_modules/bb-mate"
+test ! -e "$prefix/node_modules/.bin/bb-mate"
+```
+
+BB Mate stores no persistent plugin, Connect, or secret state. For rollback,
+stop the server, uninstall the current archive, reinstall the previously
+retained and checksummed tarball into the same disposable prefix, and rerun
+`--help` plus the required Fixture check. If recovery is uncertain, discard the
+exact disposable prefix and create a new one; do not remove/reinstall a managed
+bb plugin or alter normal bb data. Registry unpublish/deprecation is not a
+rollback plan and is outside this candidate.
+
+Full lifecycle details are in [local-package.md](local-package.md), the
+step-by-step external trial is in [alpha-trial-runbook.md](alpha-trial-runbook.md),
+and the sanitized result is in [alpha-trial-report.md](alpha-trial-report.md).
+
+## Trust, security, support, and fidelity
+
+- Plugins are full-trust local code; BB Mate is not a sandbox. Review code and
+  dependencies before native build/dev execution.
+- Passive inspection does not import a plugin or run native mutations, but it
+  can read supported manifest/metadata/native status and query public evidence.
+- `check` executes the selected plugin build toolchain. `live` can execute a
+  previously installed plugin through native bb. The printed install command is
+  a handoff and is not executed by BB Mate.
+- The packaged lab serves static Fixture assets on loopback and has no source
+  inspection endpoint. Fixture approximates plugin-owned UI; Harness validates
+  public behavior when available; Live bb is the visual authority.
+- Do not include secrets, authenticated state, customer data, or unredacted
+  local paths in issues, logs, fixtures, screenshots, or support requests.
+- Security reports use the private advisory flow in [SECURITY.md](../SECURITY.md).
+  Support and compatibility expectations are in [SUPPORT.md](../SUPPORT.md), and
+  the full operation matrix is in [trust-model.md](trust-model.md).
+
+## Upstream-dependent work — not release regressions
+
+These issues remain Backlog with `upstream-dependent`. Do not implement local
+substitutes; start them only after their upstream release and clean-room unblock
+rule pass.
+
+| Issue  | Deferred capability                                                 | Upstream gate                                                            |
+| ------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| OS-639 | Official Harness adapter                                            | get-bb/bb#1134 publishes the SDK testing subpaths                        |
+| OS-640 | Real frontend reference plugin/live adapter                         | #1134 plus the supported external sidebar example from PR #1109          |
+| OS-641 | Native scaffold, declaration refresh, and `plugin --check` adoption | #1133/PR #1135 and PR #1107 land in a released bb                        |
+| OS-642 | Multi-plugin collection manifest                                    | get-bb/bb#1097 defines the released manifest/provenance contract         |
+| OS-643 | Sanctioned registry/style update workflow                           | get-bb/bb#1095 and #1106 establish the authoring/update contract         |
+| OS-644 | Complete Live parity validation                                     | OS-639/640/643 plus required host APIs, including #1094 where applicable |
+
+Harness unavailability, absent real reference-plugin Live parity, and native
+workflow/collection/style deferrals are known upstream capability gaps. They do
+not indicate regression in the green Fixture/local-package candidate.
+
+## Proposed release notes
+
+> **Draft — do not publish without owner approval**
+>
+> BB Mate `0.1.0-alpha.0` is a private local preview for bb plugin authors. It
+> adds actionable compatibility inspection, a thin native-handoff CLI, a
+> deterministic 13-surface Fixture lab, visual/accessibility checks, and a
+> reproducible local archive. Native bb still owns scaffold, build, install,
+> dev/reload, and runtime. Fixture is an approximation; official Harness and a
+> real frontend reference-plugin Live path remain upstream-dependent. This
+> preview is `UNLICENSED`, carries no stable support promise, and must not be
+> redistributed.
+
+## Proposed announcement copy
+
+> **Draft — do not send without owner approval**
+>
+> We have a private BB Mate alpha ready for a small, explicitly authorized bb
+> plugin-author trial. It provides a compatibility report, deterministic public
+> UI-surface stories, and clear handoffs to native bb without replacing bb's
+> lifecycle. The current artifact is for local evaluation only: it is not
+> published, publicly licensed, or a claim of exact host rendering. If you are
+> invited, verify the supplied checksum, use a disposable prefix, and send
+> sanitized feedback through the private support channel.
+
+## Go/no-go checklist
+
+### Technical candidate — complete
+
+- [x] Independent OS-623 and OS-628 through OS-637 work is Done.
+- [x] CI, static surface lab, 14 visual/accessibility checks, package inspection,
+      and clean-room install/uninstall are green.
+- [x] Artifact version, product source baseline, file/story counts, and checksum
+      are recorded.
+- [x] Compatibility, trust, security, support, limitations, recovery, draft
+      notes, and draft announcement are documented.
+- [x] Fixture/Harness/Live claims remain honest and upstream work is separate.
+
+### Owner decisions — blocking public/npm release
+
+- [ ] Approve the distribution model and audience: private file, private
+      registry, or public npm.
+- [ ] Choose and re-check the final package name/scope; npm `E404` is not a
+      reservation.
+- [ ] Choose a public license, add the license file, and update package/repository
+      metadata, or explicitly keep the candidate private and `UNLICENSED`.
+- [ ] Decide repository visibility independently from package distribution.
+- [ ] Approve supported platforms/versions, support commitment, security contact,
+      and release channel.
+- [ ] Approve the final version/tag policy. Proposed first registry version:
+      `0.1.0-alpha.1`, not a mutation of the verified local `alpha.0` bytes.
+- [ ] Approve exact release notes, announcement copy, audience, and timing.
+
+### Execution — not authorized by this handoff
+
+- [ ] Remove `private: true` only after all applicable owner decisions are
+      committed and reviewed.
+- [ ] Rebuild and rerun every gate; record the new commit, artifact manifest,
+      checksum, and registry dry run.
+- [ ] Publish, tag, create a release, change visibility, or send the announcement
+      only under separate explicit approval.
+
+Current verdict: **private local sharing go; public/npm release no-go**. Keep the
+OS-638 PR ready but unmerged until the owner chooses the next boundary.

--- a/docs/release-handoff.md
+++ b/docs/release-handoff.md
@@ -122,8 +122,9 @@ npm install --prefix "$prefix" --no-save --package-lock=false "$artifact"
 "$prefix/node_modules/.bin/bb-mate" --help
 ```
 
-Stop any foreground Fixture server before update or uninstall. A local update
-is a replacement with another explicitly checksummed archive:
+Stop any foreground Fixture server before update or uninstall. If the next
+artifact keeps the same package identity (`bb-mate`), a local update is a
+replacement with another explicitly checksummed archive:
 
 ```sh
 next_artifact="/approved/path/bb-mate-next.tgz"
@@ -131,6 +132,26 @@ next_artifact="/approved/path/bb-mate-next.tgz"
 npm install --prefix "$prefix" --no-save --package-lock=false "$next_artifact"
 "$prefix/node_modules/.bin/bb-mate" --help
 ```
+
+If the owner changes the package name or scope, do not install the new identity
+over the old one or use the old binary as verification. Remove the old package,
+prove its package and binary are absent, then install and verify the exact new
+package and bin identities recorded by that handoff:
+
+```sh
+old_package="bb-mate"
+next_package="@approved-scope/approved-name"
+next_bin="approved-bin"
+npm uninstall --prefix "$prefix" --no-save --package-lock=false "$old_package"
+test ! -e "$prefix/node_modules/$old_package"
+test ! -e "$prefix/node_modules/.bin/bb-mate"
+npm install --prefix "$prefix" --no-save --package-lock=false "$next_artifact"
+test -e "$prefix/node_modules/$next_package/package.json"
+"$prefix/node_modules/.bin/$next_bin" --help
+```
+
+The values above are placeholders, not a proposed public identity. Replace them
+only with the approved package metadata in the next handoff.
 
 Uninstall only BB Mate from the disposable prefix:
 


### PR DESCRIPTION
## Context

Closes the upstream-independent implementation portion of #40 by assembling the reviewable private local-alpha handoff. Publication, repository visibility, license selection, tagging/release, announcement, and this PR merge remain explicit owner decisions.

## What changed

- proposes the private 0.1.0-alpha.0 changelog and later registry-version path
- records exact product baseline, artifact checksum, compatibility and trial evidence
- documents install, same-identity update, renamed/scoped update, uninstall, rollback, and recovery
- separates #41 through #46 as upstream-dependent work
- includes draft release/announcement copy and explicit technical, owner, and execution go/no-go checklists

## Verification

- bun run format:check && bun run check && bun run test && bun run build
- bun run visual:test (14 passed)
- bun run package:inspect && bun run package:test
- artifact: 40 files, 13 stories, SHA-256 0e5503f371a1ffc57c4f4fc333828f4b40affe146b82c7f2c7980f925c48d00e
- standing and fresh targeted reviews: 5/5, zero P0-P3 at exact head

## Stop boundary

Keep this PR unmerged after it is green and ready. Do not publish, tag, release, change visibility, choose a public license, or send the drafted announcement without separate owner approval.

## Issue

Implements #40 and records the separate upstream-adoption queue #41, #42, #43, #44, #45, #46, under roadmap #21.