### PR TITLE
feat: compile standalone bb-mate executable

### DIFF
--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -146,8 +146,8 @@ The legacy package lane remained separate and green: 41 files, 13 stories, and
 clean-room SHA-256
 `77f7cb2e924e047d09c53237e28eeeee5a69c2023829134ba497ba69d7530ba2`.
 Focused tests, format, typecheck, compatibility, aggregate tests/build, and 14
-visual/accessibility checks passed. A dedicated `macos-15` arm64 hosted job is
-added but remains pending until the draft PR is pushed.
+visual/accessibility checks passed. Draft PR #69 is pushed, and its dedicated
+`macos-15` arm64 job, Linux verification, visual, and security checks are green.
 
 ## Review Log
 
@@ -199,6 +199,16 @@ added but remains pending until the draft PR is pushed.
   merge endpoint as `d40aef0b7b04e6f76982b7203927905fd380c5a8`, closed #54,
   and reconciled to a clean, lane-free GitButler workspace. Epic #21 now links
   the capability matrix on `main` and marks Gate 0 complete.
+- Standalone round 1: standing scored 3/5 and targeted scored 2/5. Their shared
+  P1 (`ST-SA-001` / `PW-STANDALONE-001`) found that the exported builder could
+  recursively delete a caller-selected broad output root. Recursive root
+  deletion is removed: the builder now rejects repository ancestors, symlink
+  roots, and unexpected entries, validates the whole directory first, and
+  unlinks only `bb-mate` and `manifest.json`; three focused ownership tests
+  cover replacement, no-delete rejection, broad paths, and symlinks. Shared P2
+  `ST-SA-002` / `PW-STANDALONE-002` corrected the plan's package filter to
+  `bb-mate`. `PW-STANDALONE-003` corrected hosted CI state from pending to
+  green. All findings are fixed for round 2.
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -209,6 +209,15 @@ visual/accessibility checks passed. Draft PR #69 is pushed, and its dedicated
   `ST-SA-002` / `PW-STANDALONE-002` corrected the plan's package filter to
   `bb-mate`. `PW-STANDALONE-003` corrected hosted CI state from pending to
   green. All findings are fixed for round 2.
+- Standalone round 2: standing reached 5/5; targeted reached 4/5 and kept
+  `PW-STANDALONE-001` open because allowlisted replacement still removed the
+  prior valid pair before a new build succeeded, and the system temp root was
+  rejected only incidentally. The builder now structurally permits only the
+  canonical artifact root or a leaf beneath `os.tmpdir()`, builds both files in
+  a sibling staging directory, validates the exact pair before promotion,
+  restores the old directory if promotion fails, and removes only a validated
+  backup. Five ownership tests now include incomplete-stage and injected
+  partway-promotion failures that prove the prior pair stays byte-identical.
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -5,23 +5,23 @@ Status: Active
 
 ## Summary
 
-The execution goal is active. Compatibility baseline #52 and spec/goal PR #53
-are merged. Released-capability Gate 0 implementation and review are complete
-with all six rows passing and both independent reviewers at 5/5; PR #68 is at
-its final ready/merge gate.
+The execution goal is active. Compatibility baseline #52, spec/goal PR #53,
+and released-capability Gate 0 PR #68 are merged. Standalone-runtime #56 is
+implemented and independently reviewed at 5/5; PR #69 is at its final
+ready/merge gate.
 
 ## Readiness
 
-Active. Prompt/doctor/formatting and packet reviews pass; #52 and #53 are
+Active. Prompt/doctor/formatting and packet reviews pass; #52, #53, and #68 are
 merged. Gate 0 admits all released host-plugin rows to downstream execution.
-Its exact-head review and hosted CI gates pass; only the ready/merge transition
-and reconciliation remain.
+Standalone #69 has green local, hosted, and two-lane exact-head review evidence;
+only its ready/merge transition and reconciliation remain.
 
 ## Baseline
 
 - Repository: `/Users/mg/Developer/bb/bb-mate`
-- Gate branch: `test/plugin-workbench/released-capability-gate`; issue #54.
-- Current merge base: `59479253b2c0f6b465d5da870958267f846f42de`.
+- Standalone branch: `feat/cli/standalone-executable`; issue #56; PR #69.
+- Current merge base: `d40aef0b7b04e6f76982b7203927905fd380c5a8`.
 - Compatibility PR #52 merged from exact head
   `1b047598b52f49ed8e6e0f7dd88387ff02c10445` to baseline merge commit
   `fa02c6d0d7c4ffb2f8855029def1589ed7ce7824`; issue #51 is closed.
@@ -29,7 +29,10 @@ and reconciliation remain.
   `e48e0306f2eb01c167aca19ce349c5b54bfcfc80` through GitHub async request
   `3227e20c-b82b-4b20-9138-e7b17bd95d77`. Merge commit:
   `59479253b2c0f6b465d5da870958267f846f42de`.
-- GitButler is clean with only the Gate 0 branch active.
+- Gate 0 PR #68 merged from exact reviewed head
+  `87066b4f62f82283fec8f25a912bd48a682f72cb` to merge commit
+  `d40aef0b7b04e6f76982b7203927905fd380c5a8`; issue #54 is closed.
+- GitButler is clean with only the standalone branch active.
 
 ## Preparation findings
 
@@ -225,11 +228,16 @@ visual/accessibility checks passed. Draft PR #69 is pushed, and its dedicated
   rejects symlinks before creating the leaf, then verifies the real output root
   remains beneath the real allowed base. A focused no-write test uses an
   outside task-owned directory and proves the symlink target remains empty.
+- Standalone round 4: standing and targeted exact-head reviews both reached
+  5/5 at `c6d0e93109f492cad754f270adef5ec6a39935c2` with zero findings. The
+  original symlink-parent attack now rejects without touching its target;
+  transactional rollback, moved empty-PATH execution, legacy package,
+  aggregate, visual, hosted CI, thread, tracker, and clean-workspace gates pass.
 
 ## Verification Log
 
 - `check-goal-prompt --no-placeholders`: passed at 3,216/4,000 characters.
-- `goal-loop-doctor`: passed with both active round-three reports clean.
+- `goal-loop-doctor`: passed with every active review report clean.
 - `bun run format:check`: passed for the reviewed packet and design record.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
@@ -258,6 +266,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 ## Final State
 
-Execution active. Gate 0 is merged and reconciled. Standalone-runtime #56
-implementation is locally green and entering review from the clean post-#68
-base; domain #55 remains independent and prepared for a separate branch.
+Execution active. Gate 0 is merged and reconciled. Standalone-runtime #56 has
+completed implementation and two independent review lanes; PR #69 is ready for
+its final merge transition. Domain #55 remains independent and prepared for a
+separate branch.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -166,6 +166,13 @@ only representation.
   `G0-SG-005` and targeted `PW-GATE0-004` both scored the head 4/5 and required
   “implementation and review complete; merge pending.” The status is corrected;
   completion remains reserved for post-merge reconciliation and #54 closure.
+- Gate 0 round 5: standing and targeted exact-head reviews both reached 5/5 at
+  `87066b4f62f82283fec8f25a912bd48a682f72cb` with zero findings. Hosted
+  verify, visual, and security checks were green, and no review threads remained.
+- PR #68 left draft at that exact head, merged through GitHub's SHA-pinned async
+  merge endpoint as `d40aef0b7b04e6f76982b7203927905fd380c5a8`, closed #54,
+  and reconciled to a clean, lane-free GitButler workspace. Epic #21 now links
+  the capability matrix on `main` and marks Gate 0 complete.
 
 ## Verification Log
 
@@ -199,6 +206,6 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 ## Final State
 
-Execution active; next gate is PR #68 ready transition, exact-head pin, async
-merge, and reconciliation, then the domain and standalone-runtime foundation
-lanes.
+Execution active. Gate 0 is merged and reconciled. The standalone-runtime #56
+lane is in progress from the clean post-#68 base; the domain #55 lane remains
+independent and prepared for a separate branch.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -218,6 +218,13 @@ visual/accessibility checks passed. Draft PR #69 is pushed, and its dedicated
   restores the old directory if promotion fails, and removes only a validated
   backup. Five ownership tests now include incomplete-stage and injected
   partway-promotion failures that prove the prior pair stays byte-identical.
+- Standalone round 3: standing and targeted both scored 4/5. Their shared P2
+  (`ST-SA-003` / continued `PW-STANDALONE-001`) reproduced a symlinked parent
+  beneath the lexical temporary root redirecting output into a separate
+  physical tree. The builder now walks every existing relative component and
+  rejects symlinks before creating the leaf, then verifies the real output root
+  remains beneath the real allowed base. A focused no-write test uses an
+  outside task-owned directory and proves the symlink target remains empty.
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -123,6 +123,32 @@ blocked by every integrated input; #63 blocks on #65; and #64 blocks on #63.
 Issue dependency sections match the native graph rather than serving as its
 only representation.
 
+## Standalone executable #56
+
+Implementation head `02be708155cf3e7f66165cfe092bedbc361ade5e` builds a
+separate unsigned `bun-darwin-arm64` executable without changing the published
+npm/shebang package. A generated, sorted static-import entry embeds the exact
+Ladle bytes behind stable routes; source/package and standalone entrypoint modes
+are explicit, and standalone has no Bun interpreter fallback.
+
+The pre-review clean-room artifact is mode `0755`, 64,420,322 bytes, SHA-256
+`479df4999ef6e6d340134a6dae61e85b11bc1a98f0c085754b152485ce7b0ec3`,
+with 35 hashed assets and 13 stories. Two complete pinned Bun 1.3.14 builds were
+byte-identical. The moved executable passed with empty `PATH`, isolated
+HOME/TMP/XDG state, cleared Bun override variables, ambient `.env` and
+`bunfig.toml`, and the checkout lab renamed out of reach. It passed help,
+passive inspection without target-plugin execution, GET/HEAD, every asset hash,
+story metadata, SIGTERM, and post-exit listener unreachability. Printable
+payload inspection and the clean-room assertion found no absolute repository
+path.
+
+The legacy package lane remained separate and green: 41 files, 13 stories, and
+clean-room SHA-256
+`77f7cb2e924e047d09c53237e28eeeee5a69c2023829134ba497ba69d7530ba2`.
+Focused tests, format, typecheck, compatibility, aggregate tests/build, and 14
+visual/accessibility checks passed. A dedicated `macos-15` arm64 hosted job is
+added but remains pending until the draft PR is pushed.
+
 ## Review Log
 
 - Runtime/packaging, public bb seam, security/MCP, and goal-scope audits
@@ -206,6 +232,6 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 ## Final State
 
-Execution active. Gate 0 is merged and reconciled. The standalone-runtime #56
-lane is in progress from the clean post-#68 base; the domain #55 lane remains
-independent and prepared for a separate branch.
+Execution active. Gate 0 is merged and reconciled. Standalone-runtime #56
+implementation is locally green and entering review from the clean post-#68
+base; domain #55 remains independent and prepared for a separate branch.

--- a/.agents/plans/2026-08-10-plugin-workbench-gate-0.md
+++ b/.agents/plans/2026-08-10-plugin-workbench-gate-0.md
@@ -1,7 +1,7 @@
 # Plugin Workbench released-capability Gate 0
 
 Date: 2026-08-10
-Status: Implementation and review complete; merge pending
+Status: Complete
 Issue: [#54](https://github.com/galligan/bb-mate/issues/54)
 Goal: `.agents/goals/2026-08-10-plugin-workbench/`
 
@@ -95,3 +95,5 @@ All six rows have reproducible evidence and pass; they are admitted to the goal
 independently; any later failed row has an honest tracked unblock condition; #54
 and the goal ledger are current; the result is merged to `main` with clean
 workspace/CI/reviews.
+
+Merged through PR #68 as `d40aef0b7b04e6f76982b7203927905fd380c5a8`.

--- a/.agents/plans/2026-08-10-standalone-executable.md
+++ b/.agents/plans/2026-08-10-standalone-executable.md
@@ -1,7 +1,7 @@
 # Self-contained bb-mate executable
 
 Date: 2026-08-10
-Status: In progress
+Status: Implementation complete; review pending
 Issue: [#56](https://github.com/galligan/bb-mate/issues/56)
 Goal: `.agents/goals/2026-08-10-plugin-workbench/`
 
@@ -31,22 +31,22 @@ a separate compatibility lane.
 
 ## Implementation
 
-1. [ ] Introduce a focused lab asset provider with filesystem containment and
+1. [x] Introduce a focused lab asset provider with filesystem containment and
        exact-key embedded implementations.
-2. [ ] Make the static lab handler consume the provider while retaining
+2. [x] Make the static lab handler consume the provider while retaining
        GET/HEAD, MIME, traversal/symlink, loopback, and shutdown behavior.
-3. [ ] Split entrypoint construction from the shebang wrapper; make source and
+3. [x] Split entrypoint construction from the shebang wrapper; make source and
        standalone modes explicit and make standalone incapable of re-executing
        itself as Bun.
-4. [ ] Generate a sorted, validated static-import entry from the 13-story Ladle
+4. [x] Generate a sorted, validated static-import entry from the 13-story Ladle
        output and compile `bun-darwin-arm64` with dotenv/bunfig autoload disabled.
-5. [ ] Emit an exact two-file artifact directory (`bb-mate`, `manifest.json`)
+5. [x] Emit an exact two-file artifact directory (`bb-mate`, `manifest.json`)
        recording mode, arch, size, SHA-256, story count, and sorted asset hashes.
-6. [ ] Add a separate empty-PATH clean-room lane that builds twice, compares
+6. [x] Add a separate empty-PATH clean-room lane that builds twice, compares
        unsigned bytes, moves the binary, makes checkout lab assets unavailable,
        proves help/passive inspect/Fixture GET+HEAD/all stories, and confirms
        process/listener cleanup.
-7. [ ] Add focused unit/integration tests and a native arm64 macOS CI job while
+7. [x] Add focused unit/integration tests and a native arm64 macOS CI job while
        preserving the legacy package lane unchanged.
 8. [ ] Run focused, standalone, legacy-package, aggregate, exact-head review,
        hosted CI, issue, merge, and clean GitButler reconciliation gates.

--- a/.agents/plans/2026-08-10-standalone-executable.md
+++ b/.agents/plans/2026-08-10-standalone-executable.md
@@ -53,8 +53,8 @@ a separate compatibility lane.
 
 ## Verification
 
-- `bun test apps/cli/src/lab-assets.test.ts apps/cli/src/surface-lab-server.test.ts apps/cli/src/entrypoint.test.ts scripts/standalone-assets.test.ts`
-- `bun --filter @bb-mate/cli check && tsc -p scripts/tsconfig.json`
+- `bun test apps/cli/src/lab-assets.test.ts apps/cli/src/surface-lab-server.test.ts apps/cli/src/entrypoint.test.ts scripts/standalone-assets.test.ts scripts/build-standalone.test.ts`
+- `bun --filter bb-mate check && tsc -p scripts/tsconfig.json`
 - `bun run standalone:inspect`
 - `bun run standalone:test`
 - `bun run package:inspect`

--- a/.agents/plans/2026-08-10-standalone-executable.md
+++ b/.agents/plans/2026-08-10-standalone-executable.md
@@ -1,0 +1,82 @@
+# Self-contained bb-mate executable
+
+Date: 2026-08-10
+Status: In progress
+Issue: [#56](https://github.com/galligan/bb-mate/issues/56)
+Goal: `.agents/goals/2026-08-10-plugin-workbench/`
+
+## Outcome
+
+Produce an unsigned macOS arm64 `bb-mate` executable that embeds the complete
+deterministic Fixture lab and runs after being moved away from the checkout with
+an empty `PATH` and no global Bun. Preserve the existing npm/shebang artifact as
+a separate compatibility lane.
+
+## Decisions
+
+- Generate one static `with { type: "file" }` import per built Ladle asset and
+  preserve an explicit stable route-to-embedded-path map. Pinned Bun 1.3.14 did
+  not embed the asset graph through `compile.assets`, and full-stack HTML
+  rebundling would alter already-built Ladle bytes.
+- Use a literal standalone entrypoint mode. Do not depend on
+  `Bun.isStandaloneExecutable`, which is unavailable on the pinned runtime.
+- Keep the native artifact out of the current npm tarball. The existing
+  `dist/cli.js`, `engines.bun`, package inspection, and package clean-room lane
+  remain unchanged.
+- Define determinism as same-input, same-host, pinned-toolchain byte identity for
+  the unsigned artifact and manifest. Signing, notarization, Intel macOS, other
+  platforms, installation, updating, and public distribution are out of scope.
+- Managed launchers must clear `BUN_BE_BUN` and `BUN_OPTIONS`; application code
+  cannot sanitize `BUN_BE_BUN` because Bun consumes it before the entrypoint.
+
+## Implementation
+
+1. [ ] Introduce a focused lab asset provider with filesystem containment and
+       exact-key embedded implementations.
+2. [ ] Make the static lab handler consume the provider while retaining
+       GET/HEAD, MIME, traversal/symlink, loopback, and shutdown behavior.
+3. [ ] Split entrypoint construction from the shebang wrapper; make source and
+       standalone modes explicit and make standalone incapable of re-executing
+       itself as Bun.
+4. [ ] Generate a sorted, validated static-import entry from the 13-story Ladle
+       output and compile `bun-darwin-arm64` with dotenv/bunfig autoload disabled.
+5. [ ] Emit an exact two-file artifact directory (`bb-mate`, `manifest.json`)
+       recording mode, arch, size, SHA-256, story count, and sorted asset hashes.
+6. [ ] Add a separate empty-PATH clean-room lane that builds twice, compares
+       unsigned bytes, moves the binary, makes checkout lab assets unavailable,
+       proves help/passive inspect/Fixture GET+HEAD/all stories, and confirms
+       process/listener cleanup.
+7. [ ] Add focused unit/integration tests and a native arm64 macOS CI job while
+       preserving the legacy package lane unchanged.
+8. [ ] Run focused, standalone, legacy-package, aggregate, exact-head review,
+       hosted CI, issue, merge, and clean GitButler reconciliation gates.
+
+## Verification
+
+- `bun test apps/cli/src/lab-assets.test.ts apps/cli/src/surface-lab-server.test.ts apps/cli/src/entrypoint.test.ts scripts/standalone-assets.test.ts`
+- `bun --filter @bb-mate/cli check && tsc -p scripts/tsconfig.json`
+- `bun run standalone:inspect`
+- `bun run standalone:test`
+- `bun run package:inspect`
+- `bun run package:test`
+- `bun run format:check`
+- `bun run check`
+- `bun run test`
+- `bun run build`
+
+## Boundaries
+
+- No `serve` domain protocol, runtime supervisor, plugin embedding, browser
+  bootstrap, signing/notarization, automatic bunx, second platform, publish,
+  release, or normal bb profile mutation.
+- No imports or copied contracts from `../bb` or unpublished SDK packages.
+- No claim that direct invocation can defeat user-supplied Bun runtime override
+  variables; the isolated clean-room contract supplies a sanitized environment.
+
+## Done
+
+The moved exact artifact works with empty `PATH`, unreadable checkout assets, and
+no global Bun; two complete builds are byte-identical on the pinned host; all 13
+stories and passive commands pass; legacy packaging is non-regressed; focused,
+aggregate, hosted, and two independent 5/5 review lanes are green; #56 and the
+goal ledger are current; the PR is merged and GitButler is clean on `main`.

--- a/.agents/plans/2026-08-10-standalone-executable.md
+++ b/.agents/plans/2026-08-10-standalone-executable.md
@@ -1,7 +1,7 @@
 # Self-contained bb-mate executable
 
 Date: 2026-08-10
-Status: Implementation complete; review pending
+Status: Implementation and review complete; merge pending
 Issue: [#56](https://github.com/galligan/bb-mate/issues/56)
 Goal: `.agents/goals/2026-08-10-plugin-workbench/`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,14 @@ jobs:
             apps/workbench/dist/playwright/report
             apps/workbench/dist/playwright/results
           if-no-files-found: ignore
+
+  standalone-darwin-arm64:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: test "$(uname -m)" = arm64
+      - run: bun install --frozen-lockfile
+      - run: bun run standalone:test

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -74,6 +74,21 @@ Learn more in the
 - Native handoffs target a supported macOS bb host.
 - Fixture and package checks are also exercised in isolated Linux CI.
 
+The repository also builds a separate, unsigned macOS arm64 executable for
+isolated Plugin Workbench development:
+
+```sh
+bun run standalone:build
+bun run standalone:inspect
+bun run standalone:test
+```
+
+That executable embeds the exact deterministic lab and is verified after being
+moved away from the checkout with an empty `PATH` and no global Bun. It is an
+internal build artifact: the npm package still ships the Bun-based CLI, and the
+standalone executable is not published, signed, notarized, or installed by
+these commands.
+
 ## Trust and security
 
 Plugins are full-trust local code. Review a plugin before using native

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -1,53 +1,11 @@
 #!/usr/bin/env bun
 
-import { promises as fs } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { runCli, type CliRuntime } from "./commands.ts";
-import {
-  nativeCommandEnv,
-  resolveBbExecutable,
-  runCapturedCommand,
-  runInheritedCommand,
-} from "./native.ts";
-import { runSurfaceLab } from "./surface-lab-server.ts";
+import { runBbMateEntrypoint } from "./entrypoint.ts";
 
-const workspaceRoot = fileURLToPath(new URL("../../..", import.meta.url));
-const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
-const packagedLabRoot = path.join(moduleDirectory, "lab");
-const packaged = await fs
-  .access(path.join(packagedLabRoot, "index.html"))
-  .then(() => true)
-  .catch(() => false);
-
-const runtime: CliRuntime = {
-  cwd: process.cwd(),
-  env: process.env,
+const result = await runBbMateEntrypoint({
+  mode: "source-or-package",
+  moduleUrl: import.meta.url,
   bunExecutable: process.execPath,
-  workspaceRoot,
-  ...(packaged
-    ? {
-        fixtureName: "surface lab",
-        runFixture: (options: { host: string; port: number }) =>
-          runSurfaceLab({
-            root: packagedLabRoot,
-            ...options,
-            stdout: (value) => process.stdout.write(value),
-            stderr: (value) => process.stderr.write(value),
-          }),
-      }
-    : {}),
-  stdout: (value) => process.stdout.write(value),
-  stderr: (value) => process.stderr.write(value),
-  resolveBb: () =>
-    resolveBbExecutable({ cwd: process.cwd(), env: process.env }),
-  runCaptured: (executable, args, cwd) =>
-    runCapturedCommand(executable, args, cwd, {
-      env: nativeCommandEnv(process.env),
-    }),
-  runInherited: runInheritedCommand,
-};
-
-const result = await runCli(process.argv.slice(2), runtime);
+});
 if (result.signal) process.kill(process.pid, result.signal);
 process.exit(result.exitCode ?? 1);

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -19,8 +19,8 @@ export interface ProcessExit {
 export interface CliRuntime {
   cwd: string;
   env: NodeJS.ProcessEnv;
-  bunExecutable: string;
-  workspaceRoot: string;
+  bunExecutable?: string;
+  workspaceRoot?: string;
   fixtureName?: string;
   stdout(value: string): void;
   stderr(value: string): void;
@@ -214,6 +214,10 @@ export async function runCli(
     line(runtime.stdout, connectExposure(context.report, args.port));
     if (runtime.runFixture) {
       return runtime.runFixture({ host: args.host, port: args.port });
+    }
+    if (!runtime.bunExecutable || !runtime.workspaceRoot) {
+      line(runtime.stderr, "Fixture surface lab assets are unavailable.");
+      return failure;
     }
     line(
       runtime.stdout,

--- a/apps/cli/src/entrypoint.test.ts
+++ b/apps/cli/src/entrypoint.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createBbMateCliRuntime, runBbMateEntrypoint } from "./entrypoint.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+describe("bb-mate entrypoint modes", () => {
+  test("standalone mode requires embedded index assets and has no Bun source runner", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-entry-"));
+    roots.push(root);
+    const indexPath = path.join(root, "index.html");
+    await fs.writeFile(indexPath, "standalone");
+
+    const runtime = await createBbMateCliRuntime({
+      mode: "standalone",
+      assets: { "/index.html": indexPath },
+    });
+
+    expect(runtime.runFixture).toBeFunction();
+    expect(runtime.bunExecutable).toBeUndefined();
+    expect(runtime.workspaceRoot).toBeUndefined();
+    await expect(
+      createBbMateCliRuntime({ mode: "standalone", assets: {} }),
+    ).rejects.toThrow("Standalone surface lab assets must include /index.html");
+  });
+
+  test("source-or-package mode uses Bun only when no packaged lab exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-entry-"));
+    roots.push(root);
+    const moduleDirectory = path.join(root, "apps", "cli", "src");
+    await fs.mkdir(moduleDirectory, { recursive: true });
+    const moduleUrl = pathToFileURL(path.join(moduleDirectory, "bin.ts")).href;
+
+    const source = await createBbMateCliRuntime({
+      mode: "source-or-package",
+      moduleUrl,
+      bunExecutable: "/actual/bun",
+    });
+    expect(source.bunExecutable).toBe("/actual/bun");
+    expect(source.runFixture).toBeUndefined();
+
+    await fs.mkdir(path.join(moduleDirectory, "lab"));
+    await fs.writeFile(path.join(moduleDirectory, "lab", "index.html"), "lab");
+    const packaged = await createBbMateCliRuntime({
+      mode: "source-or-package",
+      moduleUrl,
+      bunExecutable: "/actual/bun",
+    });
+    expect(packaged.runFixture).toBeFunction();
+    expect(packaged.bunExecutable).toBeUndefined();
+  });
+
+  test("runs the standalone CLI through the exported executable seam", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-entry-"));
+    roots.push(root);
+    const indexPath = path.join(root, "index.html");
+    await fs.writeFile(indexPath, "standalone");
+    const stdout: string[] = [];
+
+    const result = await runBbMateEntrypoint(
+      { mode: "standalone", assets: { "/index.html": indexPath } },
+      {
+        argv: ["--help"],
+        stdout: (value) => stdout.push(value),
+        stderr: () => undefined,
+      },
+    );
+
+    expect(result).toEqual({ exitCode: 0, signal: null });
+    expect(stdout.join("")).toContain("Usage: bb-mate");
+  });
+});

--- a/apps/cli/src/entrypoint.ts
+++ b/apps/cli/src/entrypoint.ts
@@ -1,0 +1,123 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCli, type CliRuntime, type ProcessExit } from "./commands.ts";
+import {
+  createEmbeddedLabAssets,
+  type EmbeddedLabAssetMap,
+} from "./lab-assets.ts";
+import {
+  nativeCommandEnv,
+  resolveBbExecutable,
+  runCapturedCommand,
+  runInheritedCommand,
+} from "./native.ts";
+import { runSurfaceLab } from "./surface-lab-server.ts";
+
+export type BbMateEntrypointOptions =
+  | {
+      mode: "source-or-package";
+      moduleUrl: string;
+      bunExecutable: string;
+    }
+  | {
+      mode: "standalone";
+      assets: EmbeddedLabAssetMap;
+    };
+
+interface EntrypointEnvironment {
+  argv?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdout?(value: string): void;
+  stderr?(value: string): void;
+}
+
+function environment(overrides: EntrypointEnvironment) {
+  return {
+    argv: overrides.argv ?? process.argv.slice(2),
+    cwd: overrides.cwd ?? process.cwd(),
+    env: overrides.env ?? process.env,
+    stdout:
+      overrides.stdout ?? ((value: string) => process.stdout.write(value)),
+    stderr:
+      overrides.stderr ?? ((value: string) => process.stderr.write(value)),
+  };
+}
+
+export async function createBbMateCliRuntime(
+  options: BbMateEntrypointOptions,
+  overrides: EntrypointEnvironment = {},
+): Promise<CliRuntime> {
+  const current = environment(overrides);
+  let fixture: Pick<CliRuntime, "fixtureName" | "runFixture"> = {};
+  let source: Pick<CliRuntime, "bunExecutable" | "workspaceRoot"> = {};
+
+  if (options.mode === "standalone") {
+    if (!("/index.html" in options.assets)) {
+      throw new Error(
+        "Standalone surface lab assets must include /index.html.",
+      );
+    }
+    const assets = createEmbeddedLabAssets(options.assets);
+    fixture = {
+      fixtureName: "surface lab",
+      runFixture: (serverOptions) =>
+        runSurfaceLab({
+          assets,
+          ...serverOptions,
+          stdout: current.stdout,
+          stderr: current.stderr,
+        }),
+    };
+  } else {
+    const moduleDirectory = path.dirname(fileURLToPath(options.moduleUrl));
+    const packagedLabRoot = path.join(moduleDirectory, "lab");
+    const packaged = await fs
+      .access(path.join(packagedLabRoot, "index.html"))
+      .then(() => true)
+      .catch(() => false);
+    if (packaged) {
+      fixture = {
+        fixtureName: "surface lab",
+        runFixture: (serverOptions) =>
+          runSurfaceLab({
+            root: packagedLabRoot,
+            ...serverOptions,
+            stdout: current.stdout,
+            stderr: current.stderr,
+          }),
+      };
+    } else {
+      source = {
+        bunExecutable: options.bunExecutable,
+        workspaceRoot: fileURLToPath(new URL("../../..", options.moduleUrl)),
+      };
+    }
+  }
+
+  return {
+    cwd: current.cwd,
+    env: current.env,
+    ...source,
+    ...fixture,
+    stdout: current.stdout,
+    stderr: current.stderr,
+    resolveBb: () =>
+      resolveBbExecutable({ cwd: current.cwd, env: current.env }),
+    runCaptured: (executable, args, cwd) =>
+      runCapturedCommand(executable, args, cwd, {
+        env: nativeCommandEnv(current.env),
+      }),
+    runInherited: runInheritedCommand,
+  };
+}
+
+export async function runBbMateEntrypoint(
+  options: BbMateEntrypointOptions,
+  overrides: EntrypointEnvironment = {},
+): Promise<ProcessExit> {
+  const current = environment(overrides);
+  const runtime = await createBbMateCliRuntime(options, current);
+  return runCli(current.argv, runtime);
+}

--- a/apps/cli/src/lab-assets.test.ts
+++ b/apps/cli/src/lab-assets.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  createEmbeddedLabAssets,
+  createFileSystemLabAssets,
+  createInMemoryLabAssets,
+} from "./lab-assets.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+describe("surface lab asset providers", () => {
+  test("resolves stable routes from an in-memory asset map", async () => {
+    const assets = createInMemoryLabAssets({
+      "/index.html": "<h1>Embedded lab</h1>",
+    });
+
+    const index = await assets.get("/index.html");
+    expect(index?.contentType).toBe("text/html; charset=utf-8");
+    expect(await new Response(index?.body).text()).toBe(
+      "<h1>Embedded lab</h1>",
+    );
+    expect(await assets.get("/missing.html")).toBeNull();
+  });
+
+  test("keeps filesystem assets inside their real root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-assets-"));
+    const outside = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-assets-outside-"),
+    );
+    roots.push(root, outside);
+    await fs.writeFile(path.join(root, "index.html"), "inside");
+    await fs.writeFile(path.join(outside, "secret.txt"), "outside");
+    await fs.symlink(
+      path.join(outside, "secret.txt"),
+      path.join(root, "escape.txt"),
+    );
+
+    const assets = createFileSystemLabAssets(root);
+    expect(
+      await new Response((await assets.get("/index.html"))?.body).text(),
+    ).toBe("inside");
+    expect(await assets.get("/../secret.txt")).toBeNull();
+    expect(await assets.get("/escape.txt")).toBeNull();
+  });
+
+  test("reports an unavailable filesystem root without throwing", async () => {
+    const assets = createFileSystemLabAssets(
+      path.join(os.tmpdir(), "bb-mate-assets-does-not-exist"),
+    );
+
+    expect(await assets.get("/index.html")).toBeNull();
+  });
+
+  test("reads standalone assets from their embedded file paths", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-embedded-"));
+    roots.push(root);
+    const embeddedPath = path.join(root, "index.html");
+    await fs.writeFile(embeddedPath, "embedded");
+
+    const assets = createEmbeddedLabAssets({ "/index.html": embeddedPath });
+    const index = await assets.get("/index.html");
+    expect(await new Response(index?.body).text()).toBe("embedded");
+    expect(index?.contentType).toBe("text/html; charset=utf-8");
+  });
+});

--- a/apps/cli/src/lab-assets.ts
+++ b/apps/cli/src/lab-assets.ts
@@ -1,0 +1,84 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export type LabAssetBody = Blob | Uint8Array | string;
+
+export interface LabAsset {
+  body: LabAssetBody;
+  contentType: string;
+}
+
+export interface LabAssetProvider {
+  get(route: string): Promise<LabAsset | null>;
+}
+
+export type EmbeddedLabAssetMap = Readonly<Record<string, string>>;
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".webmanifest", "application/manifest+json"],
+  [".woff2", "font/woff2"],
+]);
+
+export function labAssetContentType(route: string): string {
+  return contentTypes.get(path.extname(route)) ?? "application/octet-stream";
+}
+
+export function createInMemoryLabAssets(
+  assets: Readonly<Record<string, LabAssetBody>>,
+): LabAssetProvider {
+  return {
+    async get(route) {
+      const body = assets[route];
+      return body === undefined
+        ? null
+        : { body, contentType: labAssetContentType(route) };
+    },
+  };
+}
+
+export function createEmbeddedLabAssets(
+  assets: EmbeddedLabAssetMap,
+): LabAssetProvider {
+  return {
+    async get(route) {
+      const filePath = assets[route];
+      if (filePath === undefined) return null;
+      const file = Bun.file(filePath);
+      if (!(await file.exists())) return null;
+      return { body: file, contentType: labAssetContentType(route) };
+    },
+  };
+}
+
+function contained(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+export function createFileSystemLabAssets(root: string): LabAssetProvider {
+  const resolvedRoot = fs.realpath(path.resolve(root));
+  return {
+    async get(route) {
+      if (!route.startsWith("/") || route.includes("\0")) return null;
+      try {
+        const labRoot = await resolvedRoot;
+        const candidate = path.resolve(labRoot, route.slice(1));
+        if (!contained(labRoot, candidate)) return null;
+        const filePath = await fs.realpath(candidate);
+        const stat = await fs.stat(filePath);
+        if (!stat.isFile() || !contained(labRoot, filePath)) return null;
+        return {
+          body: Bun.file(filePath),
+          contentType: labAssetContentType(route),
+        };
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/apps/cli/src/surface-lab-server.test.ts
+++ b/apps/cli/src/surface-lab-server.test.ts
@@ -7,6 +7,7 @@ import {
   isLoopbackHost,
   runSurfaceLab,
 } from "./surface-lab-server.ts";
+import { createInMemoryLabAssets } from "./lab-assets.ts";
 
 const roots: string[] = [];
 
@@ -95,6 +96,24 @@ describe("packaged surface lab server", () => {
     );
     expect(await metadata.text()).toBe("");
 
+    expect(
+      (await handle(new Request("http://lab.local/assets/app.js"))).headers.get(
+        "content-type",
+      ),
+    ).toBe("text/javascript; charset=utf-8");
+  });
+
+  test("uses the same handler for embedded or in-memory assets", async () => {
+    const handle = createSurfaceLabHandler(
+      createInMemoryLabAssets({
+        "/index.html": "<h1>Standalone lab</h1>",
+        "/assets/app.js": "export {};",
+      }),
+    );
+
+    const index = await handle(new Request("http://lab.local/"));
+    expect(index.status).toBe(200);
+    expect(await index.text()).toContain("Standalone lab");
     expect(
       (await handle(new Request("http://lab.local/assets/app.js"))).headers.get(
         "content-type",

--- a/apps/cli/src/surface-lab-server.ts
+++ b/apps/cli/src/surface-lab-server.ts
@@ -1,31 +1,23 @@
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import type { ProcessExit } from "./commands.ts";
-
-const contentTypes = new Map([
-  [".css", "text/css; charset=utf-8"],
-  [".html", "text/html; charset=utf-8"],
-  [".js", "text/javascript; charset=utf-8"],
-  [".json", "application/json; charset=utf-8"],
-  [".png", "image/png"],
-  [".svg", "image/svg+xml"],
-  [".webmanifest", "application/manifest+json"],
-  [".woff2", "font/woff2"],
-]);
-
-function contained(root: string, candidate: string): boolean {
-  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
-}
+import {
+  createFileSystemLabAssets,
+  type LabAssetProvider,
+} from "./lab-assets.ts";
 
 export function isLoopbackHost(host: string): boolean {
   return host === "127.0.0.1" || host === "::1" || host === "localhost";
 }
 
-export function createSurfaceLabHandler(root: string) {
-  const resolvedRoot = fs.realpath(path.resolve(root));
+function providerFor(source: string | LabAssetProvider): LabAssetProvider {
+  return typeof source === "string"
+    ? createFileSystemLabAssets(source)
+    : source;
+}
+
+export function createSurfaceLabHandler(source: string | LabAssetProvider) {
+  const assets = providerFor(source);
 
   return async (request: Request): Promise<Response> => {
-    const labRoot = await resolvedRoot;
     if (request.method !== "GET" && request.method !== "HEAD") {
       return new Response(null, {
         status: 405,
@@ -42,38 +34,28 @@ export function createSurfaceLabHandler(root: string) {
     if (pathname.includes("\0")) {
       return new Response("Invalid request path.\n", { status: 400 });
     }
-
-    const relative = pathname === "/" ? "index.html" : pathname.slice(1);
-    const candidate = path.resolve(labRoot, relative);
-    if (!contained(labRoot, candidate)) {
+    if (pathname.split("/").some((segment) => segment === "..")) {
       return new Response("Not found.\n", { status: 404 });
     }
 
-    let filePath: string;
-    try {
-      filePath = await fs.realpath(candidate);
-      const stat = await fs.stat(filePath);
-      if (!stat.isFile() || !contained(labRoot, filePath)) {
-        return new Response("Not found.\n", { status: 404 });
-      }
-    } catch {
-      return new Response("Not found.\n", { status: 404 });
-    }
+    const route = pathname === "/" ? "/index.html" : pathname;
+    const asset = await assets.get(route);
+    if (!asset) return new Response("Not found.\n", { status: 404 });
 
     const headers = new Headers({
-      "Content-Type":
-        contentTypes.get(path.extname(filePath)) ?? "application/octet-stream",
+      "Content-Type": asset.contentType,
       "Referrer-Policy": "no-referrer",
       "X-Content-Type-Options": "nosniff",
     });
     return request.method === "HEAD"
       ? new Response(null, { status: 200, headers })
-      : new Response(Bun.file(filePath), { status: 200, headers });
+      : new Response(asset.body, { status: 200, headers });
   };
 }
 
 export async function runSurfaceLab(options: {
-  root: string;
+  root?: string;
+  assets?: LabAssetProvider;
   host: string;
   port: number;
   stdout(value: string): void;
@@ -85,9 +67,10 @@ export async function runSurfaceLab(options: {
     );
     return { exitCode: 1, signal: null };
   }
-  try {
-    await fs.access(path.join(options.root, "index.html"));
-  } catch {
+  const assets =
+    options.assets ??
+    (options.root ? createFileSystemLabAssets(options.root) : undefined);
+  if (!assets || !(await assets.get("/index.html"))) {
     options.stderr("Packaged surface lab assets are unavailable.\n");
     return { exitCode: 1, signal: null };
   }
@@ -97,7 +80,7 @@ export async function runSurfaceLab(options: {
     server = Bun.serve({
       hostname: options.host,
       port: options.port,
-      fetch: createSurfaceLabHandler(options.root),
+      fetch: createSurfaceLabHandler(assets),
     });
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "package:artifact": "bun scripts/package-local.ts",
     "package:inspect": "bun scripts/package-local.ts --dry-run",
     "package:test": "bun scripts/package-clean-room.ts",
+    "standalone:build": "bun scripts/build-standalone.ts",
+    "standalone:inspect": "bun scripts/inspect-standalone.ts",
+    "standalone:test": "bun scripts/standalone-clean-room.ts",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },

--- a/scripts/build-standalone.test.ts
+++ b/scripts/build-standalone.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { prepareStandaloneOutputRoot } from "./build-standalone.ts";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const roots: string[] = [];
+
+async function temporaryRoot(): Promise<string> {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), "bb-mate-standalone-output-"),
+  );
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("standalone output ownership", () => {
+  test("replaces only the two owned artifact files", async () => {
+    const root = await temporaryRoot();
+    await Promise.all([
+      fs.writeFile(path.join(root, "bb-mate"), "old binary"),
+      fs.writeFile(path.join(root, "manifest.json"), "old manifest"),
+    ]);
+
+    expect(await prepareStandaloneOutputRoot(root)).toBe(root);
+    expect(await fs.readdir(root)).toEqual([]);
+  });
+
+  test("rejects unexpected entries without deleting owned files", async () => {
+    const root = await temporaryRoot();
+    await Promise.all([
+      fs.writeFile(path.join(root, "bb-mate"), "old binary"),
+      fs.writeFile(path.join(root, "keep.txt"), "user data"),
+    ]);
+
+    await expect(prepareStandaloneOutputRoot(root)).rejects.toThrow(
+      "unexpected entry: keep.txt",
+    );
+    expect(await fs.readFile(path.join(root, "bb-mate"), "utf8")).toBe(
+      "old binary",
+    );
+    expect(await fs.readFile(path.join(root, "keep.txt"), "utf8")).toBe(
+      "user data",
+    );
+  });
+
+  test("rejects broad repository paths and a symlink root", async () => {
+    await expect(prepareStandaloneOutputRoot(repositoryRoot)).rejects.toThrow(
+      "Refusing unsafe",
+    );
+    await expect(
+      prepareStandaloneOutputRoot(path.dirname(repositoryRoot)),
+    ).rejects.toThrow("Refusing unsafe");
+    await expect(
+      prepareStandaloneOutputRoot(path.join(repositoryRoot, "apps")),
+    ).rejects.toThrow("unexpected entry");
+
+    const root = await temporaryRoot();
+    const destination = await temporaryRoot();
+    const link = path.join(root, "linked-output");
+    await fs.symlink(destination, link);
+    await expect(prepareStandaloneOutputRoot(link)).rejects.toThrow(
+      "real directory",
+    );
+  });
+});

--- a/scripts/build-standalone.test.ts
+++ b/scripts/build-standalone.test.ts
@@ -3,7 +3,10 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { prepareStandaloneOutputRoot } from "./build-standalone.ts";
+import {
+  prepareStandaloneOutputRoot,
+  promoteStandaloneOutputRoot,
+} from "./build-standalone.ts";
 
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const roots: string[] = [];
@@ -25,19 +28,36 @@ afterEach(async () => {
 });
 
 describe("standalone output ownership", () => {
-  test("replaces only the two owned artifact files", async () => {
-    const root = await temporaryRoot();
+  test("preserves the previous artifact until complete staged output is promoted", async () => {
+    const parent = await temporaryRoot();
+    const root = path.join(parent, "output");
+    const stage = path.join(parent, "stage");
+    await Promise.all([fs.mkdir(root), fs.mkdir(stage)]);
     await Promise.all([
       fs.writeFile(path.join(root, "bb-mate"), "old binary"),
       fs.writeFile(path.join(root, "manifest.json"), "old manifest"),
+      fs.writeFile(path.join(stage, "bb-mate"), "new binary"),
+      fs.writeFile(path.join(stage, "manifest.json"), "new manifest"),
     ]);
 
     expect(await prepareStandaloneOutputRoot(root)).toBe(root);
-    expect(await fs.readdir(root)).toEqual([]);
+    expect(await fs.readFile(path.join(root, "bb-mate"), "utf8")).toBe(
+      "old binary",
+    );
+    await promoteStandaloneOutputRoot(root, stage);
+    expect(await fs.readFile(path.join(root, "bb-mate"), "utf8")).toBe(
+      "new binary",
+    );
+    expect(await fs.readFile(path.join(root, "manifest.json"), "utf8")).toBe(
+      "new manifest",
+    );
+    await expect(fs.access(stage)).rejects.toThrow();
   });
 
   test("rejects unexpected entries without deleting owned files", async () => {
-    const root = await temporaryRoot();
+    const parent = await temporaryRoot();
+    const root = path.join(parent, "output");
+    await fs.mkdir(root);
     await Promise.all([
       fs.writeFile(path.join(root, "bb-mate"), "old binary"),
       fs.writeFile(path.join(root, "keep.txt"), "user data"),
@@ -63,7 +83,10 @@ describe("standalone output ownership", () => {
     ).rejects.toThrow("Refusing unsafe");
     await expect(
       prepareStandaloneOutputRoot(path.join(repositoryRoot, "apps")),
-    ).rejects.toThrow("unexpected entry");
+    ).rejects.toThrow("Refusing unsafe");
+    await expect(prepareStandaloneOutputRoot(os.tmpdir())).rejects.toThrow(
+      "Refusing unsafe",
+    );
 
     const root = await temporaryRoot();
     const destination = await temporaryRoot();
@@ -71,6 +94,62 @@ describe("standalone output ownership", () => {
     await fs.symlink(destination, link);
     await expect(prepareStandaloneOutputRoot(link)).rejects.toThrow(
       "real directory",
+    );
+  });
+
+  test("rejects incomplete staged output without touching the previous artifact", async () => {
+    const parent = await temporaryRoot();
+    const root = path.join(parent, "output");
+    const stage = path.join(parent, "stage");
+    await Promise.all([fs.mkdir(root), fs.mkdir(stage)]);
+    await Promise.all([
+      fs.writeFile(path.join(root, "bb-mate"), "old binary"),
+      fs.writeFile(path.join(root, "manifest.json"), "old manifest"),
+      fs.writeFile(path.join(stage, "bb-mate"), "incomplete binary"),
+    ]);
+
+    await expect(promoteStandaloneOutputRoot(root, stage)).rejects.toThrow(
+      "must contain exactly",
+    );
+    expect(await fs.readFile(path.join(root, "bb-mate"), "utf8")).toBe(
+      "old binary",
+    );
+    expect(await fs.readFile(path.join(root, "manifest.json"), "utf8")).toBe(
+      "old manifest",
+    );
+  });
+
+  test("restores the previous pair when staged promotion fails partway", async () => {
+    const parent = await temporaryRoot();
+    const root = path.join(parent, "output");
+    const stage = path.join(parent, "stage");
+    await Promise.all([fs.mkdir(root), fs.mkdir(stage)]);
+    await Promise.all([
+      fs.writeFile(path.join(root, "bb-mate"), "old binary"),
+      fs.writeFile(path.join(root, "manifest.json"), "old manifest"),
+      fs.writeFile(path.join(stage, "bb-mate"), "new binary"),
+      fs.writeFile(path.join(stage, "manifest.json"), "new manifest"),
+    ]);
+    let renameCount = 0;
+
+    await expect(
+      promoteStandaloneOutputRoot(root, stage, {
+        async rename(source, destination) {
+          renameCount += 1;
+          if (renameCount === 2) throw new Error("injected promotion failure");
+          await fs.rename(source, destination);
+        },
+      }),
+    ).rejects.toThrow("injected promotion failure");
+    expect(renameCount).toBe(3);
+    expect(await fs.readFile(path.join(root, "bb-mate"), "utf8")).toBe(
+      "old binary",
+    );
+    expect(await fs.readFile(path.join(root, "manifest.json"), "utf8")).toBe(
+      "old manifest",
+    );
+    expect(await fs.readFile(path.join(stage, "bb-mate"), "utf8")).toBe(
+      "new binary",
     );
   });
 });

--- a/scripts/build-standalone.test.ts
+++ b/scripts/build-standalone.test.ts
@@ -19,6 +19,14 @@ async function temporaryRoot(): Promise<string> {
   return root;
 }
 
+async function temporaryHomeRoot(): Promise<string> {
+  const root = await fs.mkdtemp(
+    path.join(os.homedir(), ".bb-mate-standalone-outside-"),
+  );
+  roots.push(root);
+  return root;
+}
+
 afterEach(async () => {
   await Promise.all(
     roots
@@ -93,8 +101,22 @@ describe("standalone output ownership", () => {
     const link = path.join(root, "linked-output");
     await fs.symlink(destination, link);
     await expect(prepareStandaloneOutputRoot(link)).rejects.toThrow(
-      "real directory",
+      "symlink component",
     );
+  });
+
+  test("rejects a symlinked ancestor without writing through it", async () => {
+    const holder = await temporaryRoot();
+    const outside = await temporaryHomeRoot();
+    const linkedParent = path.join(holder, "parent-link");
+    const escapedOutput = path.join(linkedParent, "output");
+    await fs.symlink(outside, linkedParent);
+
+    await expect(prepareStandaloneOutputRoot(escapedOutput)).rejects.toThrow(
+      "symlink component",
+    );
+    await expect(fs.access(path.join(outside, "output"))).rejects.toThrow();
+    expect(await fs.readdir(outside)).toEqual([]);
   });
 
   test("rejects incomplete staged output without touching the previous artifact", async () => {

--- a/scripts/build-standalone.ts
+++ b/scripts/build-standalone.ts
@@ -27,6 +27,39 @@ function containsPath(parent: string, candidate: string): boolean {
   return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
 }
 
+async function assertPhysicalContainment(
+  baseRoot: string,
+  outputRoot: string,
+): Promise<void> {
+  const relative = path.relative(baseRoot, outputRoot);
+  let current = baseRoot;
+  for (const component of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, component);
+    const stat = await fs.lstat(current).catch((error: unknown) => {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return null;
+      }
+      throw error;
+    });
+    if (!stat) break;
+    if (stat.isSymbolicLink()) {
+      throw new Error(
+        `Standalone output path contains a symlink component: ${current}`,
+      );
+    }
+    if (!stat.isDirectory() && current !== outputRoot) {
+      throw new Error(
+        `Standalone output path contains a non-directory component: ${current}`,
+      );
+    }
+  }
+}
+
 export async function prepareStandaloneOutputRoot(
   root: string,
 ): Promise<string> {
@@ -43,6 +76,10 @@ export async function prepareStandaloneOutputRoot(
   ) {
     throw new Error(`Refusing unsafe standalone output root: ${outputRoot}`);
   }
+
+  const allowedBase =
+    outputRoot === defaultOutputRoot ? repositoryRoot : temporaryRoot;
+  await assertPhysicalContainment(allowedBase, outputRoot);
 
   const existing = await fs.lstat(outputRoot).catch((error: unknown) => {
     if (
@@ -61,6 +98,16 @@ export async function prepareStandaloneOutputRoot(
     );
   }
   if (!existing) await fs.mkdir(outputRoot, { recursive: true });
+
+  const [physicalBase, physicalOutput] = await Promise.all([
+    fs.realpath(allowedBase),
+    fs.realpath(outputRoot),
+  ]);
+  if (!containsPath(physicalBase, physicalOutput)) {
+    throw new Error(
+      `Standalone output root escapes its physical allowed base: ${outputRoot}`,
+    );
+  }
 
   const entries = await fs.readdir(outputRoot, { withFileTypes: true });
   for (const entry of entries) {

--- a/scripts/build-standalone.ts
+++ b/scripts/build-standalone.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,11 +31,15 @@ export async function prepareStandaloneOutputRoot(
   root: string,
 ): Promise<string> {
   const outputRoot = path.resolve(root);
+  const temporaryRoot = path.resolve(os.tmpdir());
   if (
     outputRoot === path.parse(outputRoot).root ||
     outputRoot === repositoryRoot ||
     outputRoot === os.homedir() ||
-    containsPath(outputRoot, repositoryRoot)
+    containsPath(outputRoot, repositoryRoot) ||
+    (outputRoot !== defaultOutputRoot &&
+      (outputRoot === temporaryRoot ||
+        !containsPath(temporaryRoot, outputRoot)))
   ) {
     throw new Error(`Refusing unsafe standalone output root: ${outputRoot}`);
   }
@@ -65,10 +70,76 @@ export async function prepareStandaloneOutputRoot(
       );
     }
   }
-  await Promise.all(
-    entries.map((entry) => fs.unlink(path.join(outputRoot, entry.name))),
-  );
   return outputRoot;
+}
+
+async function assertCompleteStagedOutput(root: string): Promise<void> {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const names = entries.map((entry) => entry.name).sort();
+  if (
+    entries.some((entry) => !entry.isFile()) ||
+    JSON.stringify(names) !== JSON.stringify([...outputAllowlist].sort())
+  ) {
+    throw new Error(
+      `Standalone staged output must contain exactly bb-mate and manifest.json: ${names.join(", ")}`,
+    );
+  }
+}
+
+async function removeOwnedOutputDirectory(root: string): Promise<void> {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!outputAllowlist.has(entry.name) || !entry.isFile()) {
+      throw new Error(
+        `Refusing to remove unexpected standalone backup entry: ${entry.name}`,
+      );
+    }
+  }
+  await Promise.all(
+    entries.map((entry) => fs.unlink(path.join(root, entry.name))),
+  );
+  await fs.rmdir(root);
+}
+
+export async function promoteStandaloneOutputRoot(
+  root: string,
+  stagedRoot: string,
+  options: {
+    rename?(source: string, destination: string): Promise<void>;
+  } = {},
+): Promise<void> {
+  const outputRoot = await prepareStandaloneOutputRoot(root);
+  const stage = path.resolve(stagedRoot);
+  if (path.dirname(stage) !== path.dirname(outputRoot)) {
+    throw new Error("Standalone staged output must be beside its final root.");
+  }
+  const stageStat = await fs.lstat(stage);
+  if (stageStat.isSymbolicLink() || !stageStat.isDirectory()) {
+    throw new Error("Standalone staged output must be a real directory.");
+  }
+  await assertCompleteStagedOutput(stage);
+
+  const backup = `${outputRoot}.previous-${randomUUID()}`;
+  const rename = options.rename ?? fs.rename;
+  let previousMoved = false;
+  try {
+    await rename(outputRoot, backup);
+    previousMoved = true;
+    await rename(stage, outputRoot);
+  } catch (error) {
+    if (previousMoved) {
+      try {
+        await rename(backup, outputRoot);
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          "Could not promote standalone output or restore the previous artifact.",
+        );
+      }
+    }
+    throw error;
+  }
+  await removeOwnedOutputDirectory(backup);
 }
 
 async function run(
@@ -113,6 +184,9 @@ export async function buildStandalone(
   const temporaryRoot = await fs.mkdtemp(
     path.join(os.tmpdir(), "bb-mate-standalone-build-"),
   );
+  const stagedRoot = await fs.mkdtemp(
+    path.join(path.dirname(outputRoot), ".bb-mate-standalone-stage-"),
+  );
   try {
     const generatedEntry = path.join(temporaryRoot, "standalone-entry.ts");
     await fs.writeFile(
@@ -123,12 +197,12 @@ export async function buildStandalone(
       }),
     );
 
-    const executablePath = path.join(outputRoot, "bb-mate");
+    const stagedExecutablePath = path.join(stagedRoot, "bb-mate");
     const result = await Bun.build({
       entrypoints: [generatedEntry],
       compile: {
         target: "bun-darwin-arm64",
-        outfile: executablePath,
+        outfile: stagedExecutablePath,
         autoloadDotenv: false,
         autoloadBunfig: false,
       },
@@ -140,23 +214,29 @@ export async function buildStandalone(
         "Could not compile the standalone bb-mate executable.",
       );
     }
-    await fs.chmod(executablePath, 0o755);
+    await fs.chmod(stagedExecutablePath, 0o755);
 
     const sourceManifest = JSON.parse(
       await fs.readFile(path.join(cliRoot, "package.json"), "utf8"),
     ) as { version: string };
-    const executable = await fs.readFile(executablePath);
+    const executable = await fs.readFile(stagedExecutablePath);
     const manifest = createStandaloneManifest({
       graph,
       executable,
       bunVersion: Bun.version,
       runtimeVersion: sourceManifest.version,
     });
+    await fs.writeFile(
+      path.join(stagedRoot, "manifest.json"),
+      serializeStandaloneManifest(manifest),
+    );
+    await promoteStandaloneOutputRoot(outputRoot, stagedRoot);
+    const executablePath = path.join(outputRoot, "bb-mate");
     const manifestPath = path.join(outputRoot, "manifest.json");
-    await fs.writeFile(manifestPath, serializeStandaloneManifest(manifest));
     return { executablePath, manifestPath, manifest };
   } finally {
     await fs.rm(temporaryRoot, { recursive: true, force: true });
+    await fs.rm(stagedRoot, { recursive: true, force: true });
   }
 }
 

--- a/scripts/build-standalone.ts
+++ b/scripts/build-standalone.ts
@@ -20,6 +20,56 @@ const defaultOutputRoot = path.join(
   "standalone",
   "darwin-arm64",
 );
+const outputAllowlist = new Set(["bb-mate", "manifest.json"]);
+
+function containsPath(parent: string, candidate: string): boolean {
+  return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+}
+
+export async function prepareStandaloneOutputRoot(
+  root: string,
+): Promise<string> {
+  const outputRoot = path.resolve(root);
+  if (
+    outputRoot === path.parse(outputRoot).root ||
+    outputRoot === repositoryRoot ||
+    outputRoot === os.homedir() ||
+    containsPath(outputRoot, repositoryRoot)
+  ) {
+    throw new Error(`Refusing unsafe standalone output root: ${outputRoot}`);
+  }
+
+  const existing = await fs.lstat(outputRoot).catch((error: unknown) => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  });
+  if (existing?.isSymbolicLink() || (existing && !existing.isDirectory())) {
+    throw new Error(
+      `Standalone output root must be a real directory: ${outputRoot}`,
+    );
+  }
+  if (!existing) await fs.mkdir(outputRoot, { recursive: true });
+
+  const entries = await fs.readdir(outputRoot, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!outputAllowlist.has(entry.name) || !entry.isFile()) {
+      throw new Error(
+        `Standalone output root contains an unexpected entry: ${entry.name}`,
+      );
+    }
+  }
+  await Promise.all(
+    entries.map((entry) => fs.unlink(path.join(outputRoot, entry.name))),
+  );
+  return outputRoot;
+}
 
 async function run(
   args: readonly string[],
@@ -52,14 +102,9 @@ export interface BuildStandaloneResult {
 export async function buildStandalone(
   options: BuildStandaloneOptions = {},
 ): Promise<BuildStandaloneResult> {
-  const outputRoot = path.resolve(options.outputRoot ?? defaultOutputRoot);
-  if (
-    outputRoot === path.parse(outputRoot).root ||
-    outputRoot === repositoryRoot ||
-    outputRoot === os.homedir()
-  ) {
-    throw new Error(`Refusing unsafe standalone output root: ${outputRoot}`);
-  }
+  const outputRoot = await prepareStandaloneOutputRoot(
+    options.outputRoot ?? defaultOutputRoot,
+  );
   if (options.buildStories !== false) {
     await run([process.execPath, "run", "stories:build"], workbenchRoot);
   }
@@ -78,8 +123,6 @@ export async function buildStandalone(
       }),
     );
 
-    await fs.rm(outputRoot, { recursive: true, force: true });
-    await fs.mkdir(outputRoot, { recursive: true });
     const executablePath = path.join(outputRoot, "bb-mate");
     const result = await Bun.build({
       entrypoints: [generatedEntry],

--- a/scripts/build-standalone.ts
+++ b/scripts/build-standalone.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createStandaloneManifest,
+  generateStandaloneEntry,
+  inspectStandaloneAssets,
+  serializeStandaloneManifest,
+  type StandaloneManifest,
+} from "./standalone-assets.ts";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const workbenchRoot = path.join(repositoryRoot, "apps", "workbench");
+const labRoot = path.join(workbenchRoot, "dist", "ladle");
+const cliRoot = path.join(repositoryRoot, "apps", "cli");
+const defaultOutputRoot = path.join(
+  repositoryRoot,
+  "artifacts",
+  "standalone",
+  "darwin-arm64",
+);
+
+async function run(
+  args: readonly string[],
+  cwd = repositoryRoot,
+): Promise<void> {
+  const child = Bun.spawn([...args], {
+    cwd,
+    env: process.env,
+    stdin: "ignore",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) {
+    throw new Error(`${args.join(" ")} exited with code ${exitCode}.`);
+  }
+}
+
+export interface BuildStandaloneOptions {
+  outputRoot?: string;
+  buildStories?: boolean;
+}
+
+export interface BuildStandaloneResult {
+  executablePath: string;
+  manifestPath: string;
+  manifest: StandaloneManifest;
+}
+
+export async function buildStandalone(
+  options: BuildStandaloneOptions = {},
+): Promise<BuildStandaloneResult> {
+  const outputRoot = path.resolve(options.outputRoot ?? defaultOutputRoot);
+  if (
+    outputRoot === path.parse(outputRoot).root ||
+    outputRoot === repositoryRoot ||
+    outputRoot === os.homedir()
+  ) {
+    throw new Error(`Refusing unsafe standalone output root: ${outputRoot}`);
+  }
+  if (options.buildStories !== false) {
+    await run([process.execPath, "run", "stories:build"], workbenchRoot);
+  }
+
+  const graph = await inspectStandaloneAssets(labRoot);
+  const temporaryRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "bb-mate-standalone-build-"),
+  );
+  try {
+    const generatedEntry = path.join(temporaryRoot, "standalone-entry.ts");
+    await fs.writeFile(
+      generatedEntry,
+      generateStandaloneEntry({
+        assets: graph.assets,
+        entrypointPath: path.join(cliRoot, "src", "entrypoint.ts"),
+      }),
+    );
+
+    await fs.rm(outputRoot, { recursive: true, force: true });
+    await fs.mkdir(outputRoot, { recursive: true });
+    const executablePath = path.join(outputRoot, "bb-mate");
+    const result = await Bun.build({
+      entrypoints: [generatedEntry],
+      compile: {
+        target: "bun-darwin-arm64",
+        outfile: executablePath,
+        autoloadDotenv: false,
+        autoloadBunfig: false,
+      },
+      minify: true,
+    });
+    if (!result.success) {
+      throw new AggregateError(
+        result.logs,
+        "Could not compile the standalone bb-mate executable.",
+      );
+    }
+    await fs.chmod(executablePath, 0o755);
+
+    const sourceManifest = JSON.parse(
+      await fs.readFile(path.join(cliRoot, "package.json"), "utf8"),
+    ) as { version: string };
+    const executable = await fs.readFile(executablePath);
+    const manifest = createStandaloneManifest({
+      graph,
+      executable,
+      bunVersion: Bun.version,
+      runtimeVersion: sourceManifest.version,
+    });
+    const manifestPath = path.join(outputRoot, "manifest.json");
+    await fs.writeFile(manifestPath, serializeStandaloneManifest(manifest));
+    return { executablePath, manifestPath, manifest };
+  } finally {
+    await fs.rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.main) {
+  const result = await buildStandalone();
+  console.log(
+    JSON.stringify(
+      {
+        artifact: path.relative(repositoryRoot, result.executablePath),
+        manifest: path.relative(repositoryRoot, result.manifestPath),
+        target: result.manifest.target,
+        size: result.manifest.size,
+        sha256: result.manifest.sha256,
+        stories: result.manifest.storyCount,
+        assets: result.manifest.assets.length,
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/scripts/inspect-standalone.ts
+++ b/scripts/inspect-standalone.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { StandaloneManifest } from "./standalone-assets.ts";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const defaultArtifactRoot = path.join(
+  repositoryRoot,
+  "artifacts",
+  "standalone",
+  "darwin-arm64",
+);
+const artifactAllowlist = ["bb-mate", "manifest.json"] as const;
+const machMagic64 = 0xfeedfacf;
+const cpuTypeArm64 = 0x0100000c;
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function sha256(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export interface StandaloneInspection {
+  artifactRoot: string;
+  executablePath: string;
+  manifest: StandaloneManifest;
+}
+
+export async function inspectStandalone(
+  artifactRoot = defaultArtifactRoot,
+): Promise<StandaloneInspection> {
+  const resolvedRoot = path.resolve(artifactRoot);
+  const entries = (
+    await fs.readdir(resolvedRoot, { withFileTypes: true })
+  ).sort((left, right) => compareText(left.name, right.name));
+  assert(
+    entries.every((entry) => entry.isFile()),
+    "Standalone artifact directory may contain files only.",
+  );
+  assert(
+    JSON.stringify(entries.map((entry) => entry.name)) ===
+      JSON.stringify(artifactAllowlist),
+    `Standalone artifact allowlist mismatch: ${entries.map((entry) => entry.name).join(", ")}`,
+  );
+
+  const executablePath = path.join(resolvedRoot, "bb-mate");
+  const manifest = JSON.parse(
+    await fs.readFile(path.join(resolvedRoot, "manifest.json"), "utf8"),
+  ) as StandaloneManifest;
+  const [workspaceManifest, cliManifest] = await Promise.all([
+    fs
+      .readFile(path.join(repositoryRoot, "package.json"), "utf8")
+      .then((value) => JSON.parse(value) as { packageManager: string }),
+    fs
+      .readFile(
+        path.join(repositoryRoot, "apps", "cli", "package.json"),
+        "utf8",
+      )
+      .then((value) => JSON.parse(value) as { version: string }),
+  ]);
+  const executable = await fs.readFile(executablePath);
+  const stat = await fs.stat(executablePath);
+
+  assert(
+    manifest.schemaVersion === 1,
+    "Unexpected standalone manifest schema.",
+  );
+  assert(
+    manifest.artifact === "bb-mate",
+    "Unexpected standalone artifact name.",
+  );
+  assert(
+    manifest.target === "bun-darwin-arm64" &&
+      manifest.platform === "darwin" &&
+      manifest.architecture === "arm64",
+    "Standalone manifest target must be macOS arm64.",
+  );
+  assert(manifest.mode === "0755", "Standalone manifest mode must be 0755.");
+  assert(
+    manifest.bunVersion ===
+      workspaceManifest.packageManager.replace(/^bun@/, ""),
+    "Standalone manifest Bun version differs from the workspace pin.",
+  );
+  assert(
+    manifest.runtimeVersion === cliManifest.version,
+    "Standalone manifest runtime version differs from the CLI package.",
+  );
+  assert(
+    (stat.mode & 0o777) === 0o755,
+    `Standalone executable mode is ${(stat.mode & 0o777).toString(8)}, expected 755.`,
+  );
+  await fs.access(executablePath, constants.X_OK);
+  assert(
+    executable.byteLength >= 8 &&
+      executable.readUInt32LE(0) === machMagic64 &&
+      executable.readInt32LE(4) === cpuTypeArm64,
+    "Standalone executable is not a 64-bit arm64 Mach-O.",
+  );
+  assert(
+    manifest.size === executable.byteLength,
+    "Standalone executable size does not match its manifest.",
+  );
+  assert(
+    manifest.sha256 === sha256(executable),
+    "Standalone executable SHA-256 does not match its manifest.",
+  );
+  assert(
+    manifest.storyCount === 13,
+    "Standalone manifest must contain 13 stories.",
+  );
+  assert(
+    manifest.assets.length > 2,
+    "Standalone asset graph is unexpectedly small.",
+  );
+  assert(
+    manifest.assets.some((asset) => asset.route === "index.html") &&
+      manifest.assets.some((asset) => asset.route === "meta.json"),
+    "Standalone manifest is missing required lab assets.",
+  );
+  assert(
+    manifest.assets.every(
+      (asset) =>
+        asset.route.length > 0 &&
+        asset.size >= 0 &&
+        /^[a-f0-9]{64}$/.test(asset.sha256),
+    ),
+    "Standalone manifest contains invalid asset metadata.",
+  );
+  const routes = manifest.assets.map((asset) => asset.route);
+  assert(
+    JSON.stringify(routes) ===
+      JSON.stringify(
+        [...routes].sort((left, right) => compareText(left, right)),
+      ),
+    "Standalone manifest assets are not sorted.",
+  );
+  assert(
+    new Set(routes).size === routes.length,
+    "Standalone manifest contains duplicate routes.",
+  );
+
+  return { artifactRoot: resolvedRoot, executablePath, manifest };
+}
+
+if (import.meta.main) {
+  const inspection = await inspectStandalone(process.argv[2]);
+  console.log(
+    JSON.stringify(
+      {
+        artifactRoot: path.relative(repositoryRoot, inspection.artifactRoot),
+        target: inspection.manifest.target,
+        mode: inspection.manifest.mode,
+        size: inspection.manifest.size,
+        sha256: inspection.manifest.sha256,
+        stories: inspection.manifest.storyCount,
+        assets: inspection.manifest.assets.length,
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/scripts/standalone-assets.test.ts
+++ b/scripts/standalone-assets.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  createStandaloneManifest,
+  generateStandaloneEntry,
+  inspectStandaloneAssets,
+  serializeStandaloneManifest,
+} from "./standalone-assets.ts";
+
+const temporaryRoots: string[] = [];
+
+async function fixture(storyCount = 13): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-assets-"));
+  temporaryRoots.push(root);
+  await fs.mkdir(path.join(root, "assets"));
+  await Promise.all([
+    fs.writeFile(path.join(root, "index.html"), "<h1>Workbench</h1>\n"),
+    fs.writeFile(
+      path.join(root, "meta.json"),
+      `${JSON.stringify({
+        stories: Object.fromEntries(
+          Array.from({ length: storyCount }, (_, index) => [
+            `story-${index}`,
+            {},
+          ]),
+        ),
+      })}\n`,
+    ),
+    fs.writeFile(path.join(root, "assets", "app.js"), "export {};\n"),
+  ]);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true })),
+  );
+});
+
+describe("standalone asset graph", () => {
+  test("enumerates, hashes, and sorts the required asset graph", async () => {
+    const root = await fixture();
+    const graph = await inspectStandaloneAssets(root);
+
+    expect(graph.storyCount).toBe(13);
+    expect(graph.assets.map((asset) => asset.route)).toEqual([
+      "assets/app.js",
+      "index.html",
+      "meta.json",
+    ]);
+    expect(
+      graph.assets.every((asset) => /^[a-f0-9]{64}$/.test(asset.sha256)),
+    ).toBe(true);
+  });
+
+  test("rejects missing requirements, story drift, and symlinks", async () => {
+    const missing = await fixture();
+    await fs.rm(path.join(missing, "index.html"));
+    await expect(inspectStandaloneAssets(missing)).rejects.toThrow(
+      "missing index.html",
+    );
+
+    const drift = await fixture(12);
+    await expect(inspectStandaloneAssets(drift)).rejects.toThrow(
+      "Expected 13 standalone stories, found 12",
+    );
+
+    const linked = await fixture();
+    await fs.symlink(
+      path.join(linked, "index.html"),
+      path.join(linked, "assets", "linked.html"),
+    );
+    await expect(inspectStandaloneAssets(linked)).rejects.toThrow("symlink");
+  });
+
+  test("generates stable imports, route mapping, and manifest bytes", async () => {
+    const graph = await inspectStandaloneAssets(await fixture());
+    const entry = generateStandaloneEntry({
+      assets: [...graph.assets].reverse(),
+      entrypointPath: "/repo/apps/cli/src/entrypoint.ts",
+    });
+    expect(entry).toContain('mode: "standalone"');
+    expect(entry.indexOf('"/assets/app.js"')).toBeLessThan(
+      entry.indexOf('"/index.html"'),
+    );
+
+    const manifest = createStandaloneManifest({
+      graph,
+      executable: new TextEncoder().encode("executable"),
+      bunVersion: "1.3.14",
+      runtimeVersion: "0.1.0-alpha.2",
+    });
+    expect(manifest).toMatchObject({
+      target: "bun-darwin-arm64",
+      architecture: "arm64",
+      mode: "0755",
+      size: 10,
+      storyCount: 13,
+    });
+    expect(serializeStandaloneManifest(manifest)).toEndWith("\n");
+    expect(serializeStandaloneManifest(manifest)).toBe(
+      serializeStandaloneManifest(manifest),
+    );
+  });
+});

--- a/scripts/standalone-assets.ts
+++ b/scripts/standalone-assets.ts
@@ -1,0 +1,190 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface StandaloneAsset {
+  route: string;
+  sourcePath: string;
+  size: number;
+  sha256: string;
+}
+
+export interface StandaloneAssetGraph {
+  assets: StandaloneAsset[];
+  storyCount: number;
+}
+
+export interface StandaloneManifest {
+  schemaVersion: 1;
+  artifact: "bb-mate";
+  target: "bun-darwin-arm64";
+  platform: "darwin";
+  architecture: "arm64";
+  mode: "0755";
+  size: number;
+  sha256: string;
+  bunVersion: string;
+  runtimeVersion: string;
+  storyCount: number;
+  assets: Array<{
+    route: string;
+    size: number;
+    sha256: string;
+  }>;
+}
+
+const requiredRoutes = ["index.html", "meta.json"] as const;
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sha256(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function routeFromRelative(relativePath: string): string {
+  const route = relativePath.split(path.sep).join("/");
+  if (
+    route.length === 0 ||
+    route.startsWith("/") ||
+    route
+      .split("/")
+      .some((part) => part === "" || part === "." || part === "..")
+  ) {
+    throw new Error(`Invalid standalone asset route: ${relativePath}`);
+  }
+  return route;
+}
+
+async function collectFiles(root: string, relative = ""): Promise<string[]> {
+  const entries = await fs.readdir(path.join(root, relative), {
+    withFileTypes: true,
+  });
+  entries.sort((left, right) => compareText(left.name, right.name));
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const child = path.join(relative, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Standalone asset graph contains a symlink: ${child}`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(root, child)));
+    } else if (entry.isFile()) {
+      files.push(child);
+    } else {
+      throw new Error(`Standalone asset graph contains a non-file: ${child}`);
+    }
+  }
+  return files;
+}
+
+export async function inspectStandaloneAssets(
+  root: string,
+  expectedStoryCount = 13,
+): Promise<StandaloneAssetGraph> {
+  const resolvedRoot = await fs.realpath(root);
+  const relatives = await collectFiles(resolvedRoot);
+  const assets = await Promise.all(
+    relatives.map(async (relativePath): Promise<StandaloneAsset> => {
+      const sourcePath = path.join(resolvedRoot, relativePath);
+      const content = await fs.readFile(sourcePath);
+      return {
+        route: routeFromRelative(relativePath),
+        sourcePath,
+        size: content.byteLength,
+        sha256: sha256(content),
+      };
+    }),
+  );
+  assets.sort((left, right) => compareText(left.route, right.route));
+
+  const routes = new Set(assets.map((asset) => asset.route));
+  if (routes.size !== assets.length) {
+    throw new Error("Standalone asset graph contains duplicate routes.");
+  }
+  for (const required of requiredRoutes) {
+    if (!routes.has(required)) {
+      throw new Error(`Standalone asset graph is missing ${required}.`);
+    }
+  }
+
+  const metadata = JSON.parse(
+    await fs.readFile(path.join(resolvedRoot, "meta.json"), "utf8"),
+  ) as { stories?: Record<string, unknown> };
+  const storyCount = Object.keys(metadata.stories ?? {}).length;
+  if (storyCount !== expectedStoryCount) {
+    throw new Error(
+      `Expected ${expectedStoryCount} standalone stories, found ${storyCount}.`,
+    );
+  }
+
+  return { assets, storyCount };
+}
+
+export function generateStandaloneEntry(options: {
+  assets: readonly StandaloneAsset[];
+  entrypointPath: string;
+}): string {
+  const assets = [...options.assets].sort((left, right) =>
+    compareText(left.route, right.route),
+  );
+  const imports = assets.map(
+    (asset, index) =>
+      `import embeddedAsset${index} from ${JSON.stringify(asset.sourcePath)} with { type: "file" };`,
+  );
+  const manifest = assets.map(
+    (asset, index) =>
+      `  ${JSON.stringify(`/${asset.route}`)}: embeddedAsset${index},`,
+  );
+
+  return [
+    ...imports,
+    `import { runBbMateEntrypoint } from ${JSON.stringify(options.entrypointPath)};`,
+    "",
+    "const result = await runBbMateEntrypoint({",
+    '  mode: "standalone",',
+    "  assets: {",
+    ...manifest,
+    "  },",
+    "});",
+    "if (result.signal) process.kill(process.pid, result.signal);",
+    "process.exit(result.exitCode ?? 1);",
+    "",
+  ].join("\n");
+}
+
+export function createStandaloneManifest(options: {
+  graph: StandaloneAssetGraph;
+  executable: Uint8Array;
+  bunVersion: string;
+  runtimeVersion: string;
+}): StandaloneManifest {
+  return {
+    schemaVersion: 1,
+    artifact: "bb-mate",
+    target: "bun-darwin-arm64",
+    platform: "darwin",
+    architecture: "arm64",
+    mode: "0755",
+    size: options.executable.byteLength,
+    sha256: sha256(options.executable),
+    bunVersion: options.bunVersion,
+    runtimeVersion: options.runtimeVersion,
+    storyCount: options.graph.storyCount,
+    assets: options.graph.assets.map(
+      ({ route, size, sha256: assetSha256 }) => ({
+        route,
+        size,
+        sha256: assetSha256,
+      }),
+    ),
+  };
+}
+
+export function serializeStandaloneManifest(
+  manifest: StandaloneManifest,
+): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}

--- a/scripts/standalone-clean-room.ts
+++ b/scripts/standalone-clean-room.ts
@@ -1,0 +1,327 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildStandalone } from "./build-standalone.ts";
+import { inspectStandalone } from "./inspect-standalone.ts";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+const labRoot = path.join(repositoryRoot, "apps", "workbench", "dist", "ladle");
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function sha256(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function run(
+  args: readonly string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    allowFailure?: boolean;
+  },
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0 && !options.allowFailure) {
+    throw new Error(
+      `${args.join(" ")} exited with code ${exitCode}\n${stdout.trim()}\n${stderr.trim()}`,
+    );
+  }
+  return { exitCode, stdout, stderr };
+}
+
+async function unusedPort(): Promise<number> {
+  const probe = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("probe"),
+  });
+  const port = probe.port;
+  probe.stop(true);
+  if (port === undefined)
+    throw new Error("Could not allocate a loopback port.");
+  return port;
+}
+
+const temporaryRoot = await fs.mkdtemp(
+  path.join(os.tmpdir(), "bb-mate-standalone-clean-room-"),
+);
+let server: ReturnType<typeof Bun.spawn> | null = null;
+let hiddenLabRoot: string | null = null;
+
+try {
+  assert(
+    process.platform === "darwin" && process.arch === "arm64",
+    "The standalone clean-room lane requires a native macOS arm64 host.",
+  );
+
+  const buildRoot = path.join(temporaryRoot, "build");
+  const firstCopy = path.join(temporaryRoot, "first-bb-mate");
+  const firstManifestCopy = path.join(temporaryRoot, "first-manifest.json");
+  const first = await buildStandalone({ outputRoot: buildRoot });
+  await Promise.all([
+    fs.copyFile(first.executablePath, firstCopy),
+    fs.copyFile(first.manifestPath, firstManifestCopy),
+  ]);
+
+  const second = await buildStandalone({ outputRoot: buildRoot });
+  const inspected = await inspectStandalone(buildRoot);
+  const [firstExecutable, secondExecutable, firstManifest, secondManifest] =
+    await Promise.all([
+      fs.readFile(firstCopy),
+      fs.readFile(second.executablePath),
+      fs.readFile(firstManifestCopy, "utf8"),
+      fs.readFile(second.manifestPath, "utf8"),
+    ]);
+  assert(
+    firstExecutable.equals(secondExecutable),
+    "Two complete standalone builds are not byte-for-byte deterministic.",
+  );
+  assert(
+    firstManifest === secondManifest,
+    "Two complete standalone manifests are not byte-for-byte deterministic.",
+  );
+  assert(
+    sha256(secondExecutable) === inspected.manifest.sha256,
+    "Inspected standalone hash differs from the repeated build.",
+  );
+  assert(
+    !secondExecutable.includes(Buffer.from(repositoryRoot)),
+    "Standalone executable contains the absolute repository path.",
+  );
+
+  const movedRoot = path.join(temporaryRoot, "moved");
+  const homeRoot = path.join(temporaryRoot, "home");
+  const cacheRoot = path.join(temporaryRoot, "cache");
+  const configRoot = path.join(temporaryRoot, "config");
+  const dataRoot = path.join(temporaryRoot, "data");
+  const stateRoot = path.join(temporaryRoot, "state");
+  const tempRoot = path.join(temporaryRoot, "tmp");
+  await Promise.all(
+    [
+      movedRoot,
+      homeRoot,
+      cacheRoot,
+      configRoot,
+      dataRoot,
+      stateRoot,
+      tempRoot,
+    ].map((root) => fs.mkdir(root, { recursive: true })),
+  );
+  const movedExecutable = path.join(movedRoot, "bb-mate");
+  await fs.copyFile(second.executablePath, movedExecutable);
+  await fs.chmod(movedExecutable, 0o755);
+  await fs.access(movedExecutable, constants.X_OK);
+  await Promise.all([
+    fs.writeFile(path.join(movedRoot, ".env"), "BB_CLI=/ambient/not-bb\n"),
+    fs.writeFile(path.join(movedRoot, "bunfig.toml"), 'logLevel = "debug"\n'),
+  ]);
+
+  const runtimeEnv: NodeJS.ProcessEnv = {
+    PATH: "",
+    HOME: homeRoot,
+    TMPDIR: tempRoot,
+    XDG_CACHE_HOME: cacheRoot,
+    XDG_CONFIG_HOME: configRoot,
+    XDG_DATA_HOME: dataRoot,
+    XDG_STATE_HOME: stateRoot,
+    BB_CLI: "",
+    BUN_BE_BUN: "",
+    BUN_OPTIONS: "",
+    CI: "1",
+    LANG: "C.UTF-8",
+  };
+
+  const help = await run([movedExecutable, "--help"], {
+    cwd: movedRoot,
+    env: runtimeEnv,
+  });
+  assert(
+    help.stdout.includes("Usage: bb-mate"),
+    "Moved executable help failed.",
+  );
+
+  const workspaceRoot = path.join(temporaryRoot, "workspace");
+  const pluginRoot = path.join(workspaceRoot, "plugins", "fixture");
+  const executionMarker = path.join(temporaryRoot, "plugin-executed");
+  await fs.mkdir(pluginRoot, { recursive: true });
+  await Promise.all([
+    fs.writeFile(
+      path.join(pluginRoot, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "bb-plugin-standalone-fixture",
+          version: "1.0.0",
+          engines: { bb: ">=0.36.0", bbPluginSdk: "^0.4.1" },
+          dependencies: { "@bb/plugin-sdk": "^0.4.1" },
+          bb: {
+            name: "Standalone Fixture",
+            description: "No-Bun clean-room fixture",
+            branding: { icon: "Puzzle" },
+            server: "./server.ts",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    ),
+    fs.writeFile(
+      path.join(pluginRoot, "server.ts"),
+      `await Bun.write(${JSON.stringify(executionMarker)}, "executed");\n`,
+    ),
+  ]);
+
+  const inspection = await run([movedExecutable, "inspect", pluginRoot], {
+    cwd: workspaceRoot,
+    env: runtimeEnv,
+    allowFailure: true,
+  });
+  assert(inspection.exitCode === 1, "Missing native bb must fail inspection.");
+  assert(
+    inspection.stdout.includes("Native bb executable: unavailable") &&
+      inspection.stdout.includes("Plugin: Standalone Fixture"),
+    "Moved executable did not complete passive inspection.",
+  );
+  await fs.access(executionMarker).then(
+    () => {
+      throw new Error(
+        "Passive standalone inspection executed target plugin code.",
+      );
+    },
+    () => undefined,
+  );
+
+  const unavailableLabRoot = path.join(
+    temporaryRoot,
+    "checkout-lab-unavailable",
+  );
+  await fs.rename(labRoot, unavailableLabRoot);
+  hiddenLabRoot = unavailableLabRoot;
+  const port = await unusedPort();
+  server = Bun.spawn(
+    [
+      movedExecutable,
+      "dev",
+      pluginRoot,
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+    ],
+    {
+      cwd: workspaceRoot,
+      env: runtimeEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  let exited = false;
+  void server.exited.then(() => {
+    exited = true;
+  });
+  let ready = false;
+  for (let attempt = 0; attempt < 100 && !exited; attempt += 1) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/meta.json`);
+      if (response.ok) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // The standalone process is still starting.
+    }
+    await Bun.sleep(100);
+  }
+  assert(ready, "Moved executable did not start its embedded surface lab.");
+
+  const index = await fetch(`http://127.0.0.1:${port}/`);
+  assert(index.ok, "Embedded surface lab index is unavailable.");
+  const metadataResponse = await fetch(`http://127.0.0.1:${port}/meta.json`);
+  const metadata = (await metadataResponse.json()) as {
+    stories?: Record<string, unknown>;
+  };
+  assert(
+    Object.keys(metadata.stories ?? {}).length === 13,
+    "Embedded surface lab does not expose all 13 stories.",
+  );
+  const metadataHead = await fetch(`http://127.0.0.1:${port}/meta.json`, {
+    method: "HEAD",
+  });
+  assert(metadataHead.ok, "Embedded surface lab HEAD request failed.");
+  assert(
+    (await metadataHead.arrayBuffer()).byteLength === 0,
+    "Embedded surface lab HEAD response unexpectedly contained a body.",
+  );
+
+  for (const asset of inspected.manifest.assets) {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/${asset.route
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/")}`,
+    );
+    assert(response.ok, `Embedded asset is unavailable: ${asset.route}`);
+    const body = new Uint8Array(await response.arrayBuffer());
+    assert(
+      body.byteLength === asset.size && sha256(body) === asset.sha256,
+      `Embedded asset differs from its build input: ${asset.route}`,
+    );
+  }
+
+  server.kill("SIGTERM");
+  await server.exited;
+  await fetch(`http://127.0.0.1:${port}/meta.json`).then(
+    () => {
+      throw new Error("Standalone listener remained reachable after shutdown.");
+    },
+    () => undefined,
+  );
+  const stdoutStream = server.stdout;
+  const stderrStream = server.stderr;
+  assert(
+    stdoutStream instanceof ReadableStream,
+    "Server stdout was not captured.",
+  );
+  assert(
+    stderrStream instanceof ReadableStream,
+    "Server stderr was not captured.",
+  );
+  const stdout = await new Response(stdoutStream).text();
+  const stderr = await new Response(stderrStream).text();
+  assert(
+    stdout.includes("Launching Fixture surface lab"),
+    `Standalone output did not identify its embedded lab.\n${stderr}`,
+  );
+  server = null;
+
+  console.log(
+    `Standalone clean room passed: ${inspected.manifest.target}, mode ${inspected.manifest.mode}, ${inspected.manifest.size} bytes, sha256 ${inspected.manifest.sha256}, ${inspected.manifest.assets.length} assets, 13 stories.`,
+  );
+} finally {
+  if (server) {
+    server.kill("SIGKILL");
+    await server.exited.catch(() => undefined);
+  }
+  if (hiddenLabRoot) {
+    await fs.rename(hiddenLabRoot, labRoot);
+    hiddenLabRoot = null;
+  }
+  await fs.rm(temporaryRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Context

BB Mate's npm CLI intentionally requires Bun, but Plugin Workbench supervision needs an exact self-contained runtime artifact. This adds the independent #56 foundation lane without changing npm installation or distribution.

## What changed

- split source/package and standalone entrypoint assembly so the compiled program can never reuse itself as a Bun interpreter;
- serve one contained static-lab contract from filesystem, embedded, or in-memory assets;
- generate sorted static file imports for all 35 deterministic Ladle assets and compile an unsigned Darwin arm64 executable;
- write and inspect an exact two-file artifact with mode, architecture, size, SHA-256, story count, and asset hashes;
- add an empty-PATH clean room that builds twice, moves the binary, hides checkout assets, proves passive inspection and all 13 stories, and confirms shutdown;
- preserve the existing 41-file npm/shebang package lane and add a native `macos-15` CI job.

## Verification

- `bun run standalone:build`
- `bun run standalone:inspect`
- `bun run standalone:test`
- `bun run package:inspect`
- `bun run package:test`
- `bun run format:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run visual:test`
- `bun run compatibility:latest`

Local pre-review artifact: arm64 Mach-O, mode `0755`, 64,420,322 bytes, SHA-256 `479df4999ef6e6d340134a6dae61e85b11bc1a98f0c085754b152485ce7b0ec3`, 35 embedded assets, 13 stories.

## Boundary

This does not publish or install the binary, change the npm package, sign/notarize, add another platform, invoke automatic bunx, add runtime supervision, or touch normal bb state.

Closes #56