### PR TITLE
chore: prepare bb-mate 0.1.0-alpha.2

### DIFF
--- a/.agents/plans/2026-08-08-os-647-alpha2-readme.md
+++ b/.agents/plans/2026-08-08-os-647-alpha2-readme.md
@@ -1,0 +1,66 @@
+# OS-647 — Publish alpha.2 with the public README
+
+## Outcome
+
+Publish `bb-mate@0.1.0-alpha.2` as a minimal documentation refresh so npm shows
+the public project README and repository metadata already merged to main.
+
+## Success criteria
+
+- The only intentional source changes are the package version, current release
+  documentation, clean-room version assertions, and this plan.
+- The exact package contains the public README, upstream bb link, bb/SDK/BB Mate
+  responsibility boundary, GitHub Issues/security links, MIT license, and public
+  repository/homepage/bugs metadata.
+- Full local gates, clean-room lifecycle, package inspection, targeted release
+  review, full-stack review, hosted PR CI, and post-merge main CI pass.
+- The registry tarball is byte-identical to the reviewed merged-main artifact.
+- npm `alpha` advances to `0.1.0-alpha.2`; `latest` remains at
+  `0.1.0-alpha.1`.
+- A clean global registry install/help/uninstall lifecycle passes with no
+  residue.
+
+## Plan
+
+1. [x] Verify clean main, npm identity, existing alpha.1 registry provenance,
+       and current dist-tags.
+2. [x] Bump the package and current artifact/release documentation to alpha.2
+       without changing runtime behavior.
+3. [x] Run the full local gate, inspect the packed README/metadata, and record
+       exact artifact checksums.
+4. [x] Complete targeted release and full-stack local reviews; fix and rerun
+       every open P0/P1/P2 finding.
+5. [ ] Commit on the OS-647 branch, open a draft PR, pass hosted CI/review, mark
+       ready, merge, and pass post-merge main CI.
+6. [ ] Rebuild on merged main, prove exact artifact identity, publish the exact
+       tarball with `--tag alpha`, and verify registry metadata/readme/install.
+7. [ ] Confirm `alpha` moved to alpha.2 while `latest` stayed at alpha.1, update
+       Linear and this plan, and leave GitButler clean and lane-free.
+
+## Boundaries
+
+- Do not alter or republish the existing alpha.1 bytes.
+- Do not change runtime code, dependencies, native bb behavior, Fixture stories,
+  npm `latest`, repository visibility, Git tags, GitHub releases, or upstream bb.
+- Do not announce the release.
+- Stop before publication if review/CI is not clean, the post-merge artifact
+  differs, npm authentication fails, or the registry operation would move
+  `latest`.
+
+## Evidence
+
+- Linear: OS-647
+- Registry: <https://www.npmjs.com/package/bb-mate>
+- Starting main: `16ba19baa3f32ea97adc3763d4cf3017d93ae4f2`
+- Existing alpha.1 npm shasum: `2a5360d125b0189aaef5ebc85c10da162ed2c47c`
+- Starting tags: `alpha: 0.1.0-alpha.1`, `latest: 0.1.0-alpha.1`
+- Local gates: formatting, checks, tests, builds, 14 visual/a11y tests, and
+  41-file package inspection passed.
+- Candidate SHA-256: `de6174f733c8a76fdc4b7e117ff2499a47d55e918e02150fecb9337384e0e843`
+- Candidate npm shasum: `4240b4b4cf397cda838b0a882e04ecb813835bf7`
+- Candidate npm integrity:
+  `sha512-mdh9oiBilXrpo/dcgvya791/+eCBSsynZAK6BkYG0fU/q3AtPcpLNhmNANs3yOZ8z6yXQ8zR/dvihdiL6stM2Q==`
+- Targeted release review: 5/5 clean, zero findings
+  (`/tmp/agent-reviews/os-647/targeted/round-1.json`).
+- Full-stack review: 5/5 clean, zero findings
+  (`/tmp/agent-reviews/os-647/full-stack/round-1.json`).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     id: version
     attributes:
       label: BB Mate version
-      placeholder: bb-mate@0.1.0-alpha.1 or source commit
+      placeholder: bb-mate@0.1.0-alpha.2 or source commit
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 BB Mate is an alpha. This changelog records reviewable candidates and public
 prereleases; it does not imply a stable API or support promise.
 
