### PR TITLE
docs: record bb-mate npm alpha publication

### DIFF
--- a/.agents/plans/2026-08-08-os-645-publish-bb-mate-alpha.md
+++ b/.agents/plans/2026-08-08-os-645-publish-bb-mate-alpha.md
@@ -4,8 +4,9 @@
 
 Publish the reviewed BB Mate CLI as the public unscoped package
 `bb-mate@0.1.0-alpha.1` under the `alpha` dist-tag. Preserve the verified
-private `0.1.0-alpha.0` bytes, keep the GitHub repository private, and leave
-`latest` untouched.
+private `0.1.0-alpha.0` bytes and keep the GitHub repository private. npm's
+first-package registry bootstrap also created its mandatory `latest` tag at the
+same only published version; the attempted authenticated removal returned E400.
 
 ## Success proof
 
@@ -20,8 +21,9 @@ private `0.1.0-alpha.0` bytes, keep the GitHub repository private, and leave
 - Targeted and full-stack local reviews are 5/5 with no open P0/P1/P2.
 - The release PR is CI-green and merged; the exact post-merge artifact matches
   the reviewed artifact.
-- npm shows `bb-mate@0.1.0-alpha.1` under `alpha`, does not expose or move
-  `latest`, and a clean registry install/help/uninstall lifecycle passes.
+- npm shows `bb-mate@0.1.0-alpha.1` under `alpha`; the registry's mandatory
+  bootstrap `latest` tag points to the same only version; and a clean registry
+  install/help/uninstall lifecycle passes.
 - Linear OS-645 records the release commit, PR, CI, registry URL, checksums,
   integrity, and remaining alpha limitations.
 
@@ -37,17 +39,17 @@ private `0.1.0-alpha.0` bytes, keep the GitHub repository private, and leave
 4. [x] Run the full local gate and record the exact candidate artifact evidence.
 5. [x] Complete targeted and full-stack local reviews; fix and re-run any open
        P0/P1/P2 finding.
-6. [ ] Commit on the Linear branch, open a draft PR, pass hosted CI, mark ready,
+6. [x] Commit on the Linear branch, open a draft PR, pass hosted CI, mark ready,
        merge, and verify main CI.
-7. [ ] Rebuild on merged main, prove exact artifact identity, publish with
+7. [x] Rebuild on merged main, prove exact artifact identity, publish with
        `--tag alpha`, and verify registry metadata plus a clean registry lifecycle.
 8. [ ] Update Linear and this plan with final provenance and leave the GitButler
        workspace clean with no applied lanes.
 
 ## Boundaries
 
-- Do not publish `0.1.0-alpha.0`, move `latest`, create a Git tag or GitHub
-  release, change repository visibility, or announce the release.
+- Do not publish `0.1.0-alpha.0`, intentionally repoint `latest`, create a Git
+  tag or GitHub release, change repository visibility, or announce the release.
 - Do not edit `../bb`, implement upstream-dependent OS-639–OS-644 work, copy the
   SDK/Harness, or mutate normal bb/plugin/Connect state.
 - Stop before publication if the name is no longer available, the exact artifact
@@ -60,9 +62,11 @@ private `0.1.0-alpha.0` bytes, keep the GitHub repository private, and leave
 ## Evidence
 
 - Linear: OS-645
-- Release PR: pending
-- Release commit: pending
-- Main merge commit: pending
+- Release PR: <https://github.com/galligan/bb-mate/pull/14>
+- Release commit: `3a9694b4fbccf0cbeb76b8f071d9f71ab8bbea5d`
+- Main merge commit: `c2c33fea523148e56914168df84399db1c0adc51`
+- PR CI: <https://github.com/galligan/bb-mate/actions/runs/31259377836>
+- Main CI: <https://github.com/galligan/bb-mate/actions/runs/31259484216>
 - Package: 41 files, 13 stories, 514333-byte archive, 1057566 bytes unpacked
 - Package SHA-256:
   `c3d474a2eb5dc48de93c672941df8bc4313e3a62a0392ce35674ba1322d68f6d`
@@ -73,4 +77,13 @@ private `0.1.0-alpha.0` bytes, keep the GitHub repository private, and leave
   — 5/5 clean after fixing two P2s from round 1
 - Full-stack review: `/tmp/agent-reviews/os-645/full-stack/round-1.json` —
   5/5 clean, zero open P0-P3
-- Registry: pending
+- Post-publish review: `/tmp/agent-reviews/os-645/post-publish/round-1.json` —
+  5/5 clean, zero open P0-P3
+- Registry: <https://www.npmjs.com/package/bb-mate/v/0.1.0-alpha.1>
+- Live tags: `alpha: 0.1.0-alpha.1`, mandatory first-package
+  `latest: 0.1.0-alpha.1`
+- Registry lifecycle: exact registry tarball SHA-256 matched the merged-main
+  artifact; clean `bb-mate@alpha` install/help/uninstall passed with no residue
+- Tag divergence: authenticated `npm dist-tag rm bb-mate latest` returned E400;
+  [npm registry metadata](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)
+  documents that every package has a `latest` tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ prereleases; it does not imply a stable API or support promise.
   their upstream contracts ship.
 - This prerelease supports Bun as its CLI runtime and carries no stable API,
   response-time SLA, or public issue tracker.
+- npm's first-package bootstrap also points its mandatory `latest` tag at this
+  only published version; install `bb-mate@alpha` to select the intended channel
+  explicitly.
 
 ## 0.1.0-alpha.0 — private local candidate
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -91,5 +91,7 @@ record:
 - announcement text and audience.
 
 OS-645 records the owner-approved `bb-mate@0.1.0-alpha.1` npm release under the
-`alpha` dist-tag. It does not authorize moving `latest`, creating a Git tag or
-GitHub release, changing visibility, or announcing availability.
+`alpha` dist-tag. npm's first-package bootstrap also created its mandatory
+`latest` tag at that same only version; an authenticated removal attempt returned
+E400. OS-645 does not authorize intentionally repointing it, creating a Git tag
+or GitHub release, changing visibility, or announcing availability.

--- a/docs/local-package.md
+++ b/docs/local-package.md
@@ -99,6 +99,11 @@ green hosted CI, and merge, publish only the exact post-merge artifact:
 npm publish ./artifacts/bb-mate-0.1.0-alpha.1.tgz --access public --tag alpha
 ```
 
-Verify that `alpha` points to `0.1.0-alpha.1`, `latest` was not created or moved,
-and a clean registry install succeeds. Publication does not create a Git tag or
-GitHub release, change repository visibility, or send an announcement.
+Verify that `alpha` points to `0.1.0-alpha.1` and a clean registry install
+succeeds. npm's first-package bootstrap also creates the registry's mandatory
+[`latest` tag](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)
+at the only published version even when publication uses
+`--tag alpha`; OS-645 records the authenticated E400 returned when removal was
+attempted. Do not intentionally repoint that tag in later alpha work.
+Publication does not create a Git tag or GitHub release, change repository
+visibility, or send an announcement.

--- a/docs/release-handoff.md
+++ b/docs/release-handoff.md
@@ -6,8 +6,10 @@ The `0.1.0-alpha.0` candidate completed its private local handoff. On 2026-08-08
 the owner approved the next release phase in OS-645: publish the new
 `bb-mate@0.1.0-alpha.1` artifact publicly under npm's `alpha` dist-tag, license
 BB Mate under MIT, and keep the GitHub repository private. That approval does
-not move `latest`, create a Git tag or GitHub release, change repository
-visibility, or authorize an announcement.
+not intentionally repoint `latest`, create a Git tag or GitHub release, change
+repository visibility, or authorize an announcement. npm's first-package
+bootstrap nevertheless created its mandatory `latest` tag at the same only
+published version; OS-645 records the failed authenticated removal attempt.
 
 ## Candidate provenance
 
@@ -53,7 +55,7 @@ The approved public successor is a new artifact, not modified `alpha.0` bytes:
 | --------------- | ------------------------------------------------------------------------------------------------- |
 | Package         | `bb-mate`                                                                                         |
 | License         | MIT; `LICENSE` shipped                                                                            |
-| npm channel     | public `alpha`; `latest` untouched                                                                |
+| npm channel     | public `alpha`; mandatory bootstrap `latest` points to the same only version                      |
 | Archive         | `bb-mate-0.1.0-alpha.1.tgz`                                                                       |
 | Archive files   | 41                                                                                                |
 | Catalog stories | 13                                                                                                |
@@ -61,7 +63,7 @@ The approved public successor is a new artifact, not modified `alpha.0` bytes:
 | npm shasum      | `2a5360d125b0189aaef5ebc85c10da162ed2c47c`                                                        |
 | npm integrity   | `sha512-GykyMJ9mAcHPhij1njHjVE3oUszJFjBLbhhLtmFbmQdueNnBE8bRHouV/Nyhp7ald53O5Mq3lzIRxP6wAdrTwg==` |
 | Repository      | private                                                                                           |
-| Release commit  | pending PR merge                                                                                  |
+| Release commit  | `3a9694b4fbccf0cbeb76b8f071d9f71ab8bbea5d`; merge `c2c33fea523148e56914168df84399db1c0adc51`      |
 
 Two complete builds and a staging repack are byte-identical. The isolated
 lifecycle verifies both local-prefix and global npm install/help/uninstall,
@@ -70,6 +72,13 @@ package/bin/manifest/lockfile residue. npm's exact publication dry-run accepts
 the archive under `alpha`. Targeted and full-stack local reviews are 5/5 clean
 after fixing the shipped support/security disclosure and global-install test
 coverage.
+
+The live registry tarball is byte-identical to the merged-main artifact. Both
+`alpha` and npm's mandatory `latest` bootstrap tag resolve to
+`0.1.0-alpha.1`. An authenticated `npm dist-tag rm bb-mate latest` attempt
+returned E400, consistent with npm registry metadata requiring every package to
+[define `latest`](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md);
+no second version was published and no tag was repointed.
 
 ## Independent roadmap status
 
@@ -295,10 +304,10 @@ not indicate regression in the green Fixture/local-package candidate.
       metadata and the shipped license.
 - [x] Rebuild and rerun every local gate; record the candidate artifact manifest,
       checksum, and registry dry run.
-- [ ] Merge the reviewed CI-green release PR, rebuild the exact artifact on main,
+- [x] Merge the reviewed CI-green release PR, rebuild the exact artifact on main,
       publish it under `alpha`, and verify the registry lifecycle.
 - [x] Keep tags, GitHub releases, visibility changes, and announcements out of
       OS-645.
 
-Current verdict: **public npm alpha approved; implementation, review, merge, and
-exact-artifact verification pending in OS-645**.
+Current verdict: **`bb-mate@0.1.0-alpha.1` is published and byte-verified; the
+mandatory first-package `latest` bootstrap divergence is recorded in OS-645**.


### PR DESCRIPTION
## Context

Records the completed #47 registry release and one npm bootstrap divergence discovered only after the immutable publish.

## Changes

- record PR, merge, CI, registry, checksum, integrity, and clean install provenance
- document that npm created mandatory latest alongside alpha for the first package version
- record the authenticated removal attempt and registry E400 without claiming it succeeded
- keep future latest movement, Git tags/releases, visibility changes, and announcements out of scope

## Verification

- live registry metadata and dist-tags
- registry tarball byte-for-byte match with merged-main artifact
- clean bb-mate@alpha install/help/uninstall
- repository remains private with no GitHub release or head tag
- bun run format:check
- git diff --check
- post-publish local review: 5/5 clean, zero open P0-P3

No package bytes or runtime code change in this PR.

## Issue

Records completion evidence for #47 under roadmap #21.