### PR TITLE
chore: prepare bb-mate 0.1.0-alpha.1 release

### DIFF
--- a/.agents/plans/2026-08-08-os-645-publish-bb-mate-alpha.md
+++ b/.agents/plans/2026-08-08-os-645-publish-bb-mate-alpha.md
@@ -1,0 +1,76 @@
+# OS-645 — Publish BB Mate alpha to npm
+
+## Outcome
+
+Publish the reviewed BB Mate CLI as the public unscoped package
+`bb-mate@0.1.0-alpha.1` under the `alpha` dist-tag. Preserve the verified
+private `0.1.0-alpha.0` bytes, keep the GitHub repository private, and leave
+`latest` untouched.
+
+## Success proof
+
+- The package manifest and shipped `LICENSE` grant MIT terms and contain no
+  `private: true` or workspace dependency.
+- Two complete local builds and a staging repack are byte-identical; the exact
+  file allowlist, story count, SHA-256, npm integrity, and tarball shasum are
+  recorded.
+- Formatting, type/compatibility checks, 175-test aggregate, all builds, 14
+  visual/accessibility checks, package inspection, and clean-room lifecycle
+  pass for the release commit.
+- Targeted and full-stack local reviews are 5/5 with no open P0/P1/P2.
+- The release PR is CI-green and merged; the exact post-merge artifact matches
+  the reviewed artifact.
+- npm shows `bb-mate@0.1.0-alpha.1` under `alpha`, does not expose or move
+  `latest`, and a clean registry install/help/uninstall lifecycle passes.
+- Linear OS-645 records the release commit, PR, CI, registry URL, checksums,
+  integrity, and remaining alpha limitations.
+
+## Plan
+
+1. [x] Record the approved MIT, package identity, version, public npm, `alpha`
+       channel, and private-repository decisions in package and release docs.
+2. [x] Add the MIT license to the repository and package allowlist; advance the
+       package to `0.1.0-alpha.1` with explicit public publish metadata.
+3. [x] Update packaging and clean-room assertions for the public artifact while
+       preserving source exclusion, deterministic output, path confinement,
+       passive inspection, Fixture fidelity, and uninstall residue checks.
+4. [x] Run the full local gate and record the exact candidate artifact evidence.
+5. [x] Complete targeted and full-stack local reviews; fix and re-run any open
+       P0/P1/P2 finding.
+6. [ ] Commit on the Linear branch, open a draft PR, pass hosted CI, mark ready,
+       merge, and verify main CI.
+7. [ ] Rebuild on merged main, prove exact artifact identity, publish with
+       `--tag alpha`, and verify registry metadata plus a clean registry lifecycle.
+8. [ ] Update Linear and this plan with final provenance and leave the GitButler
+       workspace clean with no applied lanes.
+
+## Boundaries
+
+- Do not publish `0.1.0-alpha.0`, move `latest`, create a Git tag or GitHub
+  release, change repository visibility, or announce the release.
+- Do not edit `../bb`, implement upstream-dependent OS-639–OS-644 work, copy the
+  SDK/Harness, or mutate normal bb/plugin/Connect state.
+- Stop before publication if the name is no longer available, the exact artifact
+  differs after merge, CI or review is not clean, or npm requires owner approval
+  that cannot be completed in this session.
+- npm publication is immutable. Publish only the exact reviewed post-merge
+  `./artifacts/bb-mate-0.1.0-alpha.1.tgz` tarball (the `./` forces npm to treat
+  it as a local path) and verify the dist-tag explicitly afterward.
+
+## Evidence
+
+- Linear: OS-645
+- Release PR: pending
+- Release commit: pending
+- Main merge commit: pending
+- Package: 41 files, 13 stories, 514333-byte archive, 1057566 bytes unpacked
+- Package SHA-256:
+  `c3d474a2eb5dc48de93c672941df8bc4313e3a62a0392ce35674ba1322d68f6d`
+- npm shasum: `2a5360d125b0189aaef5ebc85c10da162ed2c47c`
+- npm integrity:
+  `sha512-GykyMJ9mAcHPhij1njHjVE3oUszJFjBLbhhLtmFbmQdueNnBE8bRHouV/Nyhp7ald53O5Mq3lzIRxP6wAdrTwg==`
+- Targeted review: `/tmp/agent-reviews/os-645/release-targeted/round-2.json`
+  — 5/5 clean after fixing two P2s from round 1
+- Full-stack review: `/tmp/agent-reviews/os-645/full-stack/round-1.json` —
+  5/5 clean, zero open P0-P3
+- Registry: pending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,27 @@
 # Changelog
 