-## Unreleased
+## 0.1.0-alpha.2 — public README refresh
 
 ### Changed
 
@@ -12,7 +12,9 @@ prereleases; it does not imply a stable API or support promise.
 - Rewrite the public documentation around plugin authors and clarify the
   boundary between native bb, `@bb/plugin-sdk`, and BB Mate.
 - Add repository, homepage, and issue-tracker metadata to the next packaged CLI
-  artifact. The existing npm `0.1.0-alpha.1` bytes remain unchanged.
+  artifact.
+- Publish a new package version so npm renders the public README. Runtime code,
+  dependencies, and Fixture stories are unchanged from alpha.1.
 
 ## 0.1.0-alpha.1 — public npm alpha
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-mate",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "A fixture-driven authoring companion for native bb plugins",
   "homepage": "https://github.com/galligan/bb-mate#readme",
   "repository": {

--- a/docs/local-package.md
+++ b/docs/local-package.md
@@ -18,7 +18,7 @@ The command rebuilds the CLI and surface lab, creates an isolated staging
 manifest with no workspace dependencies, and writes the versioned archive:
 
 ```text
-artifacts/bb-mate-0.1.0-alpha.1.tgz
+artifacts/bb-mate-0.1.0-alpha.2.tgz
 ```
 
 The artifact is MIT-licensed and configured for public publication under the
@@ -96,10 +96,10 @@ The package scripts above never publish. After owner approval, clean review,
 green hosted CI, and merge, publish only the exact post-merge artifact:
 
 ```sh
-npm publish ./artifacts/bb-mate-0.1.0-alpha.1.tgz --access public --tag alpha
+npm publish ./artifacts/bb-mate-0.1.0-alpha.2.tgz --access public --tag alpha
 ```
 
-Verify that `alpha` points to `0.1.0-alpha.1` and a clean registry install
+Verify that `alpha` points to `0.1.0-alpha.2` and a clean registry install
 succeeds. npm's first-package bootstrap also creates the registry's mandatory
 [`latest` tag](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)
 at the only published version even when publication uses `--tag alpha`. An

--- a/scripts/package-clean-room.ts
+++ b/scripts/package-clean-room.ts
@@ -93,7 +93,7 @@ function verifyResidueDetector(packageName: string) {
     { packages: { "": { bin: { [packageName]: "dist/cli.js" } } } },
     {
       packages: {
-        "": { resolved: `file:../${packageName}-0.1.0-alpha.1.tgz` },
+        "": { resolved: `file:../${packageName}-0.1.0-alpha.2.tgz` },
       },
     },
   ]) {
@@ -328,8 +328,8 @@ try {
     "Public artifact must declare the approved MIT license.",
   );
   assert(
-    stagedManifest.version === "0.1.0-alpha.1",
-    "Artifact must use the approved alpha.1 version.",
+    stagedManifest.version === "0.1.0-alpha.2",
+    "Artifact must use the approved alpha.2 version.",
   );
   assert(
     stagedManifest.homepage === "https://github.com/galligan/bb-mate#readme" &&


### PR DESCRIPTION
## Context

The first public alpha predates the open-source README and repository metadata now on main. This minimal follow-up publishes those docs on npm without changing runtime behavior.

## What changed

- bump the CLI package to 0.1.0-alpha.2
- roll the public documentation refresh into the changelog
- update version-coupled package docs, issue template, and clean-room assertions
- record #49 verification and release boundaries

## Verification

- bun run format:check
- bun run check
- bun run test
- bun run build
- bun run visual:test (14 passed)
- bun run package:inspect (41 files)
- targeted local review: 5/5 clean
- full-stack local review: 5/5 clean
- npm publish dry run for the exact artifact

Candidate SHA-256: `de6174f733c8a76fdc4b7e117ff2499a47d55e918e02150fecb9337384e0e843`

## Release boundary

After merge and main CI, rebuild and require byte identity before publishing with `--tag alpha`. Keep `latest` on 0.1.0-alpha.1. No Git tag, GitHub release, upstream edit, or announcement.

## Issue

Implements #49 under roadmap #21.