-BB Mate is a private alpha. This changelog records reviewable local candidates;
-it does not imply publication, a public license, or a stable support promise.
+BB Mate is an alpha. This changelog records reviewable candidates and public
+prereleases; it does not imply a stable API or support promise.
+
+## 0.1.0-alpha.1 — public npm alpha
+
+### Changed
+
+- Publish the CLI and deterministic 13-story Fixture lab as the unscoped
+  `bb-mate` package under npm's `alpha` dist-tag.
+- License BB Mate under MIT while keeping bundled third-party notices and
+  licenses explicit.
+- Keep the GitHub repository private; public support intake and announcements
+  are not part of this release.
+
+### Known limitations
+
+- Fixture is a deterministic approximation; Live bb remains the visual and
+  integration authority.
+- Harness and the remaining OS-639–OS-644 capabilities stay unavailable until
+  their upstream contracts ship.
+- This prerelease supports Bun as its CLI runtime and carries no stable API,
+  response-time SLA, or public issue tracker.
 
 ## 0.1.0-alpha.0 — private local candidate
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Galligan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,24 +5,25 @@
 Do not open a public issue or include exploit details, credentials, customer
 data, or local paths in ordinary logs or comments.
 
-Use the repository's GitHub **Security → Report a vulnerability** flow to open a
-private security advisory. Include the affected commit or package version,
-reproduction steps using fake data, impact, and any known workaround. If the
-private advisory flow is unavailable, contact a repository maintainer through
-the same private channel that granted repository access and ask for a secure
-reporting path before sharing details.
+Repository collaborators should use GitHub **Security → Report a
+vulnerability** to open a private security advisory. Public npm users should
+contact an npm-listed maintainer through an existing private channel and ask for
+a secure reporting path before sharing details. If no private channel is
+available, do not publish exploit details; this alpha does not yet provide a
+public vulnerability-intake address. Include the affected package version,
+reproduction steps using fake data, impact, and any known workaround.
 
-Maintainers will acknowledge a report when the private project is actively
-staffed, reproduce and triage it, coordinate a fix and disclosure boundary, and
-credit the reporter if requested. This private alpha has no public response-time
-or remediation SLA; see [SUPPORT.md](SUPPORT.md).
+Maintainers will acknowledge a report when the project is actively staffed,
+reproduce and triage it, coordinate a fix and disclosure boundary, and credit
+the reporter if requested. This alpha has no public response-time or remediation
+SLA; see [SUPPORT.md](SUPPORT.md).
 
 ## Supported security surface
 
-Only the current `main` snapshot and the exact local alpha artifact identified
-in repository documentation are considered for security fixes. Old commits,
-locally modified artifacts, unpublished branches, unsupported bb/SDK versions,
-and third-party plugins are not maintained release lines.
+Only the current `main` snapshot and exact npm alpha identified in repository
+documentation are considered for security fixes. Old commits, locally modified
+artifacts, unpublished branches, unsupported bb/SDK versions, and third-party
+plugins are not maintained release lines.
 
 BB Mate does not sandbox plugins. Full-trust execution, passive inspection,
 native mutation boundaries, content-script handling, and secret expectations

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,14 +1,15 @@
 # Support and compatibility policy
 
-BB Mate is a private `0.1.0-alpha.0` development tool. It has no public support
-commitment, stable API guarantee, or response-time SLA. Access does not imply a
-license grant or permission to redistribute it.
+BB Mate `0.1.0-alpha.1` is an MIT-licensed public npm alpha. It has no public
+support commitment, stable API guarantee, or response-time SLA. The GitHub
+repository remains private, so publication does not provide a public issue
+tracker or grant repository access.
 
 ## Supported line
 
 - Source: the current green `main` snapshot.
-- Local package: the exact private alpha artifact produced and verified by that
-  snapshot.
+- npm package: the exact `bb-mate@0.1.0-alpha.1` artifact published under the
+  `alpha` dist-tag and reproduced from the recorded release commit.
 - Toolchain: Bun 1.3.14, pinned by `packageManager`, and the npm installer path
   documented in [docs/local-package.md](docs/local-package.md). Newer versions
   accepted by the package engine are best-effort until added to CI.
@@ -49,8 +50,8 @@ implementation.
 
 ## Changes and deprecation
 
-Private alpha commands, fixtures, and package contents may change between green
-`main` snapshots. When a supported BB Mate path is replaced, changes should:
+Alpha commands, fixtures, and package contents may change between prereleases.
+When a supported BB Mate path is replaced, changes should:
 
 1. name the replacement in the issue, changelog/release handoff, or command
    diagnostic;
@@ -65,31 +66,30 @@ designed to be removable, not to freeze older native workflows.
 
 ## Asking for help
 
-If you have Outfitter Linear access, use the linked Linear issue for private
-project work. Otherwise open a private issue in this GitHub repository; a
-maintainer will triage it into Linear and keep the repository issue as the
-author-facing thread. Include the BB Mate commit, artifact version if
-applicable, `bun --version`, native `bb --version` when used, the selected
-plugin's engine ranges, the exact command and exit status, and sanitized
-diagnostics. Do not attach secrets, authenticated state, customer data, or
-unredacted local paths.
+If you have Outfitter Linear or private repository access, use the linked issue
+for project work. Public npm users should contact an npm-listed maintainer
+through an existing private channel; this alpha does not yet offer a public
+support queue. Include the BB Mate version, `bun --version`, native
+`bb --version` when used, the selected plugin's engine ranges, the exact command
+and exit status, and sanitized diagnostics. Do not attach secrets,
+authenticated state, customer data, or unredacted local paths.
 
 Potential vulnerabilities follow [SECURITY.md](SECURITY.md), not the ordinary
 support queue.
 
-## Release and license gate
+## Release boundary
 
-The repository and local package are currently private and `UNLICENSED`. No
-public-use, modification, redistribution, or publication permission is granted.
-Before any repository-visibility or registry-publication change, the owner must
-explicitly approve:
+The npm package is public under MIT while the repository remains private. Each
+later registry version, repository-visibility change, tag, GitHub release, or
+announcement remains an explicit owner decision. Before one of those actions,
+record:
 
-- a public license and corresponding repository/package metadata;
+- the package and license metadata;
 - supported versions and platforms;
 - release channel, version, provenance, and rollback plan;
 - security contact and disclosure expectations;
 - announcement text and audience.
 
-Until those decisions are recorded, do not publish, tag, create a release,
-change visibility, or announce availability. The alpha release handoff may make
-these decisions ready for approval, but it does not approve or execute them.
+OS-645 records the owner-approved `bb-mate@0.1.0-alpha.1` npm release under the
+`alpha` dist-tag. It does not authorize moving `latest`, creating a Git tag or
+GitHub release, changing visibility, or announcing availability.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,8 +1,16 @@
-# BB Mate local alpha artifact
+# BB Mate
 
-This private package is a local-only BB Mate candidate. It contains a bundled
-`bb-mate` CLI and the deterministic static surface lab; it does not contain bb,
-plugin packages, a copied plugin SDK, or authenticated host state.
+BB Mate is a fixture-driven authoring companion for native bb plugins. This
+package contains the bundled `bb-mate` CLI and deterministic static surface lab;
+it does not contain bb, plugin packages, a copied plugin SDK, or authenticated
+host state.
+
+Install the current public alpha with npm:
+
+```sh
+npm install --global bb-mate@alpha
+bb-mate --help
+```
 
 ## Runtime support
 
@@ -12,8 +20,17 @@ plugin packages, a copied plugin SDK, or authenticated host state.
   runtime.
 - Native bb handoffs target the supported macOS bb host. Fixture inspection and
   the packaged surface lab are also exercised in isolated Linux CI.
-- The package is `private` and `UNLICENSED`. Neither this artifact nor its
-  version is approved for registry publication.
+- BB Mate is an MIT-licensed public alpha. Commands, fixtures, and package
+  contents may change between prereleases without a stable API guarantee.
+
+## Support and security
+
+The source repository and issue tracker remain private. This alpha has no
+public support queue, response-time SLA, or stable API guarantee. Contact an
+npm-listed maintainer through an existing private channel for support. For a
+potential vulnerability, request a secure reporting path before sharing details
+and do not publish exploit information, credentials, customer data, or local
+paths.
 
 ## Build and inspect
 
@@ -25,10 +42,10 @@ bun run package:artifact
 bun run package:inspect
 ```
 
-The first command produces `artifacts/bb-mate-0.1.0-alpha.0.tgz`. npm's pack
+The first command produces `artifacts/bb-mate-0.1.0-alpha.1.tgz`. npm's pack
 report exposes every included file; the package manifest allowlists only
-`README.md`, `package.json`, self-contained third-party notices/licenses, the
-bundled CLI, and static lab assets.
+`LICENSE`, `README.md`, `package.json`, self-contained third-party
+notices/licenses, the bundled CLI, and static lab assets.
 
 ## Temporary local installation
 
@@ -37,7 +54,7 @@ Choose an empty prefix and install the generated file without publishing:
 ```sh
 plugin="/absolute/path/to/plugin"
 prefix="$(mktemp -d)"
-npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.0.tgz
+npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.1.tgz
 export PATH="$prefix/node_modules/.bin:$PATH"
 bb-mate --help
 bb-mate inspect "$plugin"

--- a/apps/cli/THIRD_PARTY_NOTICES.md
+++ b/apps/cli/THIRD_PARTY_NOTICES.md
@@ -30,5 +30,5 @@ The generated payload includes Base UI's runtime dependency closure, Ladle,
 classnames, Prism React Renderer and PrismJS, PropTypes and React Is, React and
 scheduler, the Focus Lock/React Remove Scroll family, Reach UI dialog, tslib,
 and the inspection parser dependency closure. This inventory and those notices
-do not choose or grant a license for BB Mate itself; the local artifact remains
-private and `UNLICENSED`.
+cover third-party components only. BB Mate itself is distributed under the MIT
+License included as `LICENSE` in the package.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,18 +1,28 @@
 {
   "name": "bb-mate",
-  "version": "0.1.0-alpha.0",
-  "private": true,
-  "license": "UNLICENSED",
+  "version": "0.1.0-alpha.1",
+  "description": "A fixture-driven authoring companion for native bb plugins",
+  "license": "MIT",
+  "keywords": [
+    "bb",
+    "plugin-development",
+    "developer-tools"
+  ],
   "type": "module",
   "bin": {
     "bb-mate": "./dist/cli.js"
   },
   "files": [
     "dist",
+    "LICENSE",
     "README.md",
     "THIRD_PARTY_NOTICES.md",
     "THIRD_PARTY_LICENSES.md"
   ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "alpha"
+  },
   "engines": {
     "bun": ">=1.3.14"
   },

--- a/docs/local-package.md
+++ b/docs/local-package.md
@@ -1,7 +1,8 @@
-# Clean-room local package
+# Clean-room package and npm release
 
-BB Mate can produce a private local alpha artifact for installation tests before
-any registry, repository-visibility, license, or release decision.
+BB Mate produces the exact public alpha artifact locally before npm publication.
+Package construction remains separate from the registry operation so the same
+reviewed bytes can be installed, inspected, and checksummed before release.
 
 ## Artifact contract
 
@@ -17,13 +18,14 @@ The command rebuilds the CLI and surface lab, creates an isolated staging
 manifest with no workspace dependencies, and writes the versioned archive:
 
 ```text
-artifacts/bb-mate-0.1.0-alpha.0.tgz
+artifacts/bb-mate-0.1.0-alpha.1.tgz
 ```
 
-The artifact remains `private: true`, `UNLICENSED`, and unpublishable by the
-supported workflow. The staged `files` allowlist permits only:
+The artifact is MIT-licensed and configured for public publication under the
+`alpha` dist-tag. The staged `files` allowlist permits only:
 
 - `package.json`;
+- `LICENSE`;
 - `README.md`, `THIRD_PARTY_NOTICES.md`, and the generated self-contained
   `THIRD_PARTY_LICENSES.md`;
 - `dist/cli.js`, a Bun-targeted self-contained CLI bundle;
@@ -33,7 +35,7 @@ Plugin packages, source files, node_modules, Vite/Ladle servers, desktop app
 bundles, `../bb`, absolute developer paths, workspace links, secrets, and
 authenticated browser state are excluded.
 
-Inspect npm's exact dry-run file list without creating or publishing an archive:
+Inspect npm's exact dry-run file list without publishing an archive:
 
 ```sh
 bun run package:inspect
@@ -88,8 +90,15 @@ The test:
 The temporary environment is removed after the test. The versioned archive
 under `artifacts/` is generated and ignored by version control.
 
-## Stop boundary
+## Publication boundary
 
-These commands do not run `npm publish`, create a tag or release, change
-repository visibility, select a public license, or send an announcement. Those
-remain explicit owner decisions for the later release handoff.
+The package scripts above never publish. After owner approval, clean review,
+green hosted CI, and merge, publish only the exact post-merge artifact:
+
+```sh
+npm publish ./artifacts/bb-mate-0.1.0-alpha.1.tgz --access public --tag alpha
+```
+
+Verify that `alpha` points to `0.1.0-alpha.1`, `latest` was not created or moved,
+and a clean registry install succeeds. Publication does not create a Git tag or
+GitHub release, change repository visibility, or send an announcement.

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -103,15 +103,14 @@ Set `BB_CLI` to an exact executable when you need to override the `bb` found on
 BB_CLI=/absolute/path/to/bb bun run bb-mate inspect "$plugin"
 ```
 
-## Use the local alpha artifact
+## Install the public alpha
 
-The private package supports Fixture exploration outside the source checkout:
+The public package supports Fixture exploration outside the source checkout:
 
 ```sh
-bun run package:artifact
 plugin="/absolute/path/to/plugin"
 prefix="$(mktemp -d)"
-npm install --prefix "$prefix" --no-save --package-lock=false ./artifacts/bb-mate-0.1.0-alpha.0.tgz
+npm install --prefix "$prefix" --no-save --package-lock=false bb-mate@alpha
 "$prefix/node_modules/.bin/bb-mate" --help
 "$prefix/node_modules/.bin/bb-mate" dev "$plugin"
 ```
@@ -125,8 +124,8 @@ npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
 
 The installed `dev` serves the packaged static lab rather than the source Vite
 workbench. It binds only to loopback and does not serve inspection data. The
-archive remains private, `UNLICENSED`, and unsupported for registry publication.
-The reproducible artifact and clean-room lifecycle are specified in
+package is an MIT-licensed prerelease with no stable API or support SLA. The
+reproducible artifact and clean-room lifecycle are specified in
 [local-package.md](local-package.md).
 Release-candidate maintainers can reproduce the source, packaged, and isolated
 native lanes with the [clean-room alpha trial runbook](alpha-trial-runbook.md).

--- a/docs/release-handoff.md
+++ b/docs/release-handoff.md
@@ -2,12 +2,12 @@
 
 ## Decision
 
-The `0.1.0-alpha.0` candidate is a **go for private local sharing with explicitly
-authorized collaborators** and a **no-go for npm publication or public release**.
-The technical independent roadmap is green, but license, distribution name,
-repository visibility, release channel, and announcement approval remain owner
-decisions. This handoff prepares those decisions; it does not make or execute
-them.
+The `0.1.0-alpha.0` candidate completed its private local handoff. On 2026-08-08
+the owner approved the next release phase in OS-645: publish the new
+`bb-mate@0.1.0-alpha.1` artifact publicly under npm's `alpha` dist-tag, license
+BB Mate under MIT, and keep the GitHub repository private. That approval does
+not move `latest`, create a Git tag or GitHub release, change repository
+visibility, or authorize an announcement.
 
 ## Candidate provenance
 
@@ -44,6 +44,32 @@ registry operation.
   rerun every gate, and record a new checksum and source commit.
 - Use [CHANGELOG.md](../CHANGELOG.md) as the proposed `0.1.0-alpha.0` notes. It
   describes current behavior and limitations without implying publication.
+
+## OS-645 public-alpha candidate
+
+The approved public successor is a new artifact, not modified `alpha.0` bytes:
+
+| Field           | `0.1.0-alpha.1` candidate                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------- |
+| Package         | `bb-mate`                                                                                         |
+| License         | MIT; `LICENSE` shipped                                                                            |
+| npm channel     | public `alpha`; `latest` untouched                                                                |
+| Archive         | `bb-mate-0.1.0-alpha.1.tgz`                                                                       |
+| Archive files   | 41                                                                                                |
+| Catalog stories | 13                                                                                                |
+| SHA-256         | `c3d474a2eb5dc48de93c672941df8bc4313e3a62a0392ce35674ba1322d68f6d`                                |
+| npm shasum      | `2a5360d125b0189aaef5ebc85c10da162ed2c47c`                                                        |
+| npm integrity   | `sha512-GykyMJ9mAcHPhij1njHjVE3oUszJFjBLbhhLtmFbmQdueNnBE8bRHouV/Nyhp7ald53O5Mq3lzIRxP6wAdrTwg==` |
+| Repository      | private                                                                                           |
+| Release commit  | pending PR merge                                                                                  |
+
+Two complete builds and a staging repack are byte-identical. The isolated
+lifecycle verifies both local-prefix and global npm install/help/uninstall,
+passive inspection without plugin execution, all 13 packaged stories, and no
+package/bin/manifest/lockfile residue. npm's exact publication dry-run accepts
+the archive under `alpha`. Targeted and full-stack local reviews are 5/5 clean
+after fixing the shipped support/security disclosure and global-install test
+coverage.
 
 ## Independent roadmap status
 
@@ -212,16 +238,16 @@ not indicate regression in the green Fixture/local-package candidate.
 
 ## Proposed release notes
 
-> **Draft — do not publish without owner approval**
+> **Approved for `bb-mate@0.1.0-alpha.1` under npm's `alpha` dist-tag**
 >
-> BB Mate `0.1.0-alpha.0` is a private local preview for bb plugin authors. It
+> BB Mate `0.1.0-alpha.1` is a public npm preview for bb plugin authors. It
 > adds actionable compatibility inspection, a thin native-handoff CLI, a
 > deterministic 13-surface Fixture lab, visual/accessibility checks, and a
 > reproducible local archive. Native bb still owns scaffold, build, install,
 > dev/reload, and runtime. Fixture is an approximation; official Harness and a
 > real frontend reference-plugin Live path remain upstream-dependent. This
-> preview is `UNLICENSED`, carries no stable support promise, and must not be
-> redistributed.
+> preview is MIT-licensed and carries no stable API or support promise. The
+> source repository and issue tracker remain private.
 
 ## Proposed announcement copy
 
@@ -248,29 +274,31 @@ not indicate regression in the green Fixture/local-package candidate.
       notes, and draft announcement are documented.
 - [x] Fixture/Harness/Live claims remain honest and upstream work is separate.
 
-### Owner decisions — blocking public/npm release
+### Owner decisions — approved for OS-645
 
-- [ ] Approve the distribution model and audience: private file, private
-      registry, or public npm.
-- [ ] Choose and re-check the final package name/scope; npm `E404` is not a
+- [x] Approve public npm distribution for the alpha audience.
+- [x] Choose `bb-mate` and re-check the final name immediately before release;
+      npm `E404` is not a
       reservation.
-- [ ] Choose a public license, add the license file, and update package/repository
-      metadata, or explicitly keep the candidate private and `UNLICENSED`.
-- [ ] Decide repository visibility independently from package distribution.
-- [ ] Approve supported platforms/versions, support commitment, security contact,
-      and release channel.
-- [ ] Approve the final version/tag policy. Proposed first registry version:
-      `0.1.0-alpha.1`, not a mutation of the verified local `alpha.0` bytes.
-- [ ] Approve exact release notes, announcement copy, audience, and timing.
+- [x] Choose MIT and add the license file plus package metadata.
+- [x] Keep the GitHub repository private independently from public npm.
+- [x] Preserve the documented alpha support/security limitations and use the
+      `alpha` release channel.
+- [x] Approve `0.1.0-alpha.1`, not a mutation of the verified local `alpha.0`
+      bytes.
+- [x] Approve the release notes. Announcement copy, audience, and timing remain
+      unapproved and out of scope.
 
-### Execution — not authorized by this handoff
+### OS-645 execution
 
-- [ ] Remove `private: true` only after all applicable owner decisions are
-      committed and reviewed.
-- [ ] Rebuild and rerun every gate; record the new commit, artifact manifest,
+- [x] Remove `private: true` after recording the approved decisions; add MIT
+      metadata and the shipped license.
+- [x] Rebuild and rerun every local gate; record the candidate artifact manifest,
       checksum, and registry dry run.
-- [ ] Publish, tag, create a release, change visibility, or send the announcement
-      only under separate explicit approval.
+- [ ] Merge the reviewed CI-green release PR, rebuild the exact artifact on main,
+      publish it under `alpha`, and verify the registry lifecycle.
+- [x] Keep tags, GitHub releases, visibility changes, and announcements out of
+      OS-645.
 
-Current verdict: **private local sharing go; public/npm release no-go**. Keep the
-OS-638 PR ready but unmerged until the owner chooses the next boundary.
+Current verdict: **public npm alpha approved; implementation, review, merge, and
+exact-artifact verification pending in OS-645**.

--- a/scripts/build-local-package.ts
+++ b/scripts/build-local-package.ts
@@ -52,4 +52,4 @@ if (storyCount !== 13) {
   throw new Error(`Expected 13 packaged surface stories, found ${storyCount}.`);
 }
 
-console.log(`Built private BB Mate CLI and ${storyCount}-story surface lab.`);
+console.log(`Built BB Mate CLI and ${storyCount}-story surface lab.`);

--- a/scripts/package-clean-room.ts
+++ b/scripts/package-clean-room.ts
@@ -93,7 +93,7 @@ function verifyResidueDetector(packageName: string) {
     { packages: { "": { bin: { [packageName]: "dist/cli.js" } } } },
     {
       packages: {
-        "": { resolved: `file:../${packageName}-0.1.0-alpha.0.tgz` },
+        "": { resolved: `file:../${packageName}-0.1.0-alpha.1.tgz` },
       },
     },
   ]) {
@@ -178,6 +178,7 @@ let server: ReturnType<typeof Bun.spawn> | null = null;
 try {
   verifyResidueDetector(sourceManifest.name);
   const installRoot = path.join(temporaryRoot, "install");
+  const globalInstallRoot = path.join(temporaryRoot, "global-install");
   const homeRoot = path.join(temporaryRoot, "home");
   const cacheRoot = path.join(temporaryRoot, "cache");
   const configRoot = path.join(temporaryRoot, "config");
@@ -188,6 +189,7 @@ try {
   await Promise.all(
     [
       homeRoot,
+      globalInstallRoot,
       cacheRoot,
       configRoot,
       dataRoot,
@@ -289,6 +291,7 @@ try {
   const unexpected = paths.filter(
     (file) =>
       file !== "package.json" &&
+      file !== "LICENSE" &&
       file !== "README.md" &&
       file !== "THIRD_PARTY_NOTICES.md" &&
       file !== "THIRD_PARTY_LICENSES.md" &&
@@ -316,14 +319,35 @@ try {
   const stagedManifest = JSON.parse(
     await fs.readFile(path.join(extractedPackage, "package.json"), "utf8"),
   ) as Record<string, unknown>;
-  assert(stagedManifest.private === true, "Artifact must remain private.");
   assert(
-    stagedManifest.license === "UNLICENSED",
-    "Artifact must remain unlicensed.",
+    !("private" in stagedManifest),
+    "Public artifact must not retain the private publication guard.",
+  );
+  assert(
+    stagedManifest.license === "MIT",
+    "Public artifact must declare the approved MIT license.",
+  );
+  assert(
+    stagedManifest.version === "0.1.0-alpha.1",
+    "Artifact must use the approved alpha.1 version.",
+  );
+  assert(
+    JSON.stringify(stagedManifest.publishConfig) ===
+      JSON.stringify({ access: "public", tag: "alpha" }),
+    "Artifact must publish publicly under the alpha dist-tag.",
   );
   assert(
     !("dependencies" in stagedManifest),
     "Artifact must not retain workspace dependencies.",
+  );
+  const packageLicense = await fs.readFile(
+    path.join(extractedPackage, "LICENSE"),
+    "utf8",
+  );
+  assert(
+    packageLicense.startsWith("MIT License") &&
+      packageLicense.includes("Copyright (c) 2026 Matt Galligan"),
+    "Artifact must ship the approved MIT license text.",
   );
   const thirdPartyLicenses = await fs.readFile(
     path.join(extractedPackage, "THIRD_PARTY_LICENSES.md"),
@@ -379,6 +403,59 @@ try {
 
   const copiedArtifact = path.join(temporaryRoot, artifactName);
   await fs.copyFile(artifactPath, copiedArtifact);
+  await run(
+    [
+      "npm",
+      "install",
+      "--global",
+      "--prefix",
+      globalInstallRoot,
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      copiedArtifact,
+    ],
+    { env: lifecycleEnv },
+  );
+  const globalBin = path.join(globalInstallRoot, "bin", "bb-mate");
+  const globalPackage = path.join(
+    globalInstallRoot,
+    "lib",
+    "node_modules",
+    sourceManifest.name,
+  );
+  await Promise.all([
+    fs.access(globalBin, constants.X_OK),
+    fs.access(globalPackage, constants.R_OK),
+  ]);
+  const globalHelp = await run([globalBin, "--help"], {
+    cwd: temporaryRoot,
+    env: lifecycleEnv,
+  });
+  assert(
+    globalHelp.stdout.includes("Usage: bb-mate"),
+    "Global installed bin help failed.",
+  );
+  await run(
+    [
+      "npm",
+      "uninstall",
+      "--global",
+      "--prefix",
+      globalInstallRoot,
+      sourceManifest.name,
+    ],
+    { env: lifecycleEnv },
+  );
+  for (const residue of [globalBin, globalPackage]) {
+    await fs.access(residue).then(
+      () => {
+        throw new Error(`npm global uninstall left ${residue} behind.`);
+      },
+      () => undefined,
+    );
+  }
+
   await run(
     [
       "npm",

--- a/scripts/package-local.ts
+++ b/scripts/package-local.ts
@@ -53,19 +53,25 @@ const stagedManifest = Object.fromEntries(
   [
     "name",
     "version",
-    "private",
+    "description",
     "license",
+    "keywords",
     "type",
     "bin",
     "files",
     "engines",
     "bbMate",
+    "publishConfig",
   ].map((key) => [key, sourceManifest[key]]),
 );
 await Promise.all([
   fs.writeFile(
     path.join(stagingRoot, "package.json"),
     `${JSON.stringify(stagedManifest, null, 2)}\n`,
+  ),
+  fs.copyFile(
+    path.join(repositoryRoot, "LICENSE"),
+    path.join(stagingRoot, "LICENSE"),
   ),
   fs.copyFile(
     path.join(cliRoot, "README.md"),
@@ -103,6 +109,7 @@ const paths = result.files.map((file) => file.path);
 const unexpected = paths.filter(
   (file) =>
     file !== "package.json" &&
+    file !== "LICENSE" &&
     file !== "README.md" &&
     file !== "THIRD_PARTY_NOTICES.md" &&
     file !== "THIRD_PARTY_LICENSES.md" &&
@@ -114,6 +121,7 @@ if (unexpected.length > 0) {
 }
 for (const required of [
   "package.json",
+  "LICENSE",
   "README.md",
   "THIRD_PARTY_NOTICES.md",
   "THIRD_PARTY_LICENSES.md",


### PR DESCRIPTION
## Context

#47 turns the reviewed private alpha handoff into the owner-approved public npm prerelease while keeping the GitHub repository private.

## Changes

- license BB Mate under MIT and ship LICENSE in the package
- advance the CLI package to bb-mate@0.1.0-alpha.1 with public alpha publish metadata
- verify both global and local-prefix install/help/uninstall lifecycles
- update package, support, security, author, changelog, and release documentation

## Verification

- bun install --frozen-lockfile
- bun run format:check
- bun run check
- bun run test
- bun run build
- bun run visual:test
- bun run package:inspect
- npm publication dry-run for the exact tarball
- targeted local review: 5/5 clean after two fixed P2s
- full-stack local review: 5/5 clean, zero open P0-P3

Candidate: 41 files, 13 stories, SHA-256 c3d474a2eb5dc48de93c672941df8bc4313e3a62a0392ce35674ba1322d68f6d.

## Release boundary

This PR does not publish, move latest, create a tag or GitHub release, change repository visibility, or announce the release. Publication happens only after this PR and hosted CI are green and merged, followed by an exact post-merge artifact match.

## Issue

Implements #47 under roadmap #21.