### PR TITLE
feat: persist source development targets

### DIFF
--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -99,6 +99,14 @@ run check && bun run test && bun run build`. The aggregate test lane contains
   and scripts 43. The legacy package clean room remained 41 files/13 stories
   with SHA-256
   `22e87071a14f060029f77500449991005de5eb88c06f7a29fa749f83848e7fb1`.
+- Slice 57A round-one remediation tightened root admission, fixed bounded
+  manifest reads, made scan budgets fair across admitted roots, validates the
+  released manifest shape, reports unreadable directories, binds issued
+  source candidates to filesystem identity, and attests every private source
+  row on reopen. The fresh aggregate gate passes with 387 tests: inspection
+  113, runtime 115, Linear plugin 21, CLI 42, Workbench 53, and scripts 43. The
+  legacy package clean room remains 41 files/13 stories with SHA-256
+  `dd6e1966905ea2e3c848d9cfedaaa341c23f1a606d98892312856700c08c757d`.
 - 2026-08-10: created the packet from the accepted design record and four
   bounded preparation audits.
 - 2026-08-10: activated the direct execution goal. Found one unresolved P2 on
@@ -352,6 +360,18 @@ and all builds.
   request `690f515a-0651-47ef-aa7a-852e9efe02cd` to
   `ac419ae1c87f7c5186b848bc937591cf45f57560`; #55 closed and GitButler
   reconciled without dirt or a residual lane.
+- Source-catalog round 1: standing and targeted both scored 2/5 at exact head
+  `5df4564d5673dafe54311b590dc5380e80d310ac`. Their security findings covered
+  broad or ignored roots, an unbounded manifest-growth race, private-source
+  rows that accepted invalid root identity, a forgeable/retargetable runtime
+  candidate bridge, cross-root scan starvation, released-manifest drift, and
+  swallowed directory-read failures. All are fixed for round 2: root policy
+  rejects filesystem/home ancestors and ignored components; manifest reads use
+  a fixed 256 KiB + 1 buffer; global budgets are partitioned across admitted
+  roots; discovery mirrors the released manifest contract and emits bounded
+  read diagnostics; issued candidates are module-private identity capabilities
+  bound to canonical path/device/inode; and stored private rows are strictly
+  parsed and fail closed without repair.
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -7,8 +7,9 @@ Status: Active
 
 The execution goal is active. Compatibility baseline #52, spec/goal PR #53,
 released-capability Gate 0 PR #68, and standalone-runtime PR #69 are merged.
-The narrowed runtime domain/security foundation #55 is implemented and locally
-green; its exact-head review and merge gate is the active milestone.
+The narrowed runtime domain/security foundation #55 is merged through PR #71
+and reconciled. Source-first development-target discovery #57 is the active
+milestone.
 
 ## Readiness
 
@@ -16,14 +17,15 @@ Active. Prompt/doctor/formatting and packet reviews pass; #52, #53, and #68 are
 merged. Gate 0 admits all released host-plugin rows to downstream execution.
 Standalone #69 passed green local, hosted, and two-lane exact-head review
 evidence and is reconciled. The transport-neutral runtime foundation #55 has
-passed focused and aggregate local verification; browser bootstrap/topology is
-isolated in #70.
+passed focused/aggregate verification, two independent exact-head reviews, and
+hosted CI, then merged and reconciled. Browser bootstrap/topology is isolated
+in #70.
 
 ## Baseline
 
 - Repository: `/Users/mg/Developer/bb/bb-mate`
-- Runtime branch: `feat/runtime/domain-security-foundation`; issue #55.
-- Current merge base: `3d37aaece878fd099854d4190df78d9ce45cb98a`.
+- Active branch: `feat/runtime/development-target-discovery`; issue #57.
+- Current merge base: `ac419ae1c87f7c5186b848bc937591cf45f57560`.
 - Compatibility PR #52 merged from exact head
   `1b047598b52f49ed8e6e0f7dd88387ff02c10445` to baseline merge commit
   `fa02c6d0d7c4ffb2f8855029def1589ed7ce7824`; issue #51 is closed.
@@ -38,7 +40,11 @@ isolated in #70.
   `d4dff55faa80231519daa2217d920cee73eb8a48` through GitHub async request
   `ed06e024-dbcc-4e9a-86e2-8560b05166a6` to merge commit
   `3d37aaece878fd099854d4190df78d9ce45cb98a`; issue #56 is closed.
-- GitButler reconciled to clean `main` with no active lanes.
+- Runtime PR #71 merged from exact reviewed head
+  `b4327b73ba8d8e1acd6c43572df417a126d71922` through GitHub async request
+  `690f515a-0651-47ef-aa7a-852e9efe02cd` to merge commit
+  `ac419ae1c87f7c5186b848bc937591cf45f57560`; issue #55 is closed.
+- GitButler reconciled to clean `main`; a fresh #57 branch was then applied.
 
 ## Preparation findings
 
@@ -291,7 +297,7 @@ and all builds.
   review rounds found and fixed ancestor-symlink admission, incomplete live-
   schema attestation, raw cursor errors, migration attestation ordering, and
   WAL/sidecar admission; round 3 reached 5/5 with zero P0-P3 and 40 focused
-  tests. Full exact-head standing and targeted PR review remains the merge gate.
+  tests. Full exact-head standing and targeted PR review then governed merge.
 - Runtime full review round 1: standing scored 3/5 and targeted 2/5 at exact
   head `f5c04a8ba2784143e023d44f603945e3f6111d6c`. Their shared P1
   (`RT-SG-001` / `PW-RUNTIME-001`) reproduced privilege escalation by spreading
@@ -319,6 +325,13 @@ and all builds.
   aggregate tests even though the exact-head run contains 304. The count is
   corrected for the final docs-only exact-head recheck; no runtime behavior or
   prior verification result changed.
+- Runtime full review round 4: standing and targeted both reached 5/5 with zero
+  P0-P3 at docs-only head `b4327b73ba8d8e1acd6c43572df417a126d71922`.
+  Hosted verify, visual, standalone-arm64, and security checks were green; the
+  PR was cleanly mergeable with no review threads. PR #71 merged through async
+  request `690f515a-0651-47ef-aa7a-852e9efe02cd` to
+  `ac419ae1c87f7c5186b848bc937591cf45f57560`; #55 closed and GitButler
+  reconciled without dirt or a residual lane.
 
 ## Verification Log
 
@@ -352,8 +365,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 ## Final State
 
-Execution active. Gate 0 and standalone-runtime #56 are merged, closed, and
-reconciled on clean `main`. Runtime foundation #55 is implemented and locally
-green on a separate merge-first branch; exact-head review, hosted CI, merge,
-and reconciliation remain. All release/upstream/Connect/normal-profile stop
-boundaries remain intact.
+Execution active. Gate 0, standalone-runtime #56, and runtime foundation #55
+are merged, closed, and reconciled on clean `main`. Source-first discovery #57
+is active on a fresh merge-first branch. All release/upstream/Connect/normal-
+profile stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -107,6 +107,17 @@ run check && bun run test && bun run build`. The aggregate test lane contains
   113, runtime 115, Linear plugin 21, CLI 42, Workbench 53, and scripts 43. The
   legacy package clean room remains 41 files/13 stories with SHA-256
   `dd6e1966905ea2e3c848d9cfedaaa341c23f1a606d98892312856700c08c757d`.
+- Slice 57A round-two remediation preserves each root's reserved scan share,
+  then redistributes unused entry/candidate capacity without exceeding the
+  global 2,048/128 bounds. Discovery rejects invalid engine shapes and
+  malformed plugin-owned SVG bytes through bounded no-follow reads. Exact
+  inspection candidates are WeakMap-issued and revalidate candidate-directory
+  identity plus bounded manifest inode/hash before a runtime bridge derives
+  conservative absent/false native capability state. The fresh aggregate gate
+  passes with 396 tests: inspection 120, runtime 116, Linear plugin 21, CLI 42,
+  Workbench 53, and scripts 44. The legacy package clean room remains 41
+  files/13 stories with SHA-256
+  `27b0418115264df75edb01b4cc4bf33c8baa7e7829a3f693d6fab392abc1fc83`.
 - 2026-08-10: created the packet from the accepted design record and four
   bounded preparation audits.
 - 2026-08-10: activated the direct execution goal. Found one unresolved P2 on
@@ -372,6 +383,16 @@ and all builds.
   read diagnostics; issued candidates are module-private identity capabilities
   bound to canonical path/device/inode; and stored private rows are strictly
   parsed and fail closed without repair.
+- Source-catalog round 2: targeted scored 4/5 and standing 3/5 at exact head
+  `36d886e02cc5bb7cabe048f45c8b890c7f431593`. `LR-003` / `SC-SG-005`
+  found that immutable per-root shares stranded unused global capacity;
+  `SC-SG-004` kept manifest-contract alignment open because discovery accepted
+  invalid engines and malformed plugin-owned SVG bytes. Both are fixed with
+  bounded reserved-first redistribution and canonical compact-SVG validation.
+  The remediation also strengthens the previously accepted internal bridge:
+  raw target/native claims have no issuance path, inspection and runtime use
+  two exact capability stages, and directory/manifest changes between
+  discovery and persistence fail closed. Fresh exact-head review remains.
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -414,7 +414,19 @@ and all builds.
   type/compatibility checks, formatting, every build, and the 41-file/13-story
   package clean room at SHA-256
   `622b4c8148f0b449c6321c8625b27ac24a84f8a0b662a4b0efcad7997715bed4`.
-  Fresh exact-head review remains.
+  Fresh exact-head review remained at that point.
+- Source-catalog round 4: standing and targeted both reached 5/5 with zero
+  P0-P3 at exact head `f8fe4765394527b03f421717bcd7780220b952a6`.
+  Each lane independently rejected all three transition-time mutations and the
+  post-issuance/pre-persistence mutation with an empty catalog, verified
+  Windows-style icon parity and true global scan bounds, and found the full
+  security/persistence/export/no-execution boundary clean. Hosted verify,
+  visual, standalone-arm64, and security checks passed; PR #72 was cleanly
+  mergeable with no review threads and GitButler had no uncommitted changes.
+  Superseded source-catalog rounds 1-3 were scratch-archived under
+  `/tmp/bb-mate-plugin-workbench-reviews-20260810/source-catalog/` after their
+  findings and dispositions were preserved here. Prompt validation and the
+  canonical goal-loop doctor then passed with 17 active review reports.
 
 ## Verification Log
 
@@ -449,6 +461,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 ## Final State
 
 Execution active. Gate 0, standalone-runtime #56, and runtime foundation #55
-are merged, closed, and reconciled on clean `main`. Source-first discovery #57
-is active on a fresh merge-first branch. All release/upstream/Connect/normal-
-profile stop boundaries remain intact.
+are merged, closed, and reconciled. Source-catalog slice 57A implementation
+and review are complete on draft PR #72; the final docs-only readiness head,
+ready transition, merge, and reconciliation remain before 57B starts. All
+release/upstream/Connect/normal-profile stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -9,7 +9,8 @@ The execution goal is active. Compatibility baseline #52, spec/goal PR #53,
 released-capability Gate 0 PR #68, and standalone-runtime PR #69 are merged.
 The narrowed runtime domain/security foundation #55 is merged through PR #71
 and reconciled. Source-first development-target discovery #57 is the active
-milestone.
+milestone. Slice 57A implementation and local verification are complete on
+draft PR #72; exact-head review, hosted CI, merge, and reconciliation remain.
 
 ## Readiness
 
@@ -45,6 +46,9 @@ in #70.
   `690f515a-0651-47ef-aa7a-852e9efe02cd` to merge commit
   `ac419ae1c87f7c5186b848bc937591cf45f57560`; issue #55 is closed.
 - GitButler reconciled to clean `main`; a fresh #57 branch was then applied.
+- Source-catalog PR #72 was opened from merge base
+  `ac419ae1c87f7c5186b848bc937591cf45f57560`; its implementation head is not
+  yet frozen because exact-head review and merge remain pending.
 
 ## Preparation findings
 
@@ -79,6 +83,22 @@ in #70.
 
 ## Execution Log
 
+- 2026-08-10: slice 57A added strict self-bound development-target codecs,
+  private/public SQLite catalog persistence, dedicated target authorization,
+  server-admitted source roots, bounded passive discovery, canonical path and
+  symlink-race attestations, no-execution sentinels, and a real cross-package
+  reopen integration test. Generic object CRUD rejects development targets;
+  direct catalog calls independently reject forged source capabilities.
+- Slice 57A focused proof passed: inspection 87 tests/191 assertions, runtime
+  113 tests/598 assertions, and the cross-package catalog plus public-export
+  checks 3 tests/18 assertions. The first aggregate build exposed Node
+  strip-only syntax in a discovery error class; a focused regression fixed it.
+- Slice 57A aggregate proof then passed exactly: `bun run format:check && bun
+run check && bun run test && bun run build`. The aggregate test lane contains
+  359 tests: inspection 87, runtime 113, Linear plugin 21, CLI 42, Workbench 53,
+  and scripts 43. The legacy package clean room remained 41 files/13 stories
+  with SHA-256
+  `22e87071a14f060029f77500449991005de5eb88c06f7a29fa749f83848e7fb1`.
 - 2026-08-10: created the packet from the accepted design record and four
   bounded preparation audits.
 - 2026-08-10: activated the direct execution goal. Found one unresolved P2 on

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -392,7 +392,29 @@ and all builds.
   The remediation also strengthens the previously accepted internal bridge:
   raw target/native claims have no issuance path, inspection and runtime use
   two exact capability stages, and directory/manifest changes between
-  discovery and persistence fail closed. Fresh exact-head review remains.
+  discovery and persistence fail closed.
+- Source-catalog round 3: standing and targeted both scored 2/5 at exact head
+  `71f2fffc0108b7427f12ba07a1226e2f8c2cf5cc`. `SC-SG-006` / `LR-001`
+  reproduced a transition race after inspection returned plain facts but
+  before runtime captured them; in-place manifest mutation, manifest inode
+  replacement, and whole-directory replacement all admitted stale claims.
+  `SC-SG-004` also remained open because discovery treated `.\\icon.svg` as a
+  plugin-owned path while the released validator treats only `./` paths that
+  way. `LR-006` noted a stale budget comment.
+- The round-3 remediation replaces the plain-facts reader with an exact,
+  one-use transition capability. Inspection pre/post-attests the candidate
+  directory and bounded manifest around runtime issuance; runtime independently
+  verifies the same canonical path, device, inode, and SHA-256 evidence, keeps
+  that identity on its own capability, and revalidates it before catalog
+  persistence. Focused attacks for all three transition races and a
+  post-issuance manifest mutation now fail closed with no catalog mutation.
+  Windows-style `.\\icon.svg` is again a host icon name, matching the released
+  validator, and the budget comment now describes reserved-first
+  redistribution. The remediation gate passes 401 repository tests, all
+  type/compatibility checks, formatting, every build, and the 41-file/13-story
+  package clean room at SHA-256
+  `622b4c8148f0b449c6321c8625b27ac24a84f8a0b662a4b0efcad7997715bed4`.
+  Fresh exact-head review remains.
 
 ## Verification Log
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -462,6 +462,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 Execution active. Gate 0, standalone-runtime #56, and runtime foundation #55
 are merged, closed, and reconciled. Source-catalog slice 57A implementation
-and review are complete on draft PR #72; the final docs-only readiness head,
-ready transition, merge, and reconciliation remain before 57B starts. All
-release/upstream/Connect/normal-profile stop boundaries remain intact.
+and code review are complete on draft PR #72; this docs-only readiness head
+still needs its narrow exact-head review, ready transition, merge, and
+reconciliation before 57B starts. All release/upstream/Connect/normal-profile
+stop boundaries remain intact.

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,0 +1,124 @@
+# Source-first development-target discovery
+
+Date: 2026-08-10
+Status: Slice A active
+Issue: #57
+Parent: #21
+Depends on: #55 (merged through PR #71)
+
+## Outcome
+
+Persist stable, opaque `DevelopmentTarget` objects only from server-admitted
+source roots, then reconcile those targets against bounded native inventory.
+Installed plugins never seed candidates, target code never executes during
+discovery, and browser/model projections never receive a raw source path.
+
+## Delivery shape
+
+Deliver #57 as two independently reviewable, merge-first slices:
+
+1. **57A — secure persisted source catalog.** Admit bounded trusted roots,
+   discover passive manifests, persist a self-bound target plus its private
+   canonical root atomically, reopen it with a stable ID, and expose an
+   allowlist-built redacted projection.
+2. **57B — native reconciliation and Workbench adapter.** Classify exact path,
+   other path, managed, builtin conflict, absent, duplicate, malformed, and
+   stale states from a bounded read-only inventory; adapt inspection and the
+   browser Workbench to server-issued target IDs.
+
+Issue #57 closes only after both slices merge and reconcile.
+
+## Contract decisions
+
+- A development target is self-bound: `envelope.id` and
+  `envelope.bindings.targetId` are the same opaque target ID.
+- A bb-context-bound, target-unbound trusted server principal may create or
+  reconcile targets only through a dedicated target-catalog service with
+  `targets:write`. `targets:read` may list that principal's targets before a
+  target is selected. The generic object service remains target-bound.
+- Caller DTOs never accept IDs for creation, authorization bindings, source
+  paths, URLs, commands, credentials, or host/topology claims.
+- The public envelope and private source-root record are one SQLite
+  transaction. Canonical roots, trusted-root keys, raw inventory, and host
+  facts never enter public payloads or event records.
+- IDs are CSPRNG-generated in production and injectable in tests. Refresh and
+  restart preserve the same ID for the same private canonical root.
+- The `bb` object in `package.json` is the released plugin manifest. No second
+  manifest format is introduced.
+
+## Trusted-root policy
+
+- Roots enter only from server startup/configuration, the current project
+  context, or a previously authorized pinned record. Browser/model input can
+  select only server-issued opaque IDs.
+- V1 limits are explicit: 16 roots, depth 4, 2,048 visited entries, 128
+  candidates, 256 KiB per package manifest, and 8,192 characters per bounded
+  diagnostic. Exceeding a limit returns typed bounded evidence and does not
+  hide safe siblings.
+- Reject root leaf symlinks and every symlink component below the canonical
+  root, including candidate directories, `package.json`, entrypoints, skills,
+  icons, and themes. OS-level aliases preceding the configured root may
+  canonicalize normally.
+- Resolve lexically, reject absolute descendants and `..`, verify canonical
+  containment, open manifest leaves without following symlinks, bound before
+  reading, and recheck file identity after reading.
+- Never scan home, `/`, installed plugin roots, `node_modules`, `.git`,
+  `dist`, caches, or arbitrary hidden trees. Deduplicate by canonical root.
+
+## Native reconciliation contract
+
+Native inventory is a bounded read-only input after source discovery. Matching
+precedence is malformed matching/top-level evidence, duplicate identity/root,
+stale snapshot, exact canonical path, other path with the same plugin ID,
+managed npm/Git identity, builtin identity conflict, then absent. Staleness is
+computed from an injected clock and a 30-second V1 observation horizon.
+
+Private host evidence is limited to runtime instance ID, bounded hostname,
+optional local bb host ID/name/`isServer`, and observation time. It contains no
+reachability, same-host verdict, bootstrap credential, browser URL, or topology
+decision; #70 owns that gate.
+
+## TDD execution
+
+1. [ ] Add the concrete strict v1 target codec, self-binding validation, and
+       allowlist public projection with oversize/unknown/private-field tests.
+2. [ ] Add secure trusted-root admission and bounded passive candidate
+       discovery with traversal, symlink, scan-limit, malformed-sibling, and
+       no-execution sentinels.
+3. [ ] Add atomic private/public catalog persistence, target-unbound dedicated
+       authorization, stable reopen/refresh IDs, optimistic revisions, and
+       redacted events.
+4. [ ] Review, verify, merge, and reconcile slice 57A with two 5/5 lanes.
+5. [ ] Add bounded native inventory and pure reconciliation fixtures for all
+       required states without lifecycle mutation or candidate seeding.
+6. [ ] Adapt one-authorized-target inspection and Workbench selection to
+       opaque target IDs; reverse the prior external-symlink acceptance test.
+7. [ ] Record bounded private host observations without topology conclusions.
+8. [ ] Run visual/accessibility and aggregate gates, two 5/5 reviews, hosted
+       CI, merge #57, close the issue, and reconcile GitButler.
+
+## Verification
+
+- Focused inspection/runtime/catalog tests while iterating.
+- `bun --filter @bb-mate/inspection check`
+- `bun --filter @bb-mate/runtime check`
+- `bun --filter @bb-mate/workbench check`
+- `bun run visual:test` for the Workbench adapter slice.
+- `bun run format:check && bun run check && bun run test && bun run build`
+- Exact route/export audit proving no raw path/URL/shell, arbitrary filesystem
+  browse, bootstrap/topology, lifecycle mutation, target execution, Connect,
+  remote bind, or normal-profile surface was added.
+
+## Stop conditions
+
+Stop this issue before browser credential mint/redeem, automatic host-browser
+control, target execution, build/install/dev/reload, managed-plugin mutation,
+Connect pairing/exposure, arbitrary filesystem browsing, MCP, publication,
+release, signing, or upstream submission. If a released bb contract is missing,
+leave the dependent behavior unavailable and track the exact unblock.
+
+## Done
+
+Both slices are merged to `main`; #57 and #21 are current; exact local and
+hosted gates pass; two independent review lanes score 5/5 with zero P0-P2;
+GitButler is clean/reconciled; and the goal retrospective records exact proof.

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,7 +1,7 @@
 # Source-first development-target discovery
 
 Date: 2026-08-10
-Status: Slice A active
+Status: Slice A implementation and local verification complete; review and merge pending
 Issue: #57
 Parent: #21
 Depends on: #55 (merged through PR #71)
@@ -80,12 +80,12 @@ decision; #70 owns that gate.
 
 ## TDD execution
 
-1. [ ] Add the concrete strict v1 target codec, self-binding validation, and
+1. [x] Add the concrete strict v1 target codec, self-binding validation, and
        allowlist public projection with oversize/unknown/private-field tests.
-2. [ ] Add secure trusted-root admission and bounded passive candidate
+2. [x] Add secure trusted-root admission and bounded passive candidate
        discovery with traversal, symlink, scan-limit, malformed-sibling, and
        no-execution sentinels.
-3. [ ] Add atomic private/public catalog persistence, target-unbound dedicated
+3. [x] Add atomic private/public catalog persistence, target-unbound dedicated
        authorization, stable reopen/refresh IDs, optimistic revisions, and
        redacted events.
 4. [ ] Review, verify, merge, and reconcile slice 57A with two 5/5 lanes.

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,7 +1,7 @@
 # Source-first development-target discovery
 
 Date: 2026-08-10
-Status: Slice A implementation and local verification complete; review and merge pending
+Status: Slice A implementation and review complete; merge pending
 Issue: #57
 Parent: #21
 Depends on: #55 (merged through PR #71)

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -41,6 +41,10 @@ Issue #57 closes only after both slices merge and reconcile.
 - The public envelope and private source-root record are one SQLite
   transaction. Canonical roots, trusted-root keys, raw inventory, and host
   facts never enter public payloads or event records.
+- Inspection hands a candidate to runtime through a one-use, identity-backed
+  transition. Directory and bounded `package.json` device/inode/hash evidence
+  is attested before and after runtime issuance, retained by the runtime
+  capability, and revalidated again immediately before catalog persistence.
 - IDs are CSPRNG-generated in production and injectable in tests. Refresh and
   restart preserve the same ID for the same private canonical root.
 - The `bb` object in `package.json` is the released plugin manifest. No second

--- a/.agents/plans/2026-08-10-runtime-foundation.md
+++ b/.agents/plans/2026-08-10-runtime-foundation.md
@@ -1,7 +1,7 @@
 # Workbench runtime foundation
 
 Date: 2026-08-10
-Status: Implementation and local verification complete; review and merge pending
+Status: Complete
 Issue: [#55](https://github.com/galligan/bb-mate/issues/55)
 Goal: `.agents/goals/2026-08-10-plugin-workbench/`
 
@@ -68,7 +68,7 @@ transport.
 7. [x] Add schema, canonicalization, IDOR, migration/corruption, event,
        file-mode, HTTP policy, and forbidden-surface tests. Audit exports/routes
        for every deferred feature.
-8. [ ] Run focused and aggregate checks, two independent 5/5 review lanes,
+8. [x] Run focused and aggregate checks, two independent 5/5 review lanes,
        hosted CI, issue/PR/thread gates, SHA-pinned merge, and clean GitButler
        reconciliation.
 

--- a/packages/inspection/src/discover-source-candidates.test.ts
+++ b/packages/inspection/src/discover-source-candidates.test.ts
@@ -266,7 +266,12 @@ describe("passive source discovery", () => {
           preinstall: `printf package-script > ${JSON.stringify(sentinel)}`,
           postinstall: `printf package-script > ${JSON.stringify(sentinel)}`,
         },
-        bb: { name: "passive", server: "./server.ts" },
+        bb: {
+          name: "passive",
+          description: "passive plugin",
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+        },
       }),
     );
     const admission = await admitTrustedRoots([

--- a/packages/inspection/src/discover-source-candidates.test.ts
+++ b/packages/inspection/src/discover-source-candidates.test.ts
@@ -9,7 +9,6 @@ import {
 } from "./discovery-test-helpers.ts";
 import type { TrustedRoot } from "./discovery-types.ts";
 import { admitTrustedRoots } from "./trusted-roots.ts";
-import { readIssuedSourceCandidate } from "./index.ts";
 
 const harness = createDiscoveryTestHarness();
 
@@ -67,79 +66,6 @@ describe("passive source discovery", () => {
     expect(candidate?.canonicalRoot).toBe(await fs.realpath(rootPath));
     expect(() => JSON.stringify(candidate)).toThrow(
       "source candidates are server-private",
-    );
-  });
-
-  test("reads only exact issued candidate capabilities into fresh frozen facts", async () => {
-    const rootPath = await harness.createRoot();
-    await harness.writePlugin(rootPath, "issued");
-    const admission = await admitTrustedRoots([
-      { rootKey: WORKSPACE_ROOT_KEY, kind: "pinned", path: rootPath },
-    ]);
-    const result = await discoverSourceCandidates(admission.roots);
-    const candidate = result.candidates[0]!;
-
-    const first = await readIssuedSourceCandidate(candidate);
-    const second = await readIssuedSourceCandidate(candidate);
-
-    expect(first).toEqual({
-      rootKey: WORKSPACE_ROOT_KEY,
-      rootKind: "pinned",
-      canonicalRoot: await fs.realpath(rootPath),
-      displayPath: "workspace",
-      packageName: "bb-plugin-issued",
-      version: "1.2.3",
-      pluginId: "issued",
-      displayName: "issued",
-      hasServer: true,
-      hasApp: false,
-    });
-    expect(Object.isFrozen(first)).toBeTrue();
-    expect(first).not.toBe(second);
-    for (const forged of [
-      { ...candidate },
-      Object.create(candidate) as unknown,
-      { ...first },
-      null,
-    ]) {
-      await expect(readIssuedSourceCandidate(forged)).rejects.toThrow(
-        "source candidate was not issued by discovery",
-      );
-    }
-  });
-
-  test("rejects an issued candidate whose directory is replaced at the same path", async () => {
-    const rootPath = await harness.createRoot();
-    const candidateRoot = path.join(rootPath, "plugin");
-    const originalRoot = path.join(rootPath, "plugin-original");
-    await fs.mkdir(candidateRoot);
-    await harness.writePlugin(candidateRoot, "issued");
-    const admission = await admitTrustedRoots([
-      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
-    ]);
-    const result = await discoverSourceCandidates(admission.roots);
-    const candidate = result.candidates[0]!;
-    await fs.rename(candidateRoot, originalRoot);
-    await fs.mkdir(candidateRoot);
-    await harness.writePlugin(candidateRoot, "replacement");
-
-    await expect(readIssuedSourceCandidate(candidate)).rejects.toThrow(
-      "source candidate was not issued by discovery",
-    );
-  });
-
-  test("rejects stale facts after the bounded manifest changes", async () => {
-    const rootPath = await harness.createRoot();
-    await harness.writePlugin(rootPath, "issued");
-    const admission = await admitTrustedRoots([
-      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
-    ]);
-    const result = await discoverSourceCandidates(admission.roots);
-    const candidate = result.candidates[0]!;
-    await fs.appendFile(path.join(rootPath, "package.json"), " \n");
-
-    await expect(readIssuedSourceCandidate(candidate)).rejects.toThrow(
-      "source candidate was not issued by discovery",
     );
   });
 

--- a/packages/inspection/src/discover-source-candidates.test.ts
+++ b/packages/inspection/src/discover-source-candidates.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./discovery-test-helpers.ts";
 import type { TrustedRoot } from "./discovery-types.ts";
 import { admitTrustedRoots } from "./trusted-roots.ts";
+import { readIssuedSourceCandidate } from "./index.ts";
 
 const harness = createDiscoveryTestHarness();
 
@@ -66,6 +67,79 @@ describe("passive source discovery", () => {
     expect(candidate?.canonicalRoot).toBe(await fs.realpath(rootPath));
     expect(() => JSON.stringify(candidate)).toThrow(
       "source candidates are server-private",
+    );
+  });
+
+  test("reads only exact issued candidate capabilities into fresh frozen facts", async () => {
+    const rootPath = await harness.createRoot();
+    await harness.writePlugin(rootPath, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "pinned", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+
+    const first = await readIssuedSourceCandidate(candidate);
+    const second = await readIssuedSourceCandidate(candidate);
+
+    expect(first).toEqual({
+      rootKey: WORKSPACE_ROOT_KEY,
+      rootKind: "pinned",
+      canonicalRoot: await fs.realpath(rootPath),
+      displayPath: "workspace",
+      packageName: "bb-plugin-issued",
+      version: "1.2.3",
+      pluginId: "issued",
+      displayName: "issued",
+      hasServer: true,
+      hasApp: false,
+    });
+    expect(Object.isFrozen(first)).toBeTrue();
+    expect(first).not.toBe(second);
+    for (const forged of [
+      { ...candidate },
+      Object.create(candidate) as unknown,
+      { ...first },
+      null,
+    ]) {
+      await expect(readIssuedSourceCandidate(forged)).rejects.toThrow(
+        "source candidate was not issued by discovery",
+      );
+    }
+  });
+
+  test("rejects an issued candidate whose directory is replaced at the same path", async () => {
+    const rootPath = await harness.createRoot();
+    const candidateRoot = path.join(rootPath, "plugin");
+    const originalRoot = path.join(rootPath, "plugin-original");
+    await fs.mkdir(candidateRoot);
+    await harness.writePlugin(candidateRoot, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+    await fs.rename(candidateRoot, originalRoot);
+    await fs.mkdir(candidateRoot);
+    await harness.writePlugin(candidateRoot, "replacement");
+
+    await expect(readIssuedSourceCandidate(candidate)).rejects.toThrow(
+      "source candidate was not issued by discovery",
+    );
+  });
+
+  test("rejects stale facts after the bounded manifest changes", async () => {
+    const rootPath = await harness.createRoot();
+    await harness.writePlugin(rootPath, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+    await fs.appendFile(path.join(rootPath, "package.json"), " \n");
+
+    await expect(readIssuedSourceCandidate(candidate)).rejects.toThrow(
+      "source candidate was not issued by discovery",
     );
   });
 

--- a/packages/inspection/src/discover-source-candidates.test.ts
+++ b/packages/inspection/src/discover-source-candidates.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import {
+  createDiscoveryTestHarness,
+  EXAMPLE_ROOT_KEY,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import type { TrustedRoot } from "./discovery-types.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+describe("passive source discovery", () => {
+  test("rejects a caller-forged trusted root", async () => {
+    const forged = {
+      rootKey: WORKSPACE_ROOT_KEY,
+      kind: "explicit",
+      displayName: "forged",
+    } as TrustedRoot;
+
+    await expect(discoverSourceCandidates([forged])).rejects.toThrow(
+      "trusted root was not admitted by the server",
+    );
+  });
+
+  test("discovers a bb package at an admitted root", async () => {
+    const rootPath = await harness.createRoot("example-workspace");
+    await harness.writePlugin(rootPath, "example");
+    const admission = await admitTrustedRoots([
+      { rootKey: EXAMPLE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.candidates).toEqual([
+      {
+        rootKey: EXAMPLE_ROOT_KEY,
+        canonicalRoot: await fs.realpath(rootPath),
+        displayPath: "example-workspace",
+        packageName: "bb-plugin-example",
+        version: "1.2.3",
+        pluginId: "example",
+        displayName: "example",
+        hasServer: true,
+        hasApp: false,
+      },
+    ]);
+  });
+
+  test("keeps candidate internals usable but rejects accidental serialization", async () => {
+    const rootPath = await harness.createRoot();
+    await harness.writePlugin(rootPath, "private");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0];
+
+    expect(candidate?.rootKey).toBe(WORKSPACE_ROOT_KEY);
+    expect(candidate?.canonicalRoot).toBe(await fs.realpath(rootPath));
+    expect(() => JSON.stringify(candidate)).toThrow(
+      "source candidates are server-private",
+    );
+  });
+
+  test.each([
+    [
+      "display name",
+      {
+        name: "bb-plugin-broken",
+        version: "1.0.0",
+        bb: { name: "d".repeat(129), server: "./server.ts" },
+      },
+    ],
+    [
+      "package name",
+      {
+        name: "n".repeat(215),
+        version: "1.0.0",
+        bb: { name: "broken", server: "./server.ts" },
+      },
+    ],
+    [
+      "version",
+      {
+        name: "bb-plugin-broken",
+        version: "1".repeat(65),
+        bb: { name: "broken", server: "./server.ts" },
+      },
+    ],
+    [
+      "derived plugin id",
+      {
+        name: `bb-plugin-${"p".repeat(65)}`,
+        version: "1.0.0",
+        bb: { name: "broken", server: "./server.ts" },
+      },
+    ],
+  ])(
+    "rejects an oversized %s without hiding a safe sibling",
+    async (_label, manifest) => {
+      const rootPath = await harness.createRoot();
+      const brokenRoot = path.join(rootPath, "broken");
+      const safeRoot = path.join(rootPath, "safe");
+      await fs.mkdir(brokenRoot);
+      await fs.mkdir(safeRoot);
+      await fs.writeFile(
+        path.join(brokenRoot, "package.json"),
+        JSON.stringify(manifest),
+      );
+      await fs.writeFile(path.join(brokenRoot, "server.ts"), "export {};\n");
+      await harness.writePlugin(safeRoot, "safe");
+      const admission = await admitTrustedRoots([
+        {
+          rootKey: WORKSPACE_ROOT_KEY,
+          kind: "current-project",
+          path: rootPath,
+        },
+      ]);
+
+      const result = await discoverSourceCandidates(admission.roots);
+
+      expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+        "safe",
+      ]);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: "manifest-invalid",
+          displayPath: "workspace/broken",
+        }),
+      );
+    },
+  );
+
+  test("discovers nested packages deterministically while ignoring generated and hidden trees", async () => {
+    const rootPath = await harness.createRoot();
+    const safeRoots = [
+      path.join(rootPath, "plugins", "alpha"),
+      path.join(rootPath, "plugins", "zeta"),
+    ];
+    const ignoredRoots = [
+      path.join(rootPath, "node_modules", "ignored"),
+      path.join(rootPath, ".hidden", "ignored"),
+      path.join(rootPath, "dist", "ignored"),
+      path.join(rootPath, "cache", "ignored"),
+    ];
+    for (const pluginRoot of [...safeRoots, ...ignoredRoots]) {
+      await fs.mkdir(pluginRoot, { recursive: true });
+      await harness.writePlugin(pluginRoot, path.basename(pluginRoot));
+    }
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.displayPath)).toEqual(
+      ["workspace/plugins/alpha", "workspace/plugins/zeta"],
+    );
+  });
+
+  test("reports a malformed sibling without hiding a safe candidate", async () => {
+    const rootPath = await harness.createRoot();
+    const brokenRoot = path.join(rootPath, "plugins", "broken");
+    const safeRoot = path.join(rootPath, "plugins", "safe");
+    await fs.mkdir(brokenRoot, { recursive: true });
+    await fs.mkdir(safeRoot, { recursive: true });
+    await fs.writeFile(path.join(brokenRoot, "package.json"), "{not-json");
+    await harness.writePlugin(safeRoot, "safe");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "safe",
+    ]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "manifest-invalid",
+        rootKey: WORKSPACE_ROOT_KEY,
+        displayPath: "workspace/plugins/broken",
+      }),
+    ]);
+    expect(result.diagnostics[0]?.detail.length).toBeLessThanOrEqual(8192);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(rootPath);
+  });
+
+  test("rejects an oversized manifest without hiding a safe candidate", async () => {
+    const rootPath = await harness.createRoot();
+    const oversizedRoot = path.join(rootPath, "plugins", "oversized");
+    const safeRoot = path.join(rootPath, "plugins", "safe");
+    await fs.mkdir(oversizedRoot, { recursive: true });
+    await fs.mkdir(safeRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(oversizedRoot, "package.json"),
+      Buffer.alloc(256 * 1024 + 1, 0x20),
+    );
+    await harness.writePlugin(safeRoot, "safe");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "safe",
+    ]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "manifest-too-large",
+        displayPath: "workspace/plugins/oversized",
+      }),
+    ]);
+  });
+
+  test("never follows a package.json symlink", async () => {
+    const rootPath = await harness.createRoot();
+    const candidateRoot = path.join(rootPath, "plugins", "linked-manifest");
+    await fs.mkdir(candidateRoot, { recursive: true });
+    const outsideManifest = path.join(path.dirname(rootPath), "outside.json");
+    await fs.writeFile(
+      outsideManifest,
+      JSON.stringify({
+        name: "bb-plugin-outside",
+        version: "1.0.0",
+        bb: { name: "outside", server: "./server.ts" },
+      }),
+    );
+    await fs.symlink(outsideManifest, path.join(candidateRoot, "package.json"));
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "manifest-symlink",
+        displayPath: "workspace/plugins/linked-manifest",
+      }),
+    ]);
+  });
+
+  test("never executes plugin entrypoints or package scripts", async () => {
+    const rootPath = await harness.createRoot();
+    const sentinel = path.join(path.dirname(rootPath), "executed.txt");
+    await fs.writeFile(
+      path.join(rootPath, "server.ts"),
+      `await Bun.write(${JSON.stringify(sentinel)}, "entrypoint");\n`,
+    );
+    await fs.writeFile(
+      path.join(rootPath, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-passive",
+        version: "1.0.0",
+        scripts: {
+          preinstall: `printf package-script > ${JSON.stringify(sentinel)}`,
+          postinstall: `printf package-script > ${JSON.stringify(sentinel)}`,
+        },
+        bb: { name: "passive", server: "./server.ts" },
+      }),
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "passive",
+    ]);
+    expect(await fs.readFile(sentinel, "utf8").catch(() => null)).toBeNull();
+  });
+});

--- a/packages/inspection/src/discover-source-candidates.ts
+++ b/packages/inspection/src/discover-source-candidates.ts
@@ -1,0 +1,251 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type {
+  DiscoveryDiagnostic,
+  SourceCandidate,
+  SourceDiscoveryResult,
+  TrustedRoot,
+} from "./discovery-types.ts";
+import {
+  boundedDiagnosticDetail,
+  DiscoveryFailure,
+} from "./discovery-errors.ts";
+import { candidateAtRoot } from "./discovery-manifest.ts";
+import {
+  attestScanDirectory,
+  displayPathFor,
+  type ScanDirectoryAttestation,
+} from "./discovery-path-safety.ts";
+import { runDiscoveryTestHook } from "./discovery-test-hook.ts";
+import { trustedRootDetails } from "./trusted-roots.ts";
+
+const MAX_SCAN_DEPTH = 4;
+const MAX_VISITED_ENTRIES = 2048;
+const MAX_CANDIDATES = 128;
+
+interface PendingDirectory {
+  readonly directory: string;
+  readonly relative: string;
+  readonly depth: number;
+}
+
+export async function discoverSourceCandidates(
+  roots: readonly TrustedRoot[],
+): Promise<SourceDiscoveryResult> {
+  const candidates: SourceCandidate[] = [];
+  const diagnostics: DiscoveryDiagnostic[] = [];
+  const budget = { visitedEntries: 0, entryLimitReported: false };
+  let candidateLimitReported = false;
+
+  for (const root of roots) {
+    const { canonicalRoot } = trustedRootDetails(root);
+    const queue: PendingDirectory[] = [
+      { directory: canonicalRoot, relative: "", depth: 0 },
+    ];
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current) break;
+      const attestation = await attestDirectoryOrReport(
+        root,
+        current,
+        canonicalRoot,
+        diagnostics,
+      );
+      if (!attestation) continue;
+      const candidate = await inspectDirectory(root, current, diagnostics);
+      const stableAfterManifest = await attestDirectoryOrReport(
+        root,
+        current,
+        canonicalRoot,
+        diagnostics,
+        attestation,
+      );
+      if (!stableAfterManifest) continue;
+      const stableAfterRead = await enqueueChildren(
+        root,
+        current,
+        queue,
+        diagnostics,
+        budget,
+        canonicalRoot,
+        stableAfterManifest,
+      );
+      if (!stableAfterRead) continue;
+      if (candidate && candidates.length < MAX_CANDIDATES) {
+        candidates.push(candidate);
+      } else if (candidate && !candidateLimitReported) {
+        diagnostics.push(
+          diagnostic(
+            "candidate-limit",
+            root,
+            candidate.displayPath,
+            `Source candidate ${candidate.displayPath} exceeds the ${MAX_CANDIDATES}-candidate limit.`,
+          ),
+        );
+        candidateLimitReported = true;
+      }
+    }
+  }
+
+  candidates.sort((left, right) =>
+    left.canonicalRoot.localeCompare(right.canonicalRoot),
+  );
+  return {
+    candidates: Object.freeze(candidates),
+    diagnostics: Object.freeze(diagnostics),
+  };
+}
+
+async function inspectDirectory(
+  root: TrustedRoot,
+  current: PendingDirectory,
+  diagnostics: DiscoveryDiagnostic[],
+): Promise<SourceCandidate | null> {
+  try {
+    return await candidateAtRoot(root, current.directory, current.relative);
+  } catch (error) {
+    const displayPath = displayPathFor(root, current.relative);
+    const reason =
+      error instanceof SyntaxError
+        ? error.message
+        : "declared manifest fields could not be validated";
+    diagnostics.push(
+      diagnostic(
+        error instanceof DiscoveryFailure ? error.code : "manifest-invalid",
+        root,
+        displayPath,
+        `Manifest at ${displayPath} is invalid: ${reason}`,
+      ),
+    );
+    return null;
+  }
+}
+
+async function enqueueChildren(
+  root: TrustedRoot,
+  current: PendingDirectory,
+  queue: PendingDirectory[],
+  diagnostics: DiscoveryDiagnostic[],
+  budget: { visitedEntries: number; entryLimitReported: boolean },
+  canonicalRoot: string,
+  attestation: ScanDirectoryAttestation,
+): Promise<boolean> {
+  const entries = await fs
+    .readdir(current.directory, { withFileTypes: true })
+    .catch(() => []);
+  await runDiscoveryTestHook({
+    point: "after-directory-read",
+    path: current.directory,
+  });
+  const stable = await attestDirectoryOrReport(
+    root,
+    current,
+    canonicalRoot,
+    diagnostics,
+    attestation,
+  );
+  if (!stable) return false;
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    if (budget.visitedEntries >= MAX_VISITED_ENTRIES) {
+      if (!budget.entryLimitReported) {
+        const displayPath = displayPathFor(root, current.relative);
+        diagnostics.push(
+          diagnostic(
+            "scan-entry-limit",
+            root,
+            displayPath,
+            `Source scan at ${displayPath} reached the ${MAX_VISITED_ENTRIES}-entry limit.`,
+          ),
+        );
+        budget.entryLimitReported = true;
+      }
+      break;
+    }
+    budget.visitedEntries += 1;
+    const relative = path.join(current.relative, entry.name);
+    if (entry.isSymbolicLink()) {
+      if (entry.name !== "package.json") {
+        const displayPath = displayPathFor(root, relative);
+        diagnostics.push(
+          diagnostic(
+            "path-symlink",
+            root,
+            displayPath,
+            `Source path ${displayPath} is a symlink and was skipped.`,
+          ),
+        );
+      }
+      continue;
+    }
+    if (!entry.isDirectory() || shouldIgnoreDirectory(entry.name)) continue;
+    if (current.depth >= MAX_SCAN_DEPTH) {
+      const displayPath = displayPathFor(root, relative);
+      diagnostics.push(
+        diagnostic(
+          "scan-depth-limit",
+          root,
+          displayPath,
+          `Source path ${displayPath} exceeds the depth-${MAX_SCAN_DEPTH} scan limit.`,
+        ),
+      );
+      continue;
+    }
+    queue.push({
+      directory: path.join(current.directory, entry.name),
+      relative,
+      depth: current.depth + 1,
+    });
+  }
+  return true;
+}
+
+async function attestDirectoryOrReport(
+  root: TrustedRoot,
+  current: PendingDirectory,
+  canonicalRoot: string,
+  diagnostics: DiscoveryDiagnostic[],
+  expected?: ScanDirectoryAttestation,
+): Promise<ScanDirectoryAttestation | null> {
+  try {
+    return await attestScanDirectory(
+      current.directory,
+      canonicalRoot,
+      expected,
+    );
+  } catch (error) {
+    const displayPath = displayPathFor(root, current.relative);
+    diagnostics.push(
+      diagnostic(
+        error instanceof DiscoveryFailure
+          ? error.code
+          : "scan-directory-changed",
+        root,
+        displayPath,
+        `Source directory ${displayPath} could not be scanned safely.`,
+      ),
+    );
+    return null;
+  }
+}
+
+function diagnostic(
+  code: string,
+  root: TrustedRoot,
+  displayPath: string,
+  detail: string,
+): DiscoveryDiagnostic {
+  return {
+    code,
+    rootKey: root.rootKey,
+    displayPath,
+    detail: boundedDiagnosticDetail(detail),
+  };
+}
+
+function shouldIgnoreDirectory(name: string): boolean {
+  return (
+    name.startsWith(".") ||
+    ["node_modules", "dist", "cache", "caches"].includes(name)
+  );
+}

--- a/packages/inspection/src/discover-source-candidates.ts
+++ b/packages/inspection/src/discover-source-candidates.ts
@@ -1,101 +1,49 @@
 import { promises as fs } from "node:fs";
-import path from "node:path";
+import type { Dirent } from "node:fs";
 import type {
   DiscoveryDiagnostic,
   SourceCandidate,
   SourceDiscoveryResult,
   TrustedRoot,
 } from "./discovery-types.ts";
-import {
-  boundedDiagnosticDetail,
-  DiscoveryFailure,
-} from "./discovery-errors.ts";
-import {
-  allocateDiscoveryRootBudgets,
-  type DiscoveryRootBudget,
-} from "./discovery-budget.ts";
+import { discoveryDiagnostic } from "./discovery-diagnostic.ts";
+import { DiscoveryFailure } from "./discovery-errors.ts";
 import { candidateAtRoot } from "./discovery-manifest.ts";
 import {
   attestScanDirectory,
   displayPathFor,
   type ScanDirectoryAttestation,
 } from "./discovery-path-safety.ts";
+import {
+  consumeEntries,
+  createRootScanStates,
+  type PendingDirectory,
+  recordCandidate,
+  redistributeUnusedCandidateCapacity,
+  redistributeUnusedEntryCapacity,
+  reportTrueLimits,
+  type RootScanState,
+} from "./discovery-scan-state.ts";
 import { runDiscoveryTestHook } from "./discovery-test-hook.ts";
-import { trustedRootDetails } from "./trusted-roots.ts";
-
-const MAX_SCAN_DEPTH = 4;
-const MAX_VISITED_ENTRIES = 2048;
-const MAX_CANDIDATES = 128;
-
-interface PendingDirectory {
-  readonly directory: string;
-  readonly relative: string;
-  readonly depth: number;
-}
 
 export async function discoverSourceCandidates(
   roots: readonly TrustedRoot[],
 ): Promise<SourceDiscoveryResult> {
   const candidates: SourceCandidate[] = [];
   const diagnostics: DiscoveryDiagnostic[] = [];
-  const rootBudgets = allocateDiscoveryRootBudgets(
-    roots.length,
-    MAX_VISITED_ENTRIES,
-    MAX_CANDIDATES,
-  );
+  const states = createRootScanStates(roots);
 
-  for (const [rootIndex, root] of roots.entries()) {
-    const budget = rootBudgets[rootIndex];
-    if (!budget) continue;
-    const { canonicalRoot } = trustedRootDetails(root);
-    const queue: PendingDirectory[] = [
-      { directory: canonicalRoot, relative: "", depth: 0 },
-    ];
-    while (queue.length > 0) {
-      const current = queue.shift();
-      if (!current) break;
-      const attestation = await attestDirectoryOrReport(
-        root,
-        current,
-        canonicalRoot,
-        diagnostics,
-      );
-      if (!attestation) continue;
-      const candidate = await inspectDirectory(root, current, diagnostics);
-      const stableAfterManifest = await attestDirectoryOrReport(
-        root,
-        current,
-        canonicalRoot,
-        diagnostics,
-        attestation,
-      );
-      if (!stableAfterManifest) continue;
-      const stableAfterRead = await enqueueChildren(
-        root,
-        current,
-        queue,
-        diagnostics,
-        budget,
-        canonicalRoot,
-        stableAfterManifest,
-      );
-      if (!stableAfterRead) continue;
-      if (candidate && budget.acceptedCandidates < budget.maxCandidates) {
-        candidates.push(candidate);
-        budget.acceptedCandidates += 1;
-      } else if (candidate && !budget.candidateLimitReported) {
-        diagnostics.push(
-          diagnostic(
-            "candidate-limit",
-            root,
-            candidate.displayPath,
-            `Source candidate ${candidate.displayPath} exceeds its ${budget.maxCandidates}-candidate share of the global ${MAX_CANDIDATES}-candidate limit.`,
-          ),
-        );
-        budget.candidateLimitReported = true;
-      }
-    }
+  for (const state of states) {
+    await scanAvailable(state, candidates, diagnostics);
   }
+  await redistributeUnusedEntryCapacity(
+    states,
+    candidates,
+    diagnostics,
+    scanAvailable,
+  );
+  redistributeUnusedCandidateCapacity(states, candidates);
+  reportTrueLimits(states, candidates.length, diagnostics);
 
   candidates.sort((left, right) =>
     left.canonicalRoot.localeCompare(right.canonicalRoot),
@@ -104,6 +52,131 @@ export async function discoverSourceCandidates(
     candidates: Object.freeze(candidates),
     diagnostics: Object.freeze(diagnostics),
   };
+}
+
+async function scanAvailable(
+  state: RootScanState,
+  candidates: SourceCandidate[],
+  diagnostics: DiscoveryDiagnostic[],
+): Promise<void> {
+  while (true) {
+    while (state.queue.length > 0) {
+      const current = state.queue.shift();
+      if (!current) break;
+      await inspectPendingDirectory(state, current, candidates, diagnostics);
+    }
+    if (state.budget.visitedEntries >= state.budget.maxVisitedEntries) return;
+    const continuation = state.continuations.shift();
+    if (!continuation) return;
+    if (continuation.kind === "entries") {
+      consumeEntries(
+        state,
+        continuation.current,
+        continuation.entries,
+        diagnostics,
+      );
+      continue;
+    }
+    const entries = await readDirectoryEntries(
+      state,
+      continuation.current,
+      diagnostics,
+      continuation.attestation,
+    );
+    if (entries) {
+      consumeEntries(state, continuation.current, entries, diagnostics);
+    }
+  }
+}
+
+async function inspectPendingDirectory(
+  state: RootScanState,
+  current: PendingDirectory,
+  candidates: SourceCandidate[],
+  diagnostics: DiscoveryDiagnostic[],
+): Promise<void> {
+  const attestation = await attestDirectoryOrReport(
+    state,
+    current,
+    diagnostics,
+  );
+  if (!attestation) return;
+  const candidate = await inspectDirectory(state.root, current, diagnostics);
+  const stable = await attestDirectoryOrReport(
+    state,
+    current,
+    diagnostics,
+    attestation,
+  );
+  if (!stable) return;
+
+  if (state.budget.visitedEntries < state.budget.maxVisitedEntries) {
+    const entries = await readDirectoryEntries(
+      state,
+      current,
+      diagnostics,
+      stable,
+    );
+    if (!entries) return;
+    consumeEntries(state, current, entries, diagnostics);
+  } else {
+    state.continuations.push({
+      kind: "children",
+      current,
+      attestation: stable,
+    });
+    state.entryLimitDisplayPath ??= displayPathFor(
+      state.root,
+      current.relative,
+    );
+  }
+  if (candidate) recordCandidate(state, candidate, candidates);
+}
+
+async function readDirectoryEntries(
+  state: RootScanState,
+  current: PendingDirectory,
+  diagnostics: DiscoveryDiagnostic[],
+  expected: ScanDirectoryAttestation,
+): Promise<Dirent[] | null> {
+  const stableBefore = await attestDirectoryOrReport(
+    state,
+    current,
+    diagnostics,
+    expected,
+  );
+  if (!stableBefore) return null;
+  let entries: Dirent[];
+  try {
+    await runDiscoveryTestHook({
+      point: "before-directory-read",
+      path: current.directory,
+    });
+    entries = await fs.readdir(current.directory, { withFileTypes: true });
+  } catch {
+    const displayPath = displayPathFor(state.root, current.relative);
+    diagnostics.push(
+      discoveryDiagnostic(
+        "scan-directory-unreadable",
+        state.root,
+        displayPath,
+        `Source directory ${displayPath} could not be read.`,
+      ),
+    );
+    return null;
+  }
+  await runDiscoveryTestHook({
+    point: "after-directory-read",
+    path: current.directory,
+  });
+  const stableAfter = await attestDirectoryOrReport(
+    state,
+    current,
+    diagnostics,
+    stableBefore,
+  );
+  if (!stableAfter) return null;
+  return entries.sort((left, right) => left.name.localeCompare(right.name));
 }
 
 async function inspectDirectory(
@@ -120,7 +193,7 @@ async function inspectDirectory(
         ? error.message
         : "declared manifest fields could not be validated";
     diagnostics.push(
-      diagnostic(
+      discoveryDiagnostic(
         error instanceof DiscoveryFailure ? error.code : "manifest-invalid",
         root,
         displayPath,
@@ -131,147 +204,30 @@ async function inspectDirectory(
   }
 }
 
-async function enqueueChildren(
-  root: TrustedRoot,
-  current: PendingDirectory,
-  queue: PendingDirectory[],
-  diagnostics: DiscoveryDiagnostic[],
-  budget: DiscoveryRootBudget,
-  canonicalRoot: string,
-  attestation: ScanDirectoryAttestation,
-): Promise<boolean> {
-  let entries;
-  try {
-    await runDiscoveryTestHook({
-      point: "before-directory-read",
-      path: current.directory,
-    });
-    entries = await fs.readdir(current.directory, { withFileTypes: true });
-  } catch {
-    const displayPath = displayPathFor(root, current.relative);
-    diagnostics.push(
-      diagnostic(
-        "scan-directory-unreadable",
-        root,
-        displayPath,
-        `Source directory ${displayPath} could not be read.`,
-      ),
-    );
-    return false;
-  }
-  await runDiscoveryTestHook({
-    point: "after-directory-read",
-    path: current.directory,
-  });
-  const stable = await attestDirectoryOrReport(
-    root,
-    current,
-    canonicalRoot,
-    diagnostics,
-    attestation,
-  );
-  if (!stable) return false;
-  entries.sort((left, right) => left.name.localeCompare(right.name));
-  for (const entry of entries) {
-    if (budget.visitedEntries >= budget.maxVisitedEntries) {
-      if (!budget.entryLimitReported) {
-        const displayPath = displayPathFor(root, current.relative);
-        diagnostics.push(
-          diagnostic(
-            "scan-entry-limit",
-            root,
-            displayPath,
-            `Source scan at ${displayPath} reached its ${budget.maxVisitedEntries}-entry share of the global ${MAX_VISITED_ENTRIES}-entry limit.`,
-          ),
-        );
-        budget.entryLimitReported = true;
-      }
-      break;
-    }
-    budget.visitedEntries += 1;
-    const relative = path.join(current.relative, entry.name);
-    if (entry.isSymbolicLink()) {
-      if (entry.name !== "package.json") {
-        const displayPath = displayPathFor(root, relative);
-        diagnostics.push(
-          diagnostic(
-            "path-symlink",
-            root,
-            displayPath,
-            `Source path ${displayPath} is a symlink and was skipped.`,
-          ),
-        );
-      }
-      continue;
-    }
-    if (!entry.isDirectory() || shouldIgnoreDirectory(entry.name)) continue;
-    if (current.depth >= MAX_SCAN_DEPTH) {
-      const displayPath = displayPathFor(root, relative);
-      diagnostics.push(
-        diagnostic(
-          "scan-depth-limit",
-          root,
-          displayPath,
-          `Source path ${displayPath} exceeds the depth-${MAX_SCAN_DEPTH} scan limit.`,
-        ),
-      );
-      continue;
-    }
-    queue.push({
-      directory: path.join(current.directory, entry.name),
-      relative,
-      depth: current.depth + 1,
-    });
-  }
-  return true;
-}
-
 async function attestDirectoryOrReport(
-  root: TrustedRoot,
+  state: RootScanState,
   current: PendingDirectory,
-  canonicalRoot: string,
   diagnostics: DiscoveryDiagnostic[],
   expected?: ScanDirectoryAttestation,
 ): Promise<ScanDirectoryAttestation | null> {
   try {
     return await attestScanDirectory(
       current.directory,
-      canonicalRoot,
+      state.canonicalRoot,
       expected,
     );
   } catch (error) {
-    const displayPath = displayPathFor(root, current.relative);
+    const displayPath = displayPathFor(state.root, current.relative);
     diagnostics.push(
-      diagnostic(
+      discoveryDiagnostic(
         error instanceof DiscoveryFailure
           ? error.code
           : "scan-directory-changed",
-        root,
+        state.root,
         displayPath,
         `Source directory ${displayPath} could not be scanned safely.`,
       ),
     );
     return null;
   }
-}
-
-function diagnostic(
-  code: string,
-  root: TrustedRoot,
-  displayPath: string,
-  detail: string,
-): DiscoveryDiagnostic {
-  return {
-    code,
-    rootKey: root.rootKey,
-    displayPath,
-    detail: boundedDiagnosticDetail(detail),
-  };
-}
-
-function shouldIgnoreDirectory(name: string): boolean {
-  return (
-    name.startsWith(".") ||
-    ["node_modules", "dist", "cache", "caches"].includes(name)
-  );
 }

--- a/packages/inspection/src/discover-source-candidates.ts
+++ b/packages/inspection/src/discover-source-candidates.ts
@@ -10,6 +10,10 @@ import {
   boundedDiagnosticDetail,
   DiscoveryFailure,
 } from "./discovery-errors.ts";
+import {
+  allocateDiscoveryRootBudgets,
+  type DiscoveryRootBudget,
+} from "./discovery-budget.ts";
 import { candidateAtRoot } from "./discovery-manifest.ts";
 import {
   attestScanDirectory,
@@ -34,10 +38,15 @@ export async function discoverSourceCandidates(
 ): Promise<SourceDiscoveryResult> {
   const candidates: SourceCandidate[] = [];
   const diagnostics: DiscoveryDiagnostic[] = [];
-  const budget = { visitedEntries: 0, entryLimitReported: false };
-  let candidateLimitReported = false;
+  const rootBudgets = allocateDiscoveryRootBudgets(
+    roots.length,
+    MAX_VISITED_ENTRIES,
+    MAX_CANDIDATES,
+  );
 
-  for (const root of roots) {
+  for (const [rootIndex, root] of roots.entries()) {
+    const budget = rootBudgets[rootIndex];
+    if (!budget) continue;
     const { canonicalRoot } = trustedRootDetails(root);
     const queue: PendingDirectory[] = [
       { directory: canonicalRoot, relative: "", depth: 0 },
@@ -71,18 +80,19 @@ export async function discoverSourceCandidates(
         stableAfterManifest,
       );
       if (!stableAfterRead) continue;
-      if (candidate && candidates.length < MAX_CANDIDATES) {
+      if (candidate && budget.acceptedCandidates < budget.maxCandidates) {
         candidates.push(candidate);
-      } else if (candidate && !candidateLimitReported) {
+        budget.acceptedCandidates += 1;
+      } else if (candidate && !budget.candidateLimitReported) {
         diagnostics.push(
           diagnostic(
             "candidate-limit",
             root,
             candidate.displayPath,
-            `Source candidate ${candidate.displayPath} exceeds the ${MAX_CANDIDATES}-candidate limit.`,
+            `Source candidate ${candidate.displayPath} exceeds its ${budget.maxCandidates}-candidate share of the global ${MAX_CANDIDATES}-candidate limit.`,
           ),
         );
-        candidateLimitReported = true;
+        budget.candidateLimitReported = true;
       }
     }
   }
@@ -126,13 +136,29 @@ async function enqueueChildren(
   current: PendingDirectory,
   queue: PendingDirectory[],
   diagnostics: DiscoveryDiagnostic[],
-  budget: { visitedEntries: number; entryLimitReported: boolean },
+  budget: DiscoveryRootBudget,
   canonicalRoot: string,
   attestation: ScanDirectoryAttestation,
 ): Promise<boolean> {
-  const entries = await fs
-    .readdir(current.directory, { withFileTypes: true })
-    .catch(() => []);
+  let entries;
+  try {
+    await runDiscoveryTestHook({
+      point: "before-directory-read",
+      path: current.directory,
+    });
+    entries = await fs.readdir(current.directory, { withFileTypes: true });
+  } catch {
+    const displayPath = displayPathFor(root, current.relative);
+    diagnostics.push(
+      diagnostic(
+        "scan-directory-unreadable",
+        root,
+        displayPath,
+        `Source directory ${displayPath} could not be read.`,
+      ),
+    );
+    return false;
+  }
   await runDiscoveryTestHook({
     point: "after-directory-read",
     path: current.directory,
@@ -147,7 +173,7 @@ async function enqueueChildren(
   if (!stable) return false;
   entries.sort((left, right) => left.name.localeCompare(right.name));
   for (const entry of entries) {
-    if (budget.visitedEntries >= MAX_VISITED_ENTRIES) {
+    if (budget.visitedEntries >= budget.maxVisitedEntries) {
       if (!budget.entryLimitReported) {
         const displayPath = displayPathFor(root, current.relative);
         diagnostics.push(
@@ -155,7 +181,7 @@ async function enqueueChildren(
             "scan-entry-limit",
             root,
             displayPath,
-            `Source scan at ${displayPath} reached the ${MAX_VISITED_ENTRIES}-entry limit.`,
+            `Source scan at ${displayPath} reached its ${budget.maxVisitedEntries}-entry share of the global ${MAX_VISITED_ENTRIES}-entry limit.`,
           ),
         );
         budget.entryLimitReported = true;

--- a/packages/inspection/src/discovery-asset-reader.ts
+++ b/packages/inspection/src/discovery-asset-reader.ts
@@ -1,0 +1,87 @@
+import { constants, promises as fs } from "node:fs";
+import { DiscoveryFailure } from "./discovery-errors.ts";
+
+const MAX_PLUGIN_ICON_BYTES = 256 * 1024;
+
+/** Read a plugin-owned icon without following or racing its filesystem leaf. */
+export async function readBoundedPluginIcon(
+  iconPath: string,
+): Promise<Uint8Array> {
+  const leaf = await fs.lstat(iconPath).catch(() => null);
+  if (!leaf || !leaf.isFile()) {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      "plugin-owned icon must be a regular file",
+    );
+  }
+  if (leaf.isSymbolicLink()) {
+    throw new DiscoveryFailure(
+      "manifest-path-symlink",
+      "plugin-owned icon must not be a symlink",
+    );
+  }
+  if (leaf.size > MAX_PLUGIN_ICON_BYTES) throw tooLarge();
+
+  let handle;
+  try {
+    handle = await fs.open(iconPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      "plugin-owned icon is unreadable",
+    );
+  }
+  try {
+    const before = await handle.stat();
+    if (!sameIdentity(leaf, before)) throw changed();
+    const buffer = Buffer.allocUnsafe(MAX_PLUGIN_ICON_BYTES + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.byteLength) {
+      const result = await handle.read(
+        buffer,
+        bytesRead,
+        buffer.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+    }
+    if (bytesRead > MAX_PLUGIN_ICON_BYTES) throw tooLarge();
+    const [after, leafAfter] = await Promise.all([
+      handle.stat(),
+      fs.lstat(iconPath).catch(() => null),
+    ]);
+    if (
+      !sameIdentity(before, after) ||
+      leafAfter === null ||
+      !sameIdentity(after, leafAfter) ||
+      after.size !== bytesRead
+    ) {
+      throw changed();
+    }
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+function sameIdentity(
+  left: { dev: number; ino: number },
+  right: { dev: number; ino: number },
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function tooLarge(): DiscoveryFailure {
+  return new DiscoveryFailure(
+    "manifest-invalid",
+    `plugin-owned icon exceeds ${MAX_PLUGIN_ICON_BYTES} bytes`,
+  );
+}
+
+function changed(): DiscoveryFailure {
+  return new DiscoveryFailure(
+    "manifest-path-changed",
+    "plugin-owned icon changed while it was read",
+  );
+}

--- a/packages/inspection/src/discovery-budget.ts
+++ b/packages/inspection/src/discovery-budget.ts
@@ -6,9 +6,9 @@ export interface DiscoveryRootBudget {
 }
 
 /**
- * Partition each global bound across admitted roots so an earlier noisy root
- * cannot consume the share needed to inspect an independent later root.
- * Unused shares stay unused; borrowing would make the result order-dependent.
+ * Reserve a deterministic first-pass share for every admitted root so an
+ * earlier noisy root cannot starve a later root. The scan coordinator may
+ * redistribute unused capacity only after every root receives that share.
  */
 export function allocateDiscoveryRootBudgets(
   rootCount: number,

--- a/packages/inspection/src/discovery-budget.ts
+++ b/packages/inspection/src/discovery-budget.ts
@@ -1,10 +1,8 @@
 export interface DiscoveryRootBudget {
-  readonly maxVisitedEntries: number;
+  maxVisitedEntries: number;
   readonly maxCandidates: number;
   visitedEntries: number;
   acceptedCandidates: number;
-  entryLimitReported: boolean;
-  candidateLimitReported: boolean;
 }
 
 /**
@@ -17,19 +15,17 @@ export function allocateDiscoveryRootBudgets(
   maxVisitedEntries: number,
   maxCandidates: number,
 ): DiscoveryRootBudget[] {
-  const entryShares = fairShares(maxVisitedEntries, rootCount);
-  const candidateShares = fairShares(maxCandidates, rootCount);
+  const entryShares = allocateFairShares(maxVisitedEntries, rootCount);
+  const candidateShares = allocateFairShares(maxCandidates, rootCount);
   return entryShares.map((maxEntries, index) => ({
     maxVisitedEntries: maxEntries,
     maxCandidates: candidateShares[index] ?? 0,
     visitedEntries: 0,
     acceptedCandidates: 0,
-    entryLimitReported: false,
-    candidateLimitReported: false,
   }));
 }
 
-function fairShares(total: number, count: number): number[] {
+export function allocateFairShares(total: number, count: number): number[] {
   if (count <= 0) return [];
   const base = Math.floor(total / count);
   const remainder = total % count;

--- a/packages/inspection/src/discovery-budget.ts
+++ b/packages/inspection/src/discovery-budget.ts
@@ -1,0 +1,40 @@
+export interface DiscoveryRootBudget {
+  readonly maxVisitedEntries: number;
+  readonly maxCandidates: number;
+  visitedEntries: number;
+  acceptedCandidates: number;
+  entryLimitReported: boolean;
+  candidateLimitReported: boolean;
+}
+
+/**
+ * Partition each global bound across admitted roots so an earlier noisy root
+ * cannot consume the share needed to inspect an independent later root.
+ * Unused shares stay unused; borrowing would make the result order-dependent.
+ */
+export function allocateDiscoveryRootBudgets(
+  rootCount: number,
+  maxVisitedEntries: number,
+  maxCandidates: number,
+): DiscoveryRootBudget[] {
+  const entryShares = fairShares(maxVisitedEntries, rootCount);
+  const candidateShares = fairShares(maxCandidates, rootCount);
+  return entryShares.map((maxEntries, index) => ({
+    maxVisitedEntries: maxEntries,
+    maxCandidates: candidateShares[index] ?? 0,
+    visitedEntries: 0,
+    acceptedCandidates: 0,
+    entryLimitReported: false,
+    candidateLimitReported: false,
+  }));
+}
+
+function fairShares(total: number, count: number): number[] {
+  if (count <= 0) return [];
+  const base = Math.floor(total / count);
+  const remainder = total % count;
+  return Array.from(
+    { length: count },
+    (_, index) => base + (index < remainder ? 1 : 0),
+  );
+}

--- a/packages/inspection/src/discovery-diagnostic.ts
+++ b/packages/inspection/src/discovery-diagnostic.ts
@@ -1,0 +1,16 @@
+import type { DiscoveryDiagnostic, TrustedRoot } from "./discovery-types.ts";
+import { boundedDiagnosticDetail } from "./discovery-errors.ts";
+
+export function discoveryDiagnostic(
+  code: string,
+  root: TrustedRoot,
+  displayPath: string,
+  detail: string,
+): DiscoveryDiagnostic {
+  return {
+    code,
+    rootKey: root.rootKey,
+    displayPath,
+    detail: boundedDiagnosticDetail(detail),
+  };
+}

--- a/packages/inspection/src/discovery-directory-errors.test.ts
+++ b/packages/inspection/src/discovery-directory-errors.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import { installDiscoveryTestHookForTest } from "./discovery-test-hook.ts";
+import {
+  createDiscoveryTestHarness,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+describe("directory read diagnostics", () => {
+  test("reports an unreadable directory without hiding a safe sibling", async () => {
+    const rootPath = await harness.createRoot();
+    const unreadableRoot = path.join(rootPath, "unreadable");
+    const safeRoot = path.join(rootPath, "safe");
+    await fs.mkdir(unreadableRoot);
+    await fs.mkdir(safeRoot);
+    await harness.writePlugin(safeRoot, "safe");
+    const canonicalUnreadable = await fs.realpath(unreadableRoot);
+    const restore = installDiscoveryTestHookForTest((event) => {
+      if (
+        event.point === "before-directory-read" &&
+        event.path === canonicalUnreadable
+      ) {
+        throw new Error("sensitive host error");
+      }
+    });
+
+    try {
+      const admission = await admitTrustedRoots([
+        {
+          rootKey: WORKSPACE_ROOT_KEY,
+          kind: "current-project",
+          path: rootPath,
+        },
+      ]);
+      const result = await discoverSourceCandidates(admission.roots);
+
+      expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+        "safe",
+      ]);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: "scan-directory-unreadable",
+          displayPath: "workspace/unreadable",
+        }),
+      );
+      expect(JSON.stringify(result.diagnostics)).not.toContain(rootPath);
+      expect(JSON.stringify(result.diagnostics)).not.toContain(
+        "sensitive host error",
+      );
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/inspection/src/discovery-errors.ts
+++ b/packages/inspection/src/discovery-errors.ts
@@ -1,0 +1,14 @@
+export const MAX_DIAGNOSTIC_CHARACTERS = 8192;
+
+export class DiscoveryFailure extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export function boundedDiagnosticDetail(detail: string): string {
+  return detail.slice(0, MAX_DIAGNOSTIC_CHARACTERS);
+}

--- a/packages/inspection/src/discovery-limits.test.ts
+++ b/packages/inspection/src/discovery-limits.test.ts
@@ -144,6 +144,35 @@ describe("source discovery limits", () => {
     );
   });
 
+  test("borrows an unused entry share after every root receives its reservation", async () => {
+    const busyRoot = await harness.createRoot("busy");
+    const emptyRoot = await harness.createRoot("empty");
+    await Promise.all(
+      Array.from({ length: 1500 }, (_, index) =>
+        fs.writeFile(
+          path.join(busyRoot, `entry-${index.toString().padStart(4, "0")}`),
+          "",
+        ),
+      ),
+    );
+    const latePlugin = path.join(busyRoot, "z-late-plugin");
+    await fs.mkdir(latePlugin);
+    await harness.writePlugin(latePlugin, "late");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: busyRoot },
+      { rootKey: EXAMPLE_ROOT_KEY, kind: "explicit", path: emptyRoot },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "late",
+    ]);
+    expect(result.diagnostics).not.toContainEqual(
+      expect.objectContaining({ code: "scan-entry-limit" }),
+    );
+  });
+
   test("reserves the global candidate budget fairly across independent roots", async () => {
     const noisyRoot = await harness.createRoot("noisy");
     const safeRoot = await harness.createRoot("safe-root");
@@ -165,15 +194,39 @@ describe("source discovery limits", () => {
 
     const result = await discoverSourceCandidates(admission.roots);
 
-    expect(result.candidates).toHaveLength(65);
+    expect(result.candidates).toHaveLength(128);
     expect(result.candidates.map((candidate) => candidate.pluginId)).toContain(
       "safe",
     );
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({
         code: "candidate-limit",
-        displayPath: "noisy/plugin-064",
+        displayPath: "noisy/plugin-127",
       }),
+    );
+  });
+
+  test("borrows an unused candidate share after every root receives its reservation", async () => {
+    const busyRoot = await harness.createRoot("busy");
+    const emptyRoot = await harness.createRoot("empty");
+    for (let index = 0; index < 65; index += 1) {
+      const pluginRoot = path.join(
+        busyRoot,
+        `plugin-${index.toString().padStart(3, "0")}`,
+      );
+      await fs.mkdir(pluginRoot);
+      await harness.writePlugin(pluginRoot, `busy-${index}`);
+    }
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: busyRoot },
+      { rootKey: EXAMPLE_ROOT_KEY, kind: "explicit", path: emptyRoot },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toHaveLength(65);
+    expect(result.diagnostics).not.toContainEqual(
+      expect.objectContaining({ code: "candidate-limit" }),
     );
   });
 });

--- a/packages/inspection/src/discovery-limits.test.ts
+++ b/packages/inspection/src/discovery-limits.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import {
+  createDiscoveryTestHarness,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+describe("source discovery limits", () => {
+  test("bounds the redacted display path for runtime persistence", async () => {
+    const rootPath = await harness.createRoot();
+    const pluginRoot = path.join(rootPath, "plugin");
+    await fs.mkdir(pluginRoot);
+    await harness.writePlugin(pluginRoot, "plugin");
+    const admission = await admitTrustedRoots([
+      {
+        rootKey: WORKSPACE_ROOT_KEY,
+        kind: "current-project",
+        path: rootPath,
+        displayName: "r".repeat(255),
+      },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates[0]?.displayPath).toHaveLength(256);
+  });
+
+  test("stops at depth four with typed evidence while keeping the boundary candidate", async () => {
+    const rootPath = await harness.createRoot();
+    const boundaryRoot = path.join(rootPath, "a", "b", "c", "d");
+    const tooDeepRoot = path.join(boundaryRoot, "too-deep");
+    await fs.mkdir(tooDeepRoot, { recursive: true });
+    await harness.writePlugin(boundaryRoot, "boundary");
+    await harness.writePlugin(tooDeepRoot, "too-deep");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "boundary",
+    ]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "scan-depth-limit",
+        displayPath: "workspace/a/b/c/d/too-deep",
+      }),
+    );
+  });
+
+  test("bounds visited entries while preserving an earlier safe candidate", async () => {
+    const rootPath = await harness.createRoot();
+    const safeRoot = path.join(rootPath, "00-safe");
+    await fs.mkdir(safeRoot);
+    await harness.writePlugin(safeRoot, "safe");
+    await Promise.all(
+      Array.from({ length: 2048 }, (_, index) =>
+        fs.writeFile(
+          path.join(rootPath, `z-${index.toString().padStart(4, "0")}`),
+          "",
+        ),
+      ),
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "safe",
+    ]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "scan-entry-limit",
+        displayPath: "workspace",
+      }),
+    );
+  });
+
+  test("bounds discovered candidates at one hundred twenty-eight", async () => {
+    const rootPath = await harness.createRoot();
+    for (let index = 0; index < 129; index += 1) {
+      const pluginRoot = path.join(
+        rootPath,
+        `plugin-${index.toString().padStart(3, "0")}`,
+      );
+      await fs.mkdir(pluginRoot);
+      await harness.writePlugin(pluginRoot, `plugin-${index}`);
+    }
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toHaveLength(128);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "candidate-limit",
+        displayPath: "workspace/plugin-128",
+      }),
+    );
+  });
+});

--- a/packages/inspection/src/discovery-limits.test.ts
+++ b/packages/inspection/src/discovery-limits.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { discoverSourceCandidates } from "./discover-source-candidates.ts";
 import {
   createDiscoveryTestHarness,
+  EXAMPLE_ROOT_KEY,
   WORKSPACE_ROOT_KEY,
 } from "./discovery-test-helpers.ts";
 import { admitTrustedRoots } from "./trusted-roots.ts";
@@ -107,6 +108,71 @@ describe("source discovery limits", () => {
       expect.objectContaining({
         code: "candidate-limit",
         displayPath: "workspace/plugin-128",
+      }),
+    );
+  });
+
+  test("reserves the global entry budget fairly across independent roots", async () => {
+    const noisyRoot = await harness.createRoot("noisy");
+    const safeRoot = await harness.createRoot("safe-root");
+    const safePlugin = path.join(safeRoot, "plugin");
+    await fs.mkdir(safePlugin);
+    await harness.writePlugin(safePlugin, "safe");
+    await Promise.all(
+      Array.from({ length: 2048 }, (_, index) =>
+        fs.writeFile(
+          path.join(noisyRoot, `entry-${index.toString().padStart(4, "0")}`),
+          "",
+        ),
+      ),
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: noisyRoot },
+      { rootKey: EXAMPLE_ROOT_KEY, kind: "explicit", path: safeRoot },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toContain(
+      "safe",
+    );
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "scan-entry-limit",
+        displayPath: "noisy",
+      }),
+    );
+  });
+
+  test("reserves the global candidate budget fairly across independent roots", async () => {
+    const noisyRoot = await harness.createRoot("noisy");
+    const safeRoot = await harness.createRoot("safe-root");
+    for (let index = 0; index < 128; index += 1) {
+      const pluginRoot = path.join(
+        noisyRoot,
+        `plugin-${index.toString().padStart(3, "0")}`,
+      );
+      await fs.mkdir(pluginRoot);
+      await harness.writePlugin(pluginRoot, `noisy-${index}`);
+    }
+    const safePlugin = path.join(safeRoot, "plugin");
+    await fs.mkdir(safePlugin);
+    await harness.writePlugin(safePlugin, "safe");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: noisyRoot },
+      { rootKey: EXAMPLE_ROOT_KEY, kind: "explicit", path: safeRoot },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toHaveLength(65);
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toContain(
+      "safe",
+    );
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "candidate-limit",
+        displayPath: "noisy/plugin-064",
       }),
     );
   });

--- a/packages/inspection/src/discovery-manifest-contract.test.ts
+++ b/packages/inspection/src/discovery-manifest-contract.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import {
+  createDiscoveryTestHarness,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+const baseBb = {
+  name: "broken",
+  description: "broken plugin",
+  branding: { icon: "Puzzle" },
+  server: "./server.ts",
+};
+
+describe("released bb manifest contract", () => {
+  test.each([
+    ["missing description", { ...baseBb, description: undefined }],
+    ["missing branding", { ...baseBb, branding: undefined }],
+    ["empty branding", { ...baseBb, branding: {} }],
+    ["unknown bb key", { ...baseBb, surprise: true }],
+    ["logo without light", { ...baseBb, branding: { logo: { dark: "x" } } }],
+    [
+      "invalid theme structure",
+      { ...baseBb, themes: [{ id: "invalid id", name: "Theme", css: "x" }] },
+    ],
+    [
+      "duplicate theme ids",
+      {
+        ...baseBb,
+        themes: [
+          { id: "duplicate", name: "First", css: "./theme.css" },
+          { id: "duplicate", name: "Second", css: "./theme.css" },
+        ],
+      },
+    ],
+    [
+      "non-css theme asset",
+      {
+        ...baseBb,
+        themes: [{ id: "theme", name: "Theme", css: "./theme.txt" }],
+      },
+    ],
+    [
+      "unsupported light logo asset",
+      { ...baseBb, branding: { logo: { light: "./logo.txt" } } },
+    ],
+    [
+      "unsupported dark logo asset",
+      {
+        ...baseBb,
+        branding: {
+          logo: { light: "./logo.svg", dark: "./logo.txt" },
+        },
+      },
+    ],
+    [
+      "Windows-style relative non-SVG icon",
+      { ...baseBb, branding: { icon: ".\\icon.png" } },
+    ],
+  ])("rejects %s without hiding a valid sibling", async (_label, bb) => {
+    const rootPath = await harness.createRoot();
+    const brokenRoot = path.join(rootPath, "broken");
+    const safeRoot = path.join(rootPath, "safe");
+    await fs.mkdir(brokenRoot);
+    await fs.mkdir(safeRoot);
+    await fs.writeFile(
+      path.join(brokenRoot, "package.json"),
+      JSON.stringify({ name: "bb-plugin-broken", version: "1.0.0", bb }),
+    );
+    await fs.writeFile(path.join(brokenRoot, "server.ts"), "export {};\n");
+    for (const asset of [
+      "theme.css",
+      "theme.txt",
+      "logo.svg",
+      "logo.txt",
+      "icon.png",
+    ]) {
+      await fs.writeFile(path.join(brokenRoot, asset), "fixture\n");
+    }
+    await harness.writePlugin(safeRoot, "safe");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "safe",
+    ]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "manifest-invalid",
+        displayPath: "workspace/broken",
+      }),
+    );
+  });
+
+  test.each([
+    ["POSIX icon", { icon: "./icon.svg" }],
+    ["Windows-style icon", { icon: ".\\icon.svg" }],
+    [
+      "light and dark logos",
+      { logo: { light: "./logo.png", dark: "./logo.webp" } },
+    ],
+  ])("accepts supported %s asset declarations", async (_label, branding) => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    for (const asset of ["icon.svg", "logo.png", "logo.webp"]) {
+      await fs.writeFile(path.join(rootPath, asset), "fixture\n");
+    }
+    await fs.writeFile(
+      path.join(rootPath, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-valid-assets",
+        version: "1.0.0",
+        bb: { ...baseBb, branding },
+      }),
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "valid-assets",
+    ]);
+  });
+});

--- a/packages/inspection/src/discovery-manifest-contract.test.ts
+++ b/packages/inspection/src/discovery-manifest-contract.test.ts
@@ -112,7 +112,8 @@ describe("released bb manifest contract", () => {
   ])("accepts supported %s asset declarations", async (_label, branding) => {
     const rootPath = await harness.createRoot();
     await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
-    for (const asset of ["icon.svg", "logo.png", "logo.webp"]) {
+    await fs.writeFile(path.join(rootPath, "icon.svg"), "<svg />\n");
+    for (const asset of ["logo.png", "logo.webp"]) {
       await fs.writeFile(path.join(rootPath, asset), "fixture\n");
     }
     await fs.writeFile(
@@ -133,5 +134,66 @@ describe("released bb manifest contract", () => {
     expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
       "valid-assets",
     ]);
+  });
+
+  test("rejects an invalid engines shape without hiding a safe sibling", async () => {
+    const rootPath = await harness.createRoot();
+    const brokenRoot = path.join(rootPath, "broken");
+    const safeRoot = path.join(rootPath, "safe");
+    await fs.mkdir(brokenRoot);
+    await fs.mkdir(safeRoot);
+    await fs.writeFile(path.join(brokenRoot, "server.ts"), "export {};\n");
+    await fs.writeFile(
+      path.join(brokenRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-broken",
+        version: "1.0.0",
+        engines: "invalid",
+        bb: baseBb,
+      }),
+    );
+    await harness.writePlugin(safeRoot, "safe");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+      "safe",
+    ]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "manifest-invalid",
+        displayPath: "workspace/broken",
+      }),
+    );
+  });
+
+  test("rejects invalid bytes in a plugin-owned compact SVG", async () => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    await fs.writeFile(path.join(rootPath, "icon.svg"), "not an svg\n");
+    await fs.writeFile(
+      path.join(rootPath, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-invalid-icon",
+        version: "1.0.0",
+        bb: { ...baseBb, branding: { icon: "./icon.svg" } },
+      }),
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "manifest-invalid",
+        displayPath: "workspace",
+      }),
+    );
   });
 });

--- a/packages/inspection/src/discovery-manifest-contract.test.ts
+++ b/packages/inspection/src/discovery-manifest-contract.test.ts
@@ -60,10 +60,6 @@ describe("released bb manifest contract", () => {
         },
       },
     ],
-    [
-      "Windows-style relative non-SVG icon",
-      { ...baseBb, branding: { icon: ".\\icon.png" } },
-    ],
   ])("rejects %s without hiding a valid sibling", async (_label, bb) => {
     const rootPath = await harness.createRoot();
     const brokenRoot = path.join(rootPath, "broken");
@@ -104,7 +100,7 @@ describe("released bb manifest contract", () => {
 
   test.each([
     ["POSIX icon", { icon: "./icon.svg" }],
-    ["Windows-style icon", { icon: ".\\icon.svg" }],
+    ["Windows-style host icon name", { icon: ".\\missing.svg" }],
     [
       "light and dark logos",
       { logo: { light: "./logo.png", dark: "./logo.webp" } },

--- a/packages/inspection/src/discovery-manifest-races.test.ts
+++ b/packages/inspection/src/discovery-manifest-races.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import { installDiscoveryTestHookForTest } from "./discovery-test-hook.ts";
+import {
+  createDiscoveryTestHarness,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+describe("bounded manifest reads", () => {
+  test("bounds a manifest that grows after its initial stat and keeps a safe sibling", async () => {
+    const rootPath = await harness.createRoot();
+    const growingRoot = path.join(rootPath, "growing");
+    const safeRoot = path.join(rootPath, "safe");
+    await fs.mkdir(growingRoot);
+    await fs.mkdir(safeRoot);
+    await harness.writePlugin(growingRoot, "growing");
+    await harness.writePlugin(safeRoot, "safe");
+    const growingManifest = await fs.realpath(
+      path.join(growingRoot, "package.json"),
+    );
+    let grew = false;
+    const restore = installDiscoveryTestHookForTest(async (event) => {
+      if (
+        grew ||
+        event.point !== "after-manifest-stat" ||
+        event.path !== growingManifest
+      ) {
+        return;
+      }
+      grew = true;
+      await fs.appendFile(growingManifest, Buffer.alloc(1024 * 1024, 0x20));
+    });
+
+    try {
+      const admission = await admitTrustedRoots([
+        { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+      ]);
+      const result = await discoverSourceCandidates(admission.roots);
+
+      expect(grew).toBeTrue();
+      expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+        "safe",
+      ]);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: "manifest-too-large",
+          displayPath: "workspace/growing",
+        }),
+      );
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/inspection/src/discovery-manifest-reader.ts
+++ b/packages/inspection/src/discovery-manifest-reader.ts
@@ -1,5 +1,6 @@
 import { constants, promises as fs } from "node:fs";
 import { DiscoveryFailure } from "./discovery-errors.ts";
+import { runDiscoveryTestHook } from "./discovery-test-hook.ts";
 
 const MAX_MANIFEST_BYTES = 256 * 1024;
 
@@ -47,13 +48,29 @@ export async function readBoundedManifest(
         "package.json changed before it could be read",
       );
     }
-    const bytes = await handle.readFile();
-    if (bytes.byteLength > MAX_MANIFEST_BYTES) {
+    await runDiscoveryTestHook({
+      point: "after-manifest-stat",
+      path: packagePath,
+    });
+    const buffer = Buffer.allocUnsafe(MAX_MANIFEST_BYTES + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.byteLength) {
+      const result = await handle.read(
+        buffer,
+        bytesRead,
+        buffer.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+    }
+    if (bytesRead > MAX_MANIFEST_BYTES) {
       throw new DiscoveryFailure(
         "manifest-too-large",
         `package.json exceeds ${MAX_MANIFEST_BYTES} bytes`,
       );
     }
+    const bytes = buffer.subarray(0, bytesRead);
     const [after, leafAfter] = await Promise.all([
       handle.stat(),
       fs.lstat(packagePath).catch(() => null),
@@ -62,7 +79,7 @@ export async function readBoundedManifest(
       !sameIdentity(before, after) ||
       leafAfter === null ||
       !sameIdentity(after, leafAfter) ||
-      after.size !== bytes.byteLength
+      after.size !== bytesRead
     ) {
       throw new DiscoveryFailure(
         "manifest-changed",

--- a/packages/inspection/src/discovery-manifest-reader.ts
+++ b/packages/inspection/src/discovery-manifest-reader.ts
@@ -1,0 +1,92 @@
+import { constants, promises as fs } from "node:fs";
+import { DiscoveryFailure } from "./discovery-errors.ts";
+
+const MAX_MANIFEST_BYTES = 256 * 1024;
+
+export async function readBoundedManifest(
+  packagePath: string,
+): Promise<string | null> {
+  const leaf = await fs.lstat(packagePath).catch((error: unknown) => {
+    if (hasErrorCode(error, "ENOENT")) return null;
+    throw new DiscoveryFailure("manifest-unreadable", "manifest is unreadable");
+  });
+  if (leaf === null) return null;
+  if (leaf.isSymbolicLink()) {
+    throw new DiscoveryFailure(
+      "manifest-symlink",
+      "package.json must not be a symlink",
+    );
+  }
+  if (!leaf.isFile()) {
+    throw new DiscoveryFailure(
+      "manifest-not-file",
+      "package.json must be a regular file",
+    );
+  }
+  if (leaf.size > MAX_MANIFEST_BYTES) {
+    throw new DiscoveryFailure(
+      "manifest-too-large",
+      `package.json exceeds ${MAX_MANIFEST_BYTES} bytes`,
+    );
+  }
+
+  let handle;
+  try {
+    handle = await fs.open(
+      packagePath,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+  } catch {
+    throw new DiscoveryFailure("manifest-unreadable", "manifest is unreadable");
+  }
+  try {
+    const before = await handle.stat();
+    if (!sameIdentity(leaf, before)) {
+      throw new DiscoveryFailure(
+        "manifest-changed",
+        "package.json changed before it could be read",
+      );
+    }
+    const bytes = await handle.readFile();
+    if (bytes.byteLength > MAX_MANIFEST_BYTES) {
+      throw new DiscoveryFailure(
+        "manifest-too-large",
+        `package.json exceeds ${MAX_MANIFEST_BYTES} bytes`,
+      );
+    }
+    const [after, leafAfter] = await Promise.all([
+      handle.stat(),
+      fs.lstat(packagePath).catch(() => null),
+    ]);
+    if (
+      !sameIdentity(before, after) ||
+      leafAfter === null ||
+      !sameIdentity(after, leafAfter) ||
+      after.size !== bytes.byteLength
+    ) {
+      throw new DiscoveryFailure(
+        "manifest-changed",
+        "package.json changed while it was read",
+      );
+    }
+    return bytes.toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+function sameIdentity(
+  left: { dev: number; ino: number },
+  right: { dev: number; ino: number },
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}

--- a/packages/inspection/src/discovery-manifest-reader.ts
+++ b/packages/inspection/src/discovery-manifest-reader.ts
@@ -1,12 +1,26 @@
 import { constants, promises as fs } from "node:fs";
+import { createHash } from "node:crypto";
 import { DiscoveryFailure } from "./discovery-errors.ts";
 import { runDiscoveryTestHook } from "./discovery-test-hook.ts";
 
 const MAX_MANIFEST_BYTES = 256 * 1024;
 
+export interface BoundedManifestSnapshot {
+  readonly source: string;
+  readonly device: number;
+  readonly inode: number;
+  readonly sha256: string;
+}
+
 export async function readBoundedManifest(
   packagePath: string,
 ): Promise<string | null> {
+  return (await readBoundedManifestSnapshot(packagePath))?.source ?? null;
+}
+
+export async function readBoundedManifestSnapshot(
+  packagePath: string,
+): Promise<BoundedManifestSnapshot | null> {
   const leaf = await fs.lstat(packagePath).catch((error: unknown) => {
     if (hasErrorCode(error, "ENOENT")) return null;
     throw new DiscoveryFailure("manifest-unreadable", "manifest is unreadable");
@@ -86,7 +100,12 @@ export async function readBoundedManifest(
         "package.json changed while it was read",
       );
     }
-    return bytes.toString("utf8");
+    return {
+      source: bytes.toString("utf8"),
+      device: after.dev,
+      inode: after.ino,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+    };
   } finally {
     await handle.close();
   }

--- a/packages/inspection/src/discovery-manifest.ts
+++ b/packages/inspection/src/discovery-manifest.ts
@@ -26,6 +26,11 @@ export async function candidateAtRoot(
   if (!packageJson) throw invalid("package.json must contain an object");
   const bb = record(packageJson.bb);
   if (!bb) return null;
+  rejectUnknownKeys(
+    bb,
+    ["name", "description", "branding", "server", "app", "skills", "themes"],
+    "bb",
+  );
   const packageName = requiredString(
     packageJson.name,
     "name",
@@ -41,6 +46,7 @@ export async function candidateAtRoot(
     "bb.name",
     MAX_DISPLAY_NAME_CHARACTERS,
   );
+  requiredString(bb.description, "bb.description");
   await validateDeclaredPath(
     candidateRoot,
     requiredString(bb.server, "bb.server"),
@@ -99,31 +105,46 @@ async function validateBranding(
   candidateRoot: string,
   value: unknown,
 ): Promise<void> {
-  if (value === undefined) return;
   const branding = record(value);
   if (!branding) throw invalid("bb.branding must be an object");
-  if (branding.icon !== undefined) {
-    const icon = requiredString(branding.icon, "bb.branding.icon");
-    if (icon.startsWith("./") || icon.startsWith(".\\")) {
+  rejectUnknownKeys(branding, ["icon", "logo"], "bb.branding");
+  const icon =
+    branding.icon === undefined
+      ? undefined
+      : requiredString(branding.icon, "bb.branding.icon");
+  const logo = branding.logo === undefined ? null : record(branding.logo);
+  if (branding.logo !== undefined && !logo) {
+    throw invalid("bb.branding.logo must be an object");
+  }
+  if (icon === undefined && logo === null) {
+    throw invalid("bb.branding must declare an icon or light logo");
+  }
+  if (icon !== undefined && isPluginOwnedIconPath(icon)) {
+    if (!icon.toLowerCase().endsWith(".svg")) {
+      throw invalid("plugin-owned bb.branding.icon must be an SVG path");
+    }
+    await validateDeclaredPath(candidateRoot, icon, "bb.branding.icon", "file");
+  }
+  if (logo !== null) {
+    rejectUnknownKeys(logo, ["light", "dark"], "bb.branding.logo");
+    const light = requiredString(logo.light, "bb.branding.logo.light");
+    validateLogoExtension(light, "bb.branding.logo.light");
+    await validateDeclaredPath(
+      candidateRoot,
+      light,
+      "bb.branding.logo.light",
+      "file",
+    );
+    if (logo.dark !== undefined) {
+      const dark = requiredString(logo.dark, "bb.branding.logo.dark");
+      validateLogoExtension(dark, "bb.branding.logo.dark");
       await validateDeclaredPath(
         candidateRoot,
-        icon,
-        "bb.branding.icon",
+        dark,
+        "bb.branding.logo.dark",
         "file",
       );
     }
-  }
-  if (branding.logo === undefined) return;
-  const logo = record(branding.logo);
-  if (!logo) throw invalid("bb.branding.logo must be an object");
-  for (const variant of ["light", "dark"] as const) {
-    if (logo[variant] === undefined) continue;
-    await validateDeclaredPath(
-      candidateRoot,
-      requiredString(logo[variant], `bb.branding.logo.${variant}`),
-      `bb.branding.logo.${variant}`,
-      "file",
-    );
   }
 }
 
@@ -133,16 +154,56 @@ async function validateThemes(
 ): Promise<void> {
   if (value === undefined) return;
   if (!Array.isArray(value)) throw invalid("bb.themes must be an array");
+  const ids = new Set<string>();
   for (const [index, entry] of value.entries()) {
     const theme = record(entry);
     if (!theme) throw invalid(`bb.themes.${index} must be an object`);
+    rejectUnknownKeys(
+      theme,
+      ["id", "name", "description", "css"],
+      `bb.themes.${index}`,
+    );
+    const id = requiredString(theme.id, `bb.themes.${index}.id`, 64);
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/u.test(id)) {
+      throw invalid(`bb.themes.${index}.id is invalid`);
+    }
+    if (ids.has(id)) throw invalid(`bb.themes contains duplicate id ${id}`);
+    ids.add(id);
+    requiredString(theme.name, `bb.themes.${index}.name`);
+    if (theme.description !== undefined) {
+      requiredString(theme.description, `bb.themes.${index}.description`);
+    }
+    const css = requiredString(theme.css, `bb.themes.${index}.css`);
+    if (!css.toLowerCase().endsWith(".css")) {
+      throw invalid(`bb.themes.${index}.css must be a CSS path`);
+    }
     await validateDeclaredPath(
       candidateRoot,
-      requiredString(theme.css, `bb.themes.${index}.css`),
+      css,
       `bb.themes.${index}.css`,
       "file",
     );
   }
+}
+
+function isPluginOwnedIconPath(icon: string): boolean {
+  return icon.startsWith("./") || icon.startsWith(".\\");
+}
+
+function validateLogoExtension(value: string, label: string): void {
+  if (!/\.(?:svg|png|webp)$/iu.test(value)) {
+    throw invalid(`${label} must be an SVG, PNG, or WebP path`);
+  }
+}
+
+function rejectUnknownKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+): void {
+  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknown !== undefined)
+    throw invalid(`${label}.${unknown} is not supported`);
 }
 
 function record(value: unknown): Record<string, unknown> | null {

--- a/packages/inspection/src/discovery-manifest.ts
+++ b/packages/inspection/src/discovery-manifest.ts
@@ -1,11 +1,23 @@
 import path from "node:path";
-import type { SourceCandidate, TrustedRoot } from "./discovery-types.ts";
+import type {
+  IssuedSourceCandidateFacts,
+  SourceCandidate,
+  TrustedRoot,
+} from "./discovery-types.ts";
+import { readBoundedPluginIcon } from "./discovery-asset-reader.ts";
 import { DiscoveryFailure } from "./discovery-errors.ts";
-import { readBoundedManifest } from "./discovery-manifest-reader.ts";
 import {
+  readBoundedManifestSnapshot,
+  type BoundedManifestSnapshot,
+} from "./discovery-manifest-reader.ts";
+import {
+  attestScanDirectory,
   displayPathFor,
+  isContained,
   validateDeclaredPath,
 } from "./discovery-path-safety.ts";
+import { assertValidCompactSvg } from "./svg.ts";
+import { trustedRootDetails } from "./trusted-roots.ts";
 
 const MAX_MANIFEST_STRING_CHARACTERS = 8192;
 const MAX_DISPLAY_NAME_CHARACTERS = 128;
@@ -13,19 +25,36 @@ const MAX_PACKAGE_NAME_CHARACTERS = 214;
 const MAX_VERSION_CHARACTERS = 64;
 const MAX_PLUGIN_ID_CHARACTERS = 64;
 
+const issuedCandidates = new WeakMap<
+  object,
+  {
+    readonly root: TrustedRoot;
+    readonly facts: IssuedSourceCandidateFacts;
+    readonly directoryIdentity: CandidateDirectoryIdentity;
+    readonly manifestIdentity: BoundedManifestSnapshot;
+  }
+>();
+
+interface CandidateDirectoryIdentity {
+  readonly canonicalPath: string;
+  readonly device: number;
+  readonly inode: number;
+}
+
 export async function candidateAtRoot(
   root: TrustedRoot,
   candidateRoot: string,
   relativeRoot: string,
 ): Promise<SourceCandidate | null> {
-  const source = await readBoundedManifest(
+  const manifest = await readBoundedManifestSnapshot(
     path.join(candidateRoot, "package.json"),
   );
-  if (source === null) return null;
-  const packageJson = record(JSON.parse(source) as unknown);
+  if (manifest === null) return null;
+  const packageJson = record(JSON.parse(manifest.source) as unknown);
   if (!packageJson) throw invalid("package.json must contain an object");
   const bb = record(packageJson.bb);
   if (!bb) return null;
+  validateEngines(packageJson.engines);
   rejectUnknownKeys(
     bb,
     ["name", "description", "branding", "server", "app", "skills", "themes"],
@@ -78,7 +107,94 @@ export async function candidateAtRoot(
       throw new TypeError("source candidates are server-private");
     },
   });
-  return Object.freeze(candidate);
+  Object.freeze(candidate);
+  const directoryIdentity = await captureCandidateDirectoryIdentity(
+    root,
+    candidateRoot,
+  );
+  issuedCandidates.set(candidate, {
+    root,
+    facts: Object.freeze({
+      ...candidate,
+      rootKind: root.kind,
+    }),
+    directoryIdentity,
+    manifestIdentity: manifest,
+  });
+  return candidate;
+}
+
+export async function readIssuedSourceCandidate(
+  candidate: unknown,
+): Promise<Readonly<IssuedSourceCandidateFacts>> {
+  try {
+    if (typeof candidate !== "object" || candidate === null) throw notIssued();
+    const issued = issuedCandidates.get(candidate);
+    if (!issued) throw notIssued();
+    const rootDetails = trustedRootDetails(issued.root);
+    if (
+      issued.facts.rootKey !== issued.root.rootKey ||
+      issued.facts.rootKind !== issued.root.kind ||
+      !isContained(rootDetails.canonicalRoot, issued.facts.canonicalRoot)
+    ) {
+      throw notIssued();
+    }
+    const before = await captureCandidateDirectoryIdentity(
+      issued.root,
+      issued.facts.canonicalRoot,
+    );
+    if (!sameDirectoryIdentity(before, issued.directoryIdentity)) {
+      throw notIssued();
+    }
+    const manifest = await readBoundedManifestSnapshot(
+      path.join(issued.facts.canonicalRoot, "package.json"),
+    );
+    if (
+      manifest === null ||
+      manifest.device !== issued.manifestIdentity.device ||
+      manifest.inode !== issued.manifestIdentity.inode ||
+      manifest.sha256 !== issued.manifestIdentity.sha256
+    ) {
+      throw notIssued();
+    }
+    const after = await captureCandidateDirectoryIdentity(
+      issued.root,
+      issued.facts.canonicalRoot,
+    );
+    if (!sameDirectoryIdentity(after, issued.directoryIdentity)) {
+      throw notIssued();
+    }
+    return Object.freeze({ ...issued.facts });
+  } catch {
+    throw notIssued();
+  }
+}
+
+async function captureCandidateDirectoryIdentity(
+  root: TrustedRoot,
+  candidateRoot: string,
+): Promise<CandidateDirectoryIdentity> {
+  const attestation = await attestScanDirectory(
+    candidateRoot,
+    trustedRootDetails(root).canonicalRoot,
+  );
+  if (attestation.canonicalPath !== candidateRoot) throw notIssued();
+  return {
+    canonicalPath: attestation.canonicalPath,
+    device: attestation.dev,
+    inode: attestation.ino,
+  };
+}
+
+function sameDirectoryIdentity(
+  left: CandidateDirectoryIdentity,
+  right: CandidateDirectoryIdentity,
+): boolean {
+  return (
+    left.canonicalPath === right.canonicalPath &&
+    left.device === right.device &&
+    left.inode === right.inode
+  );
 }
 
 async function validateSkills(
@@ -124,6 +240,9 @@ async function validateBranding(
       throw invalid("plugin-owned bb.branding.icon must be an SVG path");
     }
     await validateDeclaredPath(candidateRoot, icon, "bb.branding.icon", "file");
+    assertValidCompactSvg(
+      await readBoundedPluginIcon(resolveDeclaredPath(candidateRoot, icon)),
+    );
   }
   if (logo !== null) {
     rejectUnknownKeys(logo, ["light", "dark"], "bb.branding.logo");
@@ -146,6 +265,26 @@ async function validateBranding(
       );
     }
   }
+}
+
+function validateEngines(value: unknown): void {
+  if (value === undefined) return;
+  const engines = record(value);
+  if (!engines) throw invalid("engines must be an object");
+  if (engines.bb !== undefined) requiredString(engines.bb, "engines.bb");
+  if (engines.bbPluginSdk !== undefined) {
+    requiredString(engines.bbPluginSdk, "engines.bbPluginSdk");
+  }
+}
+
+function resolveDeclaredPath(
+  candidateRoot: string,
+  declaredPath: string,
+): string {
+  const segments = declaredPath
+    .split(/[\\/]/u)
+    .filter((segment) => segment.length > 0 && segment !== ".");
+  return path.join(candidateRoot, ...segments);
 }
 
 async function validateThemes(
@@ -246,4 +385,8 @@ function derivePluginId(packageName: string): string {
 
 function invalid(message: string): DiscoveryFailure {
   return new DiscoveryFailure("manifest-invalid", message);
+}
+
+function notIssued(): TypeError {
+  return new TypeError("source candidate was not issued by discovery");
 }

--- a/packages/inspection/src/discovery-manifest.ts
+++ b/packages/inspection/src/discovery-manifest.ts
@@ -1,0 +1,188 @@
+import path from "node:path";
+import type { SourceCandidate, TrustedRoot } from "./discovery-types.ts";
+import { DiscoveryFailure } from "./discovery-errors.ts";
+import { readBoundedManifest } from "./discovery-manifest-reader.ts";
+import {
+  displayPathFor,
+  validateDeclaredPath,
+} from "./discovery-path-safety.ts";
+
+const MAX_MANIFEST_STRING_CHARACTERS = 8192;
+const MAX_DISPLAY_NAME_CHARACTERS = 128;
+const MAX_PACKAGE_NAME_CHARACTERS = 214;
+const MAX_VERSION_CHARACTERS = 64;
+const MAX_PLUGIN_ID_CHARACTERS = 64;
+
+export async function candidateAtRoot(
+  root: TrustedRoot,
+  candidateRoot: string,
+  relativeRoot: string,
+): Promise<SourceCandidate | null> {
+  const source = await readBoundedManifest(
+    path.join(candidateRoot, "package.json"),
+  );
+  if (source === null) return null;
+  const packageJson = record(JSON.parse(source) as unknown);
+  if (!packageJson) throw invalid("package.json must contain an object");
+  const bb = record(packageJson.bb);
+  if (!bb) return null;
+  const packageName = requiredString(
+    packageJson.name,
+    "name",
+    MAX_PACKAGE_NAME_CHARACTERS,
+  );
+  const version = requiredString(
+    packageJson.version,
+    "version",
+    MAX_VERSION_CHARACTERS,
+  );
+  const displayName = requiredString(
+    bb.name,
+    "bb.name",
+    MAX_DISPLAY_NAME_CHARACTERS,
+  );
+  await validateDeclaredPath(
+    candidateRoot,
+    requiredString(bb.server, "bb.server"),
+    "bb.server",
+    "file",
+  );
+  const app =
+    bb.app === undefined ? undefined : requiredString(bb.app, "bb.app");
+  if (app) await validateDeclaredPath(candidateRoot, app, "bb.app", "file");
+  await validateSkills(candidateRoot, bb.skills);
+  await validateBranding(candidateRoot, bb.branding);
+  await validateThemes(candidateRoot, bb.themes);
+
+  const pluginId = derivePluginId(packageName);
+  const candidate: SourceCandidate = {
+    rootKey: root.rootKey,
+    canonicalRoot: candidateRoot,
+    displayPath: displayPathFor(root, relativeRoot),
+    packageName,
+    version,
+    pluginId,
+    displayName,
+    hasServer: true,
+    hasApp: app !== undefined,
+  };
+  Object.defineProperty(candidate, "toJSON", {
+    enumerable: false,
+    value: () => {
+      throw new TypeError("source candidates are server-private");
+    },
+  });
+  return Object.freeze(candidate);
+}
+
+async function validateSkills(
+  candidateRoot: string,
+  value: unknown,
+): Promise<void> {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw invalid("bb.skills must be an array");
+  for (const [index, entry] of value.entries()) {
+    const skillRoot = requiredString(entry, `bb.skills.${index}`).replace(
+      /[\\/]\*$/u,
+      "",
+    );
+    await validateDeclaredPath(
+      candidateRoot,
+      skillRoot,
+      `bb.skills.${index}`,
+      "directory",
+    );
+  }
+}
+
+async function validateBranding(
+  candidateRoot: string,
+  value: unknown,
+): Promise<void> {
+  if (value === undefined) return;
+  const branding = record(value);
+  if (!branding) throw invalid("bb.branding must be an object");
+  if (branding.icon !== undefined) {
+    const icon = requiredString(branding.icon, "bb.branding.icon");
+    if (icon.startsWith("./") || icon.startsWith(".\\")) {
+      await validateDeclaredPath(
+        candidateRoot,
+        icon,
+        "bb.branding.icon",
+        "file",
+      );
+    }
+  }
+  if (branding.logo === undefined) return;
+  const logo = record(branding.logo);
+  if (!logo) throw invalid("bb.branding.logo must be an object");
+  for (const variant of ["light", "dark"] as const) {
+    if (logo[variant] === undefined) continue;
+    await validateDeclaredPath(
+      candidateRoot,
+      requiredString(logo[variant], `bb.branding.logo.${variant}`),
+      `bb.branding.logo.${variant}`,
+      "file",
+    );
+  }
+}
+
+async function validateThemes(
+  candidateRoot: string,
+  value: unknown,
+): Promise<void> {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw invalid("bb.themes must be an array");
+  for (const [index, entry] of value.entries()) {
+    const theme = record(entry);
+    if (!theme) throw invalid(`bb.themes.${index} must be an object`);
+    await validateDeclaredPath(
+      candidateRoot,
+      requiredString(theme.css, `bb.themes.${index}.css`),
+      `bb.themes.${index}.css`,
+      "file",
+    );
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function requiredString(
+  value: unknown,
+  label: string,
+  maxCharacters = MAX_MANIFEST_STRING_CHARACTERS,
+): string {
+  if (typeof value !== "string") {
+    throw invalid(`${label} must be a bounded non-empty string`);
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > maxCharacters) {
+    throw invalid(`${label} must be a bounded non-empty string`);
+  }
+  return normalized;
+}
+
+function derivePluginId(packageName: string): string {
+  const base = packageName.split("/").at(-1) ?? packageName;
+  const pluginId = base
+    .replace(/^bb-plugin-/, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (
+    pluginId.length === 0 ||
+    pluginId.length > MAX_PLUGIN_ID_CHARACTERS ||
+    !/^[a-z0-9][a-z0-9-]*$/u.test(pluginId)
+  ) {
+    throw invalid("package name cannot produce a bounded plugin id");
+  }
+  return pluginId;
+}
+
+function invalid(message: string): DiscoveryFailure {
+  return new DiscoveryFailure("manifest-invalid", message);
+}

--- a/packages/inspection/src/discovery-manifest.ts
+++ b/packages/inspection/src/discovery-manifest.ts
@@ -1,45 +1,20 @@
 import path from "node:path";
-import type {
-  IssuedSourceCandidateFacts,
-  SourceCandidate,
-  TrustedRoot,
-} from "./discovery-types.ts";
+import type { SourceCandidate, TrustedRoot } from "./discovery-types.ts";
 import { readBoundedPluginIcon } from "./discovery-asset-reader.ts";
 import { DiscoveryFailure } from "./discovery-errors.ts";
+import { readBoundedManifestSnapshot } from "./discovery-manifest-reader.ts";
 import {
-  readBoundedManifestSnapshot,
-  type BoundedManifestSnapshot,
-} from "./discovery-manifest-reader.ts";
-import {
-  attestScanDirectory,
   displayPathFor,
-  isContained,
   validateDeclaredPath,
 } from "./discovery-path-safety.ts";
+import { issueSourceCandidate } from "./source-candidate-transition.ts";
 import { assertValidCompactSvg } from "./svg.ts";
-import { trustedRootDetails } from "./trusted-roots.ts";
 
 const MAX_MANIFEST_STRING_CHARACTERS = 8192;
 const MAX_DISPLAY_NAME_CHARACTERS = 128;
 const MAX_PACKAGE_NAME_CHARACTERS = 214;
 const MAX_VERSION_CHARACTERS = 64;
 const MAX_PLUGIN_ID_CHARACTERS = 64;
-
-const issuedCandidates = new WeakMap<
-  object,
-  {
-    readonly root: TrustedRoot;
-    readonly facts: IssuedSourceCandidateFacts;
-    readonly directoryIdentity: CandidateDirectoryIdentity;
-    readonly manifestIdentity: BoundedManifestSnapshot;
-  }
->();
-
-interface CandidateDirectoryIdentity {
-  readonly canonicalPath: string;
-  readonly device: number;
-  readonly inode: number;
-}
 
 export async function candidateAtRoot(
   root: TrustedRoot,
@@ -101,100 +76,7 @@ export async function candidateAtRoot(
     hasServer: true,
     hasApp: app !== undefined,
   };
-  Object.defineProperty(candidate, "toJSON", {
-    enumerable: false,
-    value: () => {
-      throw new TypeError("source candidates are server-private");
-    },
-  });
-  Object.freeze(candidate);
-  const directoryIdentity = await captureCandidateDirectoryIdentity(
-    root,
-    candidateRoot,
-  );
-  issuedCandidates.set(candidate, {
-    root,
-    facts: Object.freeze({
-      ...candidate,
-      rootKind: root.kind,
-    }),
-    directoryIdentity,
-    manifestIdentity: manifest,
-  });
-  return candidate;
-}
-
-export async function readIssuedSourceCandidate(
-  candidate: unknown,
-): Promise<Readonly<IssuedSourceCandidateFacts>> {
-  try {
-    if (typeof candidate !== "object" || candidate === null) throw notIssued();
-    const issued = issuedCandidates.get(candidate);
-    if (!issued) throw notIssued();
-    const rootDetails = trustedRootDetails(issued.root);
-    if (
-      issued.facts.rootKey !== issued.root.rootKey ||
-      issued.facts.rootKind !== issued.root.kind ||
-      !isContained(rootDetails.canonicalRoot, issued.facts.canonicalRoot)
-    ) {
-      throw notIssued();
-    }
-    const before = await captureCandidateDirectoryIdentity(
-      issued.root,
-      issued.facts.canonicalRoot,
-    );
-    if (!sameDirectoryIdentity(before, issued.directoryIdentity)) {
-      throw notIssued();
-    }
-    const manifest = await readBoundedManifestSnapshot(
-      path.join(issued.facts.canonicalRoot, "package.json"),
-    );
-    if (
-      manifest === null ||
-      manifest.device !== issued.manifestIdentity.device ||
-      manifest.inode !== issued.manifestIdentity.inode ||
-      manifest.sha256 !== issued.manifestIdentity.sha256
-    ) {
-      throw notIssued();
-    }
-    const after = await captureCandidateDirectoryIdentity(
-      issued.root,
-      issued.facts.canonicalRoot,
-    );
-    if (!sameDirectoryIdentity(after, issued.directoryIdentity)) {
-      throw notIssued();
-    }
-    return Object.freeze({ ...issued.facts });
-  } catch {
-    throw notIssued();
-  }
-}
-
-async function captureCandidateDirectoryIdentity(
-  root: TrustedRoot,
-  candidateRoot: string,
-): Promise<CandidateDirectoryIdentity> {
-  const attestation = await attestScanDirectory(
-    candidateRoot,
-    trustedRootDetails(root).canonicalRoot,
-  );
-  if (attestation.canonicalPath !== candidateRoot) throw notIssued();
-  return {
-    canonicalPath: attestation.canonicalPath,
-    device: attestation.dev,
-    inode: attestation.ino,
-  };
-}
-
-function sameDirectoryIdentity(
-  left: CandidateDirectoryIdentity,
-  right: CandidateDirectoryIdentity,
-): boolean {
-  return (
-    left.canonicalPath === right.canonicalPath &&
-    left.device === right.device &&
-    left.inode === right.inode
-  );
+  return issueSourceCandidate(root, candidate, manifest);
 }
 
 async function validateSkills(
@@ -326,7 +208,7 @@ async function validateThemes(
 }
 
 function isPluginOwnedIconPath(icon: string): boolean {
-  return icon.startsWith("./") || icon.startsWith(".\\");
+  return icon.startsWith("./");
 }
 
 function validateLogoExtension(value: string, label: string): void {
@@ -385,8 +267,4 @@ function derivePluginId(packageName: string): string {
 
 function invalid(message: string): DiscoveryFailure {
   return new DiscoveryFailure("manifest-invalid", message);
-}
-
-function notIssued(): TypeError {
-  return new TypeError("source candidate was not issued by discovery");
 }

--- a/packages/inspection/src/discovery-path-safety.test.ts
+++ b/packages/inspection/src/discovery-path-safety.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import { installDiscoveryTestHookForTest } from "./discovery-test-hook.ts";
+import {
+  createDiscoveryTestHarness,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+describe("source path safety", () => {
+  test("rejects a queued directory swapped to a symlink before inspection", async () => {
+    const rootPath = await harness.createRoot();
+    const safeRoot = path.join(rootPath, "00-safe");
+    const volatileRoot = path.join(rootPath, "volatile");
+    const originalRoot = path.join(rootPath, "volatile-original");
+    const outsideRoot = path.join(path.dirname(rootPath), "outside-plugin");
+    await fs.mkdir(safeRoot);
+    await fs.mkdir(volatileRoot);
+    await fs.mkdir(outsideRoot);
+    await harness.writePlugin(safeRoot, "safe");
+    await harness.writePlugin(outsideRoot, "outside");
+    const canonicalRootPath = await fs.realpath(rootPath);
+    let swapped = false;
+    const restore = installDiscoveryTestHookForTest(async (event) => {
+      if (
+        swapped ||
+        event.point !== "after-directory-read" ||
+        event.path !== canonicalRootPath
+      ) {
+        return;
+      }
+      swapped = true;
+      await fs.rename(volatileRoot, originalRoot);
+      await fs.symlink(outsideRoot, volatileRoot, "dir");
+    });
+    try {
+      const admission = await admitTrustedRoots([
+        {
+          rootKey: WORKSPACE_ROOT_KEY,
+          kind: "current-project",
+          path: rootPath,
+        },
+      ]);
+
+      const result = await discoverSourceCandidates(admission.roots);
+
+      expect(result.candidates.map((candidate) => candidate.pluginId)).toEqual([
+        "safe",
+      ]);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          code: "scan-directory-symlink",
+          displayPath: "workspace/volatile",
+        }),
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("reports and skips symlinked directories below a trusted root", async () => {
+    const rootPath = await harness.createRoot();
+    const outsideRoot = path.join(path.dirname(rootPath), "outside-plugin");
+    await fs.mkdir(outsideRoot);
+    await harness.writePlugin(outsideRoot, "outside");
+    await fs.symlink(outsideRoot, path.join(rootPath, "linked-plugin"), "dir");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "path-symlink",
+        displayPath: "workspace/linked-plugin",
+      }),
+    ]);
+  });
+
+  test.each([
+    ["absolute", "/tmp/outside-server.ts"],
+    ["traversal", "../outside-server.ts"],
+  ])("rejects %s declared descendants", async (_label, server) => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(
+      path.join(rootPath, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-unsafe",
+        version: "1.0.0",
+        bb: { name: "unsafe", server },
+      }),
+    );
+    await fs.writeFile(
+      path.join(path.dirname(rootPath), "outside-server.ts"),
+      "",
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "manifest-path-invalid",
+        displayPath: "workspace",
+      }),
+    ]);
+  });
+
+  test("rejects a symlink component in a declared app entrypoint", async () => {
+    const rootPath = await harness.createRoot();
+    const realDirectory = path.join(rootPath, "real");
+    await fs.mkdir(realDirectory);
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    await fs.writeFile(path.join(realDirectory, "app.tsx"), "export {};\n");
+    await fs.symlink(realDirectory, path.join(rootPath, "linked"), "dir");
+    await writeManifest(rootPath, { app: "./linked/app.tsx" });
+
+    await expectSymlinkRejection(rootPath);
+  });
+
+  test("rejects a symlink component in a declared skill root", async () => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    const realSkills = path.join(rootPath, "real-skills");
+    await fs.mkdir(realSkills);
+    await fs.symlink(realSkills, path.join(rootPath, "linked-skills"), "dir");
+    await writeManifest(rootPath, { skills: ["./linked-skills/*"] });
+
+    await expectSymlinkRejection(rootPath);
+  });
+
+  test("rejects a symlink component in a plugin-owned branding icon", async () => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    const realAssets = path.join(rootPath, "real-assets");
+    await fs.mkdir(realAssets);
+    await fs.writeFile(path.join(realAssets, "icon.svg"), "<svg />");
+    await fs.symlink(realAssets, path.join(rootPath, "assets"), "dir");
+    await writeManifest(rootPath, {
+      branding: { icon: "./assets/icon.svg" },
+    });
+
+    await expectSymlinkRejection(rootPath);
+  });
+
+  test("rejects a symlink component in a declared branding logo", async () => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    const realAssets = path.join(rootPath, "real-assets");
+    await fs.mkdir(realAssets);
+    await fs.writeFile(path.join(realAssets, "logo.svg"), "<svg />");
+    await fs.symlink(realAssets, path.join(rootPath, "assets"), "dir");
+    await writeManifest(rootPath, {
+      branding: { logo: { light: "./assets/logo.svg" } },
+    });
+
+    await expectSymlinkRejection(rootPath);
+  });
+
+  test("rejects a symlink component in a declared theme stylesheet", async () => {
+    const rootPath = await harness.createRoot();
+    await fs.writeFile(path.join(rootPath, "server.ts"), "export {};\n");
+    const realThemes = path.join(rootPath, "real-themes");
+    await fs.mkdir(realThemes);
+    await fs.writeFile(path.join(realThemes, "theme.css"), "body {}\n");
+    await fs.symlink(realThemes, path.join(rootPath, "themes"), "dir");
+    await writeManifest(rootPath, {
+      themes: [{ id: "unsafe", name: "unsafe", css: "./themes/theme.css" }],
+    });
+
+    await expectSymlinkRejection(rootPath);
+  });
+});
+
+async function writeManifest(
+  rootPath: string,
+  bb: Record<string, unknown>,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(rootPath, "package.json"),
+    JSON.stringify({
+      name: "bb-plugin-unsafe",
+      version: "1.0.0",
+      bb: { name: "unsafe", server: "./server.ts", ...bb },
+    }),
+  );
+}
+
+async function expectSymlinkRejection(rootPath: string): Promise<void> {
+  const admission = await admitTrustedRoots([
+    { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+  ]);
+  const result = await discoverSourceCandidates(admission.roots);
+  expect(result.candidates).toEqual([]);
+  expect(result.diagnostics).toContainEqual(
+    expect.objectContaining({ code: "manifest-path-symlink" }),
+  );
+}

--- a/packages/inspection/src/discovery-path-safety.test.ts
+++ b/packages/inspection/src/discovery-path-safety.test.ts
@@ -95,7 +95,12 @@ describe("source path safety", () => {
       JSON.stringify({
         name: "bb-plugin-unsafe",
         version: "1.0.0",
-        bb: { name: "unsafe", server },
+        bb: {
+          name: "unsafe",
+          description: "unsafe plugin",
+          branding: { icon: "Puzzle" },
+          server,
+        },
       }),
     );
     await fs.writeFile(
@@ -192,7 +197,13 @@ async function writeManifest(
     JSON.stringify({
       name: "bb-plugin-unsafe",
       version: "1.0.0",
-      bb: { name: "unsafe", server: "./server.ts", ...bb },
+      bb: {
+        name: "unsafe",
+        description: "unsafe plugin",
+        branding: { icon: "Puzzle" },
+        server: "./server.ts",
+        ...bb,
+      },
     }),
   );
 }

--- a/packages/inspection/src/discovery-path-safety.ts
+++ b/packages/inspection/src/discovery-path-safety.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { TrustedRoot } from "./discovery-types.ts";
+import { DiscoveryFailure } from "./discovery-errors.ts";
+
+interface FileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
+export interface ScanDirectoryAttestation extends FileIdentity {
+  readonly canonicalPath: string;
+}
+
+export async function attestScanDirectory(
+  directory: string,
+  trustedCanonicalRoot: string,
+  expected?: ScanDirectoryAttestation,
+): Promise<ScanDirectoryAttestation> {
+  const before = await fs.lstat(directory).catch(() => null);
+  if (!before) {
+    throw new DiscoveryFailure(
+      "scan-directory-changed",
+      "source directory is no longer available",
+    );
+  }
+  if (before.isSymbolicLink()) {
+    throw new DiscoveryFailure(
+      "scan-directory-symlink",
+      "source directory became a symlink",
+    );
+  }
+  if (!before.isDirectory()) {
+    throw new DiscoveryFailure(
+      "scan-directory-changed",
+      "source directory changed filesystem type",
+    );
+  }
+
+  const canonicalPath = await fs.realpath(directory).catch(() => null);
+  const after = await fs.lstat(directory).catch(() => null);
+  const canonicalPathAfter = await fs.realpath(directory).catch(() => null);
+  if (
+    canonicalPath === null ||
+    canonicalPathAfter !== canonicalPath ||
+    !after ||
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    before.dev !== after.dev ||
+    before.ino !== after.ino
+  ) {
+    throw new DiscoveryFailure(
+      "scan-directory-changed",
+      "source directory changed while it was validated",
+    );
+  }
+  if (!isContained(trustedCanonicalRoot, canonicalPath)) {
+    throw new DiscoveryFailure(
+      "scan-directory-escape",
+      "source directory escapes the admitted root",
+    );
+  }
+  if (
+    expected &&
+    (expected.dev !== after.dev ||
+      expected.ino !== after.ino ||
+      expected.canonicalPath !== canonicalPath)
+  ) {
+    throw new DiscoveryFailure(
+      "scan-directory-changed",
+      "source directory identity changed during discovery",
+    );
+  }
+  return { dev: after.dev, ino: after.ino, canonicalPath };
+}
+
+export async function validateDeclaredPath(
+  candidateRoot: string,
+  declaredPath: string,
+  label: string,
+  expected: "file" | "directory",
+): Promise<void> {
+  if (
+    path.posix.isAbsolute(declaredPath) ||
+    path.win32.isAbsolute(declaredPath)
+  ) {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      `${label} must be relative`,
+    );
+  }
+  const segments = declaredPath.split(/[\\/]/u);
+  if (segments.includes("..")) {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      `${label} must not contain traversal`,
+    );
+  }
+  const usableSegments = segments.filter(
+    (segment) => segment.length > 0 && segment !== ".",
+  );
+  if (usableSegments.length === 0) {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      `${label} must name a descendant`,
+    );
+  }
+
+  let current = candidateRoot;
+  const identities: Array<{ path: string; identity: FileIdentity }> = [];
+  for (const segment of usableSegments) {
+    current = path.join(current, segment);
+    const stat = await fs.lstat(current).catch(() => null);
+    if (!stat) {
+      throw new DiscoveryFailure(
+        "manifest-path-invalid",
+        `${label} points at a missing descendant`,
+      );
+    }
+    if (stat.isSymbolicLink()) {
+      throw new DiscoveryFailure(
+        "manifest-path-symlink",
+        `${label} contains a symlink`,
+      );
+    }
+    identities.push({ path: current, identity: stat });
+  }
+
+  const finalStat = await fs.lstat(current);
+  if (
+    (expected === "file" && !finalStat.isFile()) ||
+    (expected === "directory" && !finalStat.isDirectory())
+  ) {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      `${label} has the wrong filesystem type`,
+    );
+  }
+  const canonicalDescendant = await fs.realpath(current);
+  if (!isContained(candidateRoot, canonicalDescendant)) {
+    throw new DiscoveryFailure(
+      "manifest-path-invalid",
+      `${label} escapes the candidate root`,
+    );
+  }
+  for (const entry of identities) {
+    const after = await fs.lstat(entry.path).catch(() => null);
+    if (
+      !after ||
+      after.isSymbolicLink() ||
+      after.dev !== entry.identity.dev ||
+      after.ino !== entry.identity.ino
+    ) {
+      throw new DiscoveryFailure(
+        "manifest-path-changed",
+        `${label} changed while it was validated`,
+      );
+    }
+  }
+}
+
+export function displayPathFor(
+  root: TrustedRoot,
+  relativeRoot: string,
+): string {
+  const relative = relativeRoot
+    .split(path.sep)
+    .map((segment) => segment.replace(/[\u0000-\u001f\u007f]/gu, "?"))
+    .join("/");
+  return (
+    relative ? `${root.displayName}/${relative}` : root.displayName
+  ).slice(0, 256);
+}
+
+export function isContained(root: string, descendant: string): boolean {
+  return descendant === root || descendant.startsWith(`${root}${path.sep}`);
+}

--- a/packages/inspection/src/discovery-scan-state.ts
+++ b/packages/inspection/src/discovery-scan-state.ts
@@ -1,0 +1,242 @@
+import type { Dirent } from "node:fs";
+import path from "node:path";
+import type {
+  DiscoveryDiagnostic,
+  SourceCandidate,
+  TrustedRoot,
+} from "./discovery-types.ts";
+import {
+  allocateDiscoveryRootBudgets,
+  allocateFairShares,
+  type DiscoveryRootBudget,
+} from "./discovery-budget.ts";
+import { discoveryDiagnostic } from "./discovery-diagnostic.ts";
+import {
+  displayPathFor,
+  type ScanDirectoryAttestation,
+} from "./discovery-path-safety.ts";
+import { trustedRootDetails } from "./trusted-roots.ts";
+
+export const MAX_SCAN_DEPTH = 4;
+export const MAX_VISITED_ENTRIES = 2048;
+export const MAX_CANDIDATES = 128;
+
+export interface PendingDirectory {
+  readonly directory: string;
+  readonly relative: string;
+  readonly depth: number;
+}
+
+export type ScanContinuation =
+  | {
+      readonly kind: "children";
+      readonly current: PendingDirectory;
+      readonly attestation: ScanDirectoryAttestation;
+    }
+  | {
+      readonly kind: "entries";
+      readonly current: PendingDirectory;
+      readonly entries: readonly Dirent[];
+    };
+
+export interface RootScanState {
+  readonly root: TrustedRoot;
+  readonly canonicalRoot: string;
+  readonly budget: DiscoveryRootBudget;
+  readonly queue: PendingDirectory[];
+  readonly continuations: ScanContinuation[];
+  readonly overflowCandidates: SourceCandidate[];
+  entryLimitDisplayPath: string | null;
+  truncatedEntries: boolean;
+}
+
+export function createRootScanStates(
+  roots: readonly TrustedRoot[],
+): RootScanState[] {
+  const ordered = roots
+    .map((root) => ({
+      root,
+      canonicalRoot: trustedRootDetails(root).canonicalRoot,
+    }))
+    .sort((left, right) =>
+      left.canonicalRoot.localeCompare(right.canonicalRoot),
+    );
+  const budgets = allocateDiscoveryRootBudgets(
+    ordered.length,
+    MAX_VISITED_ENTRIES,
+    MAX_CANDIDATES,
+  );
+  return ordered.map((state, index) => ({
+    ...state,
+    budget: budgets[index]!,
+    queue: [{ directory: state.canonicalRoot, relative: "", depth: 0 }],
+    continuations: [],
+    overflowCandidates: [],
+    entryLimitDisplayPath: null,
+    truncatedEntries: false,
+  }));
+}
+
+export function consumeEntries(
+  state: RootScanState,
+  current: PendingDirectory,
+  entries: readonly Dirent[],
+  diagnostics: DiscoveryDiagnostic[],
+): void {
+  for (const [index, entry] of entries.entries()) {
+    if (state.budget.visitedEntries >= state.budget.maxVisitedEntries) {
+      const retained = entries.slice(index, index + MAX_VISITED_ENTRIES);
+      state.continuations.unshift({
+        kind: "entries",
+        current,
+        entries: retained,
+      });
+      state.truncatedEntries ||= index + retained.length < entries.length;
+      state.entryLimitDisplayPath ??= displayPathFor(
+        state.root,
+        current.relative,
+      );
+      return;
+    }
+    state.budget.visitedEntries += 1;
+    const relative = path.join(current.relative, entry.name);
+    if (entry.isSymbolicLink()) {
+      if (entry.name !== "package.json") {
+        const displayPath = displayPathFor(state.root, relative);
+        diagnostics.push(
+          discoveryDiagnostic(
+            "path-symlink",
+            state.root,
+            displayPath,
+            `Source path ${displayPath} is a symlink and was skipped.`,
+          ),
+        );
+      }
+      continue;
+    }
+    if (!entry.isDirectory() || shouldIgnoreDirectory(entry.name)) continue;
+    if (current.depth >= MAX_SCAN_DEPTH) {
+      const displayPath = displayPathFor(state.root, relative);
+      diagnostics.push(
+        discoveryDiagnostic(
+          "scan-depth-limit",
+          state.root,
+          displayPath,
+          `Source path ${displayPath} exceeds the depth-${MAX_SCAN_DEPTH} scan limit.`,
+        ),
+      );
+      continue;
+    }
+    state.queue.push({
+      directory: path.join(current.directory, entry.name),
+      relative,
+      depth: current.depth + 1,
+    });
+  }
+}
+
+export function recordCandidate(
+  state: RootScanState,
+  candidate: SourceCandidate,
+  candidates: SourceCandidate[],
+): void {
+  if (state.budget.acceptedCandidates < state.budget.maxCandidates) {
+    candidates.push(candidate);
+    state.budget.acceptedCandidates += 1;
+    return;
+  }
+  if (state.overflowCandidates.length < MAX_CANDIDATES) {
+    state.overflowCandidates.push(candidate);
+  }
+}
+
+export async function redistributeUnusedEntryCapacity(
+  states: RootScanState[],
+  candidates: SourceCandidate[],
+  diagnostics: DiscoveryDiagnostic[],
+  scanAvailable: (
+    state: RootScanState,
+    candidates: SourceCandidate[],
+    diagnostics: DiscoveryDiagnostic[],
+  ) => Promise<void>,
+): Promise<void> {
+  while (true) {
+    const used = visitedEntryCount(states);
+    const remaining = MAX_VISITED_ENTRIES - used;
+    const active = states.filter((state) => state.continuations.length > 0);
+    if (remaining <= 0 || active.length === 0) return;
+    const shares = allocateFairShares(remaining, active.length);
+    for (const [index, state] of active.entries()) {
+      state.budget.maxVisitedEntries += shares[index] ?? 0;
+      await scanAvailable(state, candidates, diagnostics);
+    }
+    if (visitedEntryCount(states) === used) return;
+  }
+}
+
+export function redistributeUnusedCandidateCapacity(
+  states: RootScanState[],
+  candidates: SourceCandidate[],
+): void {
+  while (candidates.length < MAX_CANDIDATES) {
+    let progressed = false;
+    for (const state of states) {
+      const candidate = state.overflowCandidates.shift();
+      if (!candidate) continue;
+      candidates.push(candidate);
+      state.budget.acceptedCandidates += 1;
+      progressed = true;
+      if (candidates.length >= MAX_CANDIDATES) return;
+    }
+    if (!progressed) return;
+  }
+}
+
+export function reportTrueLimits(
+  states: RootScanState[],
+  candidateCount: number,
+  diagnostics: DiscoveryDiagnostic[],
+): void {
+  if (visitedEntryCount(states) >= MAX_VISITED_ENTRIES) {
+    for (const state of states) {
+      if (state.continuations.length === 0 && !state.truncatedEntries) continue;
+      const displayPath = state.entryLimitDisplayPath ?? state.root.displayName;
+      diagnostics.push(
+        discoveryDiagnostic(
+          "scan-entry-limit",
+          state.root,
+          displayPath,
+          `Source scan at ${displayPath} reached the global ${MAX_VISITED_ENTRIES}-entry limit.`,
+        ),
+      );
+    }
+  }
+  if (candidateCount >= MAX_CANDIDATES) {
+    for (const state of states) {
+      const overflow = state.overflowCandidates[0];
+      if (!overflow) continue;
+      diagnostics.push(
+        discoveryDiagnostic(
+          "candidate-limit",
+          state.root,
+          overflow.displayPath,
+          `Source candidate ${overflow.displayPath} exceeds the global ${MAX_CANDIDATES}-candidate limit.`,
+        ),
+      );
+    }
+  }
+}
+
+function visitedEntryCount(states: RootScanState[]): number {
+  return states.reduce(
+    (total, state) => total + state.budget.visitedEntries,
+    0,
+  );
+}
+
+function shouldIgnoreDirectory(name: string): boolean {
+  return (
+    name.startsWith(".") ||
+    ["node_modules", "dist", "cache", "caches"].includes(name)
+  );
+}

--- a/packages/inspection/src/discovery-test-helpers.ts
+++ b/packages/inspection/src/discovery-test-helpers.ts
@@ -1,0 +1,48 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const EXAMPLE_ROOT_KEY = "e".repeat(32);
+export const WORKSPACE_ROOT_KEY = "w".repeat(32);
+
+export function createDiscoveryTestHarness(): {
+  createRoot(name?: string): Promise<string>;
+  writePlugin(root: string, name: string): Promise<void>;
+  cleanup(): Promise<void>;
+} {
+  const temporaryRoots: string[] = [];
+  return {
+    async createRoot(name = "workspace") {
+      const parent = await fs.mkdtemp(
+        path.join(os.tmpdir(), "bb-mate-discovery-"),
+      );
+      temporaryRoots.push(parent);
+      const root = path.join(parent, name);
+      await fs.mkdir(root);
+      return root;
+    },
+    async writePlugin(root, name) {
+      await fs.writeFile(
+        path.join(root, "package.json"),
+        `${JSON.stringify({
+          name: `bb-plugin-${name}`,
+          version: "1.2.3",
+          bb: {
+            name,
+            description: `${name} plugin`,
+            branding: { icon: "Puzzle" },
+            server: "./server.ts",
+          },
+        })}\n`,
+      );
+      await fs.writeFile(path.join(root, "server.ts"), "export {};\n");
+    },
+    async cleanup() {
+      await Promise.all(
+        temporaryRoots
+          .splice(0)
+          .map((root) => fs.rm(root, { recursive: true, force: true })),
+      );
+    },
+  };
+}

--- a/packages/inspection/src/discovery-test-hook.ts
+++ b/packages/inspection/src/discovery-test-hook.ts
@@ -1,5 +1,8 @@
 export type DiscoveryTestHookPoint =
-  "after-root-lstat" | "after-directory-read";
+  | "after-root-lstat"
+  | "after-manifest-stat"
+  | "before-directory-read"
+  | "after-directory-read";
 
 export interface DiscoveryTestHookEvent {
   readonly point: DiscoveryTestHookPoint;

--- a/packages/inspection/src/discovery-test-hook.ts
+++ b/packages/inspection/src/discovery-test-hook.ts
@@ -1,0 +1,29 @@
+export type DiscoveryTestHookPoint =
+  "after-root-lstat" | "after-directory-read";
+
+export interface DiscoveryTestHookEvent {
+  readonly point: DiscoveryTestHookPoint;
+  readonly path: string;
+}
+
+type DiscoveryTestHook = (
+  event: DiscoveryTestHookEvent,
+) => void | Promise<void>;
+
+let activeHook: DiscoveryTestHook | null = null;
+
+export async function runDiscoveryTestHook(
+  event: DiscoveryTestHookEvent,
+): Promise<void> {
+  await activeHook?.(event);
+}
+
+export function installDiscoveryTestHookForTest(
+  hook: DiscoveryTestHook,
+): () => void {
+  if (activeHook) throw new Error("a discovery test hook is already installed");
+  activeHook = hook;
+  return () => {
+    if (activeHook === hook) activeHook = null;
+  };
+}

--- a/packages/inspection/src/discovery-types.ts
+++ b/packages/inspection/src/discovery-types.ts
@@ -43,6 +43,10 @@ export interface SourceCandidate {
   readonly hasApp: boolean;
 }
 
+export interface IssuedSourceCandidateFacts extends SourceCandidate {
+  readonly rootKind: TrustedRootKind;
+}
+
 export interface SourceDiscoveryResult {
   readonly candidates: readonly SourceCandidate[];
   readonly diagnostics: readonly DiscoveryDiagnostic[];

--- a/packages/inspection/src/discovery-types.ts
+++ b/packages/inspection/src/discovery-types.ts
@@ -1,0 +1,49 @@
+export const TRUSTED_ROOT_KINDS = [
+  "current-project",
+  "explicit",
+  "pinned",
+] as const;
+
+export type TrustedRootKind = (typeof TRUSTED_ROOT_KINDS)[number];
+
+export interface TrustedRootInput {
+  rootKey: string;
+  kind: TrustedRootKind;
+  path: string;
+  displayName?: string;
+}
+
+export interface TrustedRoot {
+  readonly rootKey: string;
+  readonly kind: TrustedRootKind;
+  readonly displayName: string;
+}
+
+export interface DiscoveryDiagnostic {
+  readonly code: string;
+  readonly rootKey: string | null;
+  readonly displayPath: string | null;
+  readonly detail: string;
+}
+
+export interface TrustedRootAdmission {
+  readonly roots: readonly TrustedRoot[];
+  readonly diagnostics: readonly DiscoveryDiagnostic[];
+}
+
+export interface SourceCandidate {
+  readonly rootKey: string;
+  readonly canonicalRoot: string;
+  readonly displayPath: string;
+  readonly packageName: string;
+  readonly version: string;
+  readonly pluginId: string;
+  readonly displayName: string;
+  readonly hasServer: boolean;
+  readonly hasApp: boolean;
+}
+
+export interface SourceDiscoveryResult {
+  readonly candidates: readonly SourceCandidate[];
+  readonly diagnostics: readonly DiscoveryDiagnostic[];
+}

--- a/packages/inspection/src/index.ts
+++ b/packages/inspection/src/index.ts
@@ -1,7 +1,6 @@
 export { inspectPlugin } from "./inspect.ts";
 export { discoverPluginRoots } from "./manifest.ts";
 export { discoverSourceCandidates } from "./discover-source-candidates.ts";
-export { readIssuedSourceCandidate } from "./discovery-manifest.ts";
 export { admitTrustedRoots } from "./trusted-roots.ts";
 export { runCapturedCommand } from "./captured-command.ts";
 export type { CapturedCommandOptions } from "./captured-command.ts";
@@ -37,7 +36,6 @@ export type {
 } from "./types.ts";
 export type {
   DiscoveryDiagnostic,
-  IssuedSourceCandidateFacts,
   SourceCandidate,
   SourceDiscoveryResult,
   TrustedRoot,

--- a/packages/inspection/src/index.ts
+++ b/packages/inspection/src/index.ts
@@ -1,5 +1,7 @@
 export { inspectPlugin } from "./inspect.ts";
 export { discoverPluginRoots } from "./manifest.ts";
+export { discoverSourceCandidates } from "./discover-source-candidates.ts";
+export { admitTrustedRoots } from "./trusted-roots.ts";
 export { runCapturedCommand } from "./captured-command.ts";
 export type { CapturedCommandOptions } from "./captured-command.ts";
 export { nativeCommandEnv } from "./native-env.ts";
@@ -32,3 +34,12 @@ export type {
   SdkPublicationState,
   TrustReport,
 } from "./types.ts";
+export type {
+  DiscoveryDiagnostic,
+  SourceCandidate,
+  SourceDiscoveryResult,
+  TrustedRoot,
+  TrustedRootAdmission,
+  TrustedRootInput,
+  TrustedRootKind,
+} from "./discovery-types.ts";

--- a/packages/inspection/src/index.ts
+++ b/packages/inspection/src/index.ts
@@ -1,6 +1,7 @@
 export { inspectPlugin } from "./inspect.ts";
 export { discoverPluginRoots } from "./manifest.ts";
 export { discoverSourceCandidates } from "./discover-source-candidates.ts";
+export { readIssuedSourceCandidate } from "./discovery-manifest.ts";
 export { admitTrustedRoots } from "./trusted-roots.ts";
 export { runCapturedCommand } from "./captured-command.ts";
 export type { CapturedCommandOptions } from "./captured-command.ts";
@@ -36,6 +37,7 @@ export type {
 } from "./types.ts";
 export type {
   DiscoveryDiagnostic,
+  IssuedSourceCandidateFacts,
   SourceCandidate,
   SourceDiscoveryResult,
   TrustedRoot,

--- a/packages/inspection/src/node-strip-compat.test.ts
+++ b/packages/inspection/src/node-strip-compat.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+test("runtime discovery errors load under Node strip-only TypeScript", async () => {
+  const moduleUrl = new URL("./discovery-errors.ts", import.meta.url).href;
+  const child = Bun.spawn(
+    [
+      "node",
+      "--experimental-strip-types",
+      "--input-type=module",
+      "--eval",
+      `await import(${JSON.stringify(moduleUrl)})`,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stderr).text(),
+  ]);
+
+  expect(stderr).not.toContain("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
+  expect(exitCode).toBe(0);
+});

--- a/packages/inspection/src/source-candidate-transition.test.ts
+++ b/packages/inspection/src/source-candidate-transition.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { discoverSourceCandidates } from "./discover-source-candidates.ts";
+import {
+  createDiscoveryTestHarness,
+  WORKSPACE_ROOT_KEY,
+} from "./discovery-test-helpers.ts";
+import {
+  consumeIssuedSourceCandidate,
+  readSourceCandidateTransition,
+} from "./source-candidate-transition.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const harness = createDiscoveryTestHarness();
+
+afterEach(() => harness.cleanup());
+
+describe("source candidate transitions", () => {
+  test("consumes only an exact issued candidate through a one-use transition", async () => {
+    const rootPath = await harness.createRoot();
+    await harness.writePlugin(rootPath, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "pinned", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+
+    let capturedTransition: unknown;
+    const first = await consumeIssuedSourceCandidate(
+      candidate,
+      async (transition) => {
+        capturedTransition = transition;
+        return readSourceCandidateTransition(transition);
+      },
+    );
+
+    expect(first).toMatchObject({
+      rootKey: WORKSPACE_ROOT_KEY,
+      rootKind: "pinned",
+      canonicalRoot: await fs.realpath(rootPath),
+      displayPath: "workspace",
+      packageName: "bb-plugin-issued",
+      version: "1.2.3",
+      pluginId: "issued",
+      displayName: "issued",
+      hasServer: true,
+      hasApp: false,
+      directoryIdentity: { canonicalRoot: await fs.realpath(rootPath) },
+    });
+    expect(first.manifestIdentity.sha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(Object.isFrozen(first)).toBeTrue();
+    expect(Object.isFrozen(first.directoryIdentity)).toBeTrue();
+    expect(Object.isFrozen(first.manifestIdentity)).toBeTrue();
+    expect(() => readSourceCandidateTransition(capturedTransition)).toThrow(
+      "source candidate transition is not active",
+    );
+    await expect(
+      consumeIssuedSourceCandidate(candidate, async () => null),
+    ).rejects.toThrow("source candidate was not issued by discovery");
+    for (const forged of [
+      { ...candidate },
+      Object.create(candidate) as unknown,
+      null,
+    ]) {
+      await expect(
+        consumeIssuedSourceCandidate(forged, async () => null),
+      ).rejects.toThrow("source candidate was not issued by discovery");
+    }
+  });
+
+  test("rejects a candidate directory replaced inside its transition", async () => {
+    const rootPath = await harness.createRoot();
+    const candidateRoot = path.join(rootPath, "plugin");
+    const originalRoot = path.join(rootPath, "plugin-original");
+    await fs.mkdir(candidateRoot);
+    await harness.writePlugin(candidateRoot, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+
+    await expect(
+      consumeIssuedSourceCandidate(candidate, async (transition) => {
+        readSourceCandidateTransition(transition);
+        await fs.rename(candidateRoot, originalRoot);
+        await fs.mkdir(candidateRoot);
+        await harness.writePlugin(candidateRoot, "replacement");
+      }),
+    ).rejects.toThrow("source candidate was not issued by discovery");
+  });
+
+  test("rejects a bounded manifest changed inside its transition", async () => {
+    const rootPath = await harness.createRoot();
+    await harness.writePlugin(rootPath, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+
+    await expect(
+      consumeIssuedSourceCandidate(candidate, async (transition) => {
+        readSourceCandidateTransition(transition);
+        await fs.appendFile(path.join(rootPath, "package.json"), " \n");
+      }),
+    ).rejects.toThrow("source candidate was not issued by discovery");
+  });
+
+  test("rejects a bounded manifest inode replaced inside its transition", async () => {
+    const rootPath = await harness.createRoot();
+    await harness.writePlugin(rootPath, "issued");
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: rootPath },
+    ]);
+    const result = await discoverSourceCandidates(admission.roots);
+    const candidate = result.candidates[0]!;
+    const packagePath = path.join(rootPath, "package.json");
+    const replacementPath = path.join(rootPath, "replacement.json");
+    await fs.copyFile(packagePath, replacementPath);
+
+    await expect(
+      consumeIssuedSourceCandidate(candidate, async (transition) => {
+        const facts = readSourceCandidateTransition(transition);
+        expect(() =>
+          readSourceCandidateTransition(Object.assign({}, transition)),
+        ).toThrow("source candidate transition is not active");
+        await fs.rename(replacementPath, packagePath);
+        return facts;
+      }),
+    ).rejects.toThrow("source candidate was not issued by discovery");
+  });
+});

--- a/packages/inspection/src/source-candidate-transition.ts
+++ b/packages/inspection/src/source-candidate-transition.ts
@@ -1,0 +1,212 @@
+import path from "node:path";
+import type {
+  IssuedSourceCandidateFacts,
+  SourceCandidate,
+  TrustedRoot,
+} from "./discovery-types.ts";
+import {
+  readBoundedManifestSnapshot,
+  type BoundedManifestSnapshot,
+} from "./discovery-manifest-reader.ts";
+import { attestScanDirectory, isContained } from "./discovery-path-safety.ts";
+import { trustedRootDetails } from "./trusted-roots.ts";
+
+export interface CandidateDirectoryIdentity {
+  readonly canonicalRoot: string;
+  readonly device: number;
+  readonly inode: number;
+}
+
+export interface CandidateManifestIdentity {
+  readonly device: number;
+  readonly inode: number;
+  readonly sha256: string;
+}
+
+export interface SourceCandidateTransitionFacts extends IssuedSourceCandidateFacts {
+  readonly directoryIdentity: Readonly<CandidateDirectoryIdentity>;
+  readonly manifestIdentity: Readonly<CandidateManifestIdentity>;
+}
+
+interface IssuedCandidateRecord {
+  readonly root: TrustedRoot;
+  readonly facts: IssuedSourceCandidateFacts;
+  readonly directoryIdentity: CandidateDirectoryIdentity;
+  readonly manifestIdentity: CandidateManifestIdentity;
+}
+
+const issuedCandidates = new WeakMap<object, IssuedCandidateRecord>();
+const consumedCandidates = new WeakSet<object>();
+const activeTransitions = new WeakMap<object, SourceCandidateTransitionFacts>();
+
+export async function issueSourceCandidate(
+  root: TrustedRoot,
+  candidate: SourceCandidate,
+  manifest: BoundedManifestSnapshot,
+): Promise<SourceCandidate> {
+  Object.defineProperty(candidate, "toJSON", {
+    enumerable: false,
+    value: () => {
+      throw new TypeError("source candidates are server-private");
+    },
+  });
+  Object.freeze(candidate);
+  const directoryIdentity = await captureCandidateDirectoryIdentity(
+    root,
+    candidate.canonicalRoot,
+  );
+  issuedCandidates.set(candidate, {
+    root,
+    facts: Object.freeze({ ...candidate, rootKind: root.kind }),
+    directoryIdentity,
+    manifestIdentity: Object.freeze({
+      device: manifest.device,
+      inode: manifest.inode,
+      sha256: manifest.sha256,
+    }),
+  });
+  return candidate;
+}
+
+export async function consumeIssuedSourceCandidate<T>(
+  candidate: unknown,
+  consumer: (transition: unknown) => T | Promise<T>,
+): Promise<T> {
+  if (typeof candidate !== "object" || candidate === null) throw notIssued();
+  const issued = issuedCandidates.get(candidate);
+  if (!issued || consumedCandidates.has(candidate)) throw notIssued();
+  consumedCandidates.add(candidate);
+
+  await revalidateIssuedCandidate(issued);
+  const transition = createTransition();
+  activeTransitions.set(transition, freezeTransitionFacts(issued));
+  try {
+    let result: T | undefined;
+    let consumerFailed = false;
+    let consumerError: unknown;
+    try {
+      result = await consumer(transition);
+    } catch (error) {
+      consumerFailed = true;
+      consumerError = error;
+    }
+    await revalidateIssuedCandidate(issued);
+    if (consumerFailed) throw consumerError;
+    return result as T;
+  } finally {
+    activeTransitions.delete(transition);
+  }
+}
+
+export function readSourceCandidateTransition(
+  transition: unknown,
+): Readonly<SourceCandidateTransitionFacts> {
+  if (typeof transition !== "object" || transition === null) {
+    throw transitionNotActive();
+  }
+  const facts = activeTransitions.get(transition);
+  if (!facts) throw transitionNotActive();
+  return Object.freeze({
+    ...facts,
+    directoryIdentity: Object.freeze({ ...facts.directoryIdentity }),
+    manifestIdentity: Object.freeze({ ...facts.manifestIdentity }),
+  });
+}
+
+async function revalidateIssuedCandidate(
+  issued: IssuedCandidateRecord,
+): Promise<void> {
+  try {
+    const rootDetails = trustedRootDetails(issued.root);
+    if (
+      issued.facts.rootKey !== issued.root.rootKey ||
+      issued.facts.rootKind !== issued.root.kind ||
+      !isContained(rootDetails.canonicalRoot, issued.facts.canonicalRoot)
+    ) {
+      throw notIssued();
+    }
+    const before = await captureCandidateDirectoryIdentity(
+      issued.root,
+      issued.facts.canonicalRoot,
+    );
+    if (!sameDirectoryIdentity(before, issued.directoryIdentity)) {
+      throw notIssued();
+    }
+    const manifest = await readBoundedManifestSnapshot(
+      path.join(issued.facts.canonicalRoot, "package.json"),
+    );
+    if (
+      manifest === null ||
+      manifest.device !== issued.manifestIdentity.device ||
+      manifest.inode !== issued.manifestIdentity.inode ||
+      manifest.sha256 !== issued.manifestIdentity.sha256
+    ) {
+      throw notIssued();
+    }
+    const after = await captureCandidateDirectoryIdentity(
+      issued.root,
+      issued.facts.canonicalRoot,
+    );
+    if (!sameDirectoryIdentity(after, issued.directoryIdentity)) {
+      throw notIssued();
+    }
+  } catch {
+    throw notIssued();
+  }
+}
+
+function freezeTransitionFacts(
+  issued: IssuedCandidateRecord,
+): SourceCandidateTransitionFacts {
+  return Object.freeze({
+    ...issued.facts,
+    directoryIdentity: Object.freeze({ ...issued.directoryIdentity }),
+    manifestIdentity: Object.freeze({ ...issued.manifestIdentity }),
+  });
+}
+
+function createTransition(): object {
+  const transition = {};
+  Object.defineProperty(transition, "toJSON", {
+    enumerable: false,
+    value: () => {
+      throw new TypeError("source candidate transitions are server-private");
+    },
+  });
+  return Object.freeze(transition);
+}
+
+async function captureCandidateDirectoryIdentity(
+  root: TrustedRoot,
+  candidateRoot: string,
+): Promise<CandidateDirectoryIdentity> {
+  const attestation = await attestScanDirectory(
+    candidateRoot,
+    trustedRootDetails(root).canonicalRoot,
+  );
+  if (attestation.canonicalPath !== candidateRoot) throw notIssued();
+  return {
+    canonicalRoot: attestation.canonicalPath,
+    device: attestation.dev,
+    inode: attestation.ino,
+  };
+}
+
+function sameDirectoryIdentity(
+  left: CandidateDirectoryIdentity,
+  right: CandidateDirectoryIdentity,
+): boolean {
+  return (
+    left.canonicalRoot === right.canonicalRoot &&
+    left.device === right.device &&
+    left.inode === right.inode
+  );
+}
+
+function notIssued(): TypeError {
+  return new TypeError("source candidate was not issued by discovery");
+}
+
+function transitionNotActive(): TypeError {
+  return new TypeError("source candidate transition is not active");
+}

--- a/packages/inspection/src/trusted-roots-security.test.ts
+++ b/packages/inspection/src/trusted-roots-security.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { installDiscoveryTestHookForTest } from "./discovery-test-hook.ts";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+
+const temporaryRoots: string[] = [];
+const opaqueKey = (character: string): string => character.repeat(32);
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("trusted root security", () => {
+  test("rejects a directory swapped to a symlink during admission", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const configured = path.join(parent, "configured");
+    const original = path.join(parent, "original");
+    const outside = path.join(parent, "outside");
+    await fs.mkdir(configured);
+    await fs.mkdir(outside);
+    let swapped = false;
+    const restore = installDiscoveryTestHookForTest(async (event) => {
+      if (
+        swapped ||
+        event.point !== "after-root-lstat" ||
+        event.path !== configured
+      ) {
+        return;
+      }
+      swapped = true;
+      await fs.rename(configured, original);
+      await fs.symlink(outside, configured, "dir");
+    });
+
+    try {
+      const result = await admitTrustedRoots([
+        { rootKey: opaqueKey("r"), kind: "explicit", path: configured },
+      ]);
+
+      expect(result.roots).toEqual([]);
+      expect(result.diagnostics).toEqual([
+        expect.objectContaining({
+          code: "root-changed",
+          displayPath: "configured",
+        }),
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
+  test("rejects filesystem root and current home by canonical identity", async () => {
+    const result = await admitTrustedRoots([
+      {
+        rootKey: opaqueKey("v"),
+        kind: "explicit",
+        path: path.parse(process.cwd()).root,
+      },
+      { rootKey: opaqueKey("h"), kind: "explicit", path: os.homedir() },
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics.map((entry) => entry.code)).toEqual([
+      "root-forbidden",
+      "root-forbidden",
+    ]);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(os.homedir());
+  });
+
+  test("rejects aliases that canonicalize to root or current home", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const rootAlias = path.join(parent, "root-alias");
+    const homeParentAlias = path.join(parent, "home-parent-alias");
+    await fs.symlink(path.parse(process.cwd()).root, rootAlias, "dir");
+    await fs.symlink(path.dirname(os.homedir()), homeParentAlias, "dir");
+
+    const result = await admitTrustedRoots([
+      {
+        rootKey: opaqueKey("q"),
+        kind: "explicit",
+        path: `${rootAlias}${path.sep}tmp${path.sep}..`,
+        displayName: "root-via-alias",
+      },
+      {
+        rootKey: opaqueKey("j"),
+        kind: "pinned",
+        path: path.join(homeParentAlias, path.basename(os.homedir())),
+      },
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics.map((entry) => entry.code)).toEqual([
+      "root-forbidden",
+      "root-forbidden",
+    ]);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(os.homedir());
+  });
+});

--- a/packages/inspection/src/trusted-roots-security.test.ts
+++ b/packages/inspection/src/trusted-roots-security.test.ts
@@ -103,4 +103,55 @@ describe("trusted root security", () => {
     ]);
     expect(JSON.stringify(result.diagnostics)).not.toContain(os.homedir());
   });
+
+  test("rejects canonical ancestors of the current home without disclosing them", async () => {
+    const homeAncestor = path.dirname(await fs.realpath(os.homedir()));
+
+    const result = await admitTrustedRoots([
+      {
+        rootKey: opaqueKey("a"),
+        kind: "explicit",
+        path: homeAncestor,
+        displayName: "home-ancestor",
+      },
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "root-forbidden",
+        displayPath: path.basename(homeAncestor) || "root",
+      }),
+    ]);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(homeAncestor);
+  });
+
+  test.each(["node_modules", ".git", "dist", "cache", "caches", ".private"])(
+    "rejects a configured root inside the forbidden %s tree",
+    async (forbiddenName) => {
+      const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+      temporaryRoots.push(parent);
+      const forbiddenRoot = path.join(parent, forbiddenName);
+      const configured = path.join(forbiddenRoot, "nested-source");
+      await fs.mkdir(configured, { recursive: true });
+
+      const result = await admitTrustedRoots([
+        {
+          rootKey: opaqueKey("f"),
+          kind: "explicit",
+          path: configured,
+          displayName: "forbidden-source",
+        },
+      ]);
+
+      expect(result.roots).toEqual([]);
+      expect(result.diagnostics).toEqual([
+        expect.objectContaining({
+          code: "root-forbidden",
+          displayPath: "nested-source",
+        }),
+      ]);
+      expect(JSON.stringify(result.diagnostics)).not.toContain(parent);
+    },
+  );
 });

--- a/packages/inspection/src/trusted-roots.test.ts
+++ b/packages/inspection/src/trusted-roots.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { admitTrustedRoots } from "./trusted-roots.ts";
+import type { TrustedRootInput } from "./discovery-types.ts";
+
+const temporaryRoots: string[] = [];
+const opaqueKey = (character: string): string => character.repeat(32);
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("trusted source roots", () => {
+  test("admits a configured directory without exposing its canonical path", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const configured = path.join(parent, "example-plugin");
+    await fs.mkdir(configured);
+
+    const result = await admitTrustedRoots([
+      { rootKey: opaqueKey("t"), kind: "current-project", path: configured },
+    ]);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.roots).toEqual([
+      {
+        rootKey: opaqueKey("t"),
+        kind: "current-project",
+        displayName: "example-plugin",
+      },
+    ]);
+    expect(Object.keys(result.roots[0] ?? {})).not.toContain("canonicalRoot");
+  });
+
+  test("rejects a configured root whose leaf is a symlink", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const realRoot = path.join(parent, "real-plugin");
+    const linkedRoot = path.join(parent, "linked-plugin");
+    await fs.mkdir(realRoot);
+    await fs.symlink(realRoot, linkedRoot, "dir");
+
+    const result = await admitTrustedRoots([
+      { rootKey: opaqueKey("l"), kind: "explicit", path: linkedRoot },
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "root-symlink",
+        rootKey: opaqueKey("l"),
+        displayPath: "linked-plugin",
+      }),
+    ]);
+    expect(result.diagnostics[0]?.detail).not.toContain(parent);
+  });
+
+  test("reports invalid roots without hiding a safe sibling", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const safeRoot = path.join(parent, "safe");
+    const fileRoot = path.join(parent, "file.txt");
+    await fs.mkdir(safeRoot);
+    await fs.writeFile(fileRoot, "not a directory");
+
+    const result = await admitTrustedRoots([
+      {
+        rootKey: opaqueKey("m"),
+        kind: "pinned",
+        path: path.join(parent, "missing"),
+      },
+      { rootKey: opaqueKey("f"), kind: "explicit", path: fileRoot },
+      { rootKey: opaqueKey("s"), kind: "current-project", path: safeRoot },
+    ]);
+
+    expect(result.roots.map((root) => root.rootKey)).toEqual([opaqueKey("s")]);
+    expect(result.diagnostics.map((entry) => entry.code)).toEqual([
+      "root-missing",
+      "root-not-directory",
+    ]);
+    expect(JSON.stringify(result.diagnostics)).not.toContain(parent);
+  });
+
+  test("deduplicates roots by canonical directory", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const rootPath = path.join(parent, "plugin");
+    await fs.mkdir(rootPath);
+
+    const result = await admitTrustedRoots([
+      { rootKey: opaqueKey("a"), kind: "current-project", path: rootPath },
+      {
+        rootKey: opaqueKey("b"),
+        kind: "pinned",
+        path: path.join(rootPath, "."),
+      },
+    ]);
+
+    expect(result.roots.map((root) => root.rootKey)).toEqual([opaqueKey("a")]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "root-duplicate",
+        rootKey: opaqueKey("b"),
+        displayPath: "plugin",
+      }),
+    ]);
+  });
+
+  test("bounds configured roots at sixteen", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const inputs = await Promise.all(
+      Array.from({ length: 17 }, async (_, index) => {
+        const rootPath = path.join(
+          parent,
+          `plugin-${index.toString().padStart(2, "0")}`,
+        );
+        await fs.mkdir(rootPath);
+        return {
+          rootKey: index.toString(36).padStart(32, "0"),
+          kind: "explicit" as const,
+          path: rootPath,
+        };
+      }),
+    );
+
+    const result = await admitTrustedRoots(inputs);
+
+    expect(result.roots).toHaveLength(16);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "root-limit",
+        rootKey: (16).toString(36).padStart(32, "0"),
+      }),
+    ]);
+  });
+
+  test("rejects a non-opaque root key without echoing it", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const rootPath = path.join(parent, "plugin");
+    await fs.mkdir(rootPath);
+
+    const result = await admitTrustedRoots([
+      { rootKey: "not/an/opaque/key", kind: "explicit", path: rootPath },
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "root-key-invalid", rootKey: null }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain("not/an/opaque/key");
+  });
+
+  test("issues a server-private capability that cannot be serialized", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const rootPath = path.join(parent, "plugin");
+    await fs.mkdir(rootPath);
+
+    const result = await admitTrustedRoots([
+      { rootKey: opaqueKey("c"), kind: "explicit", path: rootPath },
+    ]);
+
+    expect(() => JSON.stringify(result.roots[0])).toThrow(
+      "trusted roots are server-private",
+    );
+  });
+
+  test("rejects reusing one opaque root key for two directories", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const first = path.join(parent, "first");
+    const second = path.join(parent, "second");
+    await fs.mkdir(first);
+    await fs.mkdir(second);
+    const rootKey = opaqueKey("d");
+
+    const result = await admitTrustedRoots([
+      { rootKey, kind: "current-project", path: first },
+      { rootKey, kind: "pinned", path: second },
+    ]);
+
+    expect(result.roots.map((root) => root.displayName)).toEqual(["first"]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "root-key-duplicate", rootKey }),
+    );
+  });
+
+  test("rejects a path-shaped display label without disclosing it", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const rootPath = path.join(parent, "plugin");
+    await fs.mkdir(rootPath);
+
+    const result = await admitTrustedRoots([
+      {
+        rootKey: opaqueKey("x"),
+        kind: "explicit",
+        path: rootPath,
+        displayName: "/Users/private/plugin",
+      },
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "root-display-invalid",
+        displayPath: "plugin",
+      }),
+    ]);
+    expect(JSON.stringify(result.diagnostics)).not.toContain("/Users/private");
+  });
+
+  test("rejects a root kind outside the admitted server sources", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const rootPath = path.join(parent, "plugin");
+    await fs.mkdir(rootPath);
+
+    const result = await admitTrustedRoots([
+      {
+        rootKey: opaqueKey("k"),
+        kind: "browser-input",
+        path: rootPath,
+      } as unknown as TrustedRootInput,
+    ]);
+
+    expect(result.roots).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "root-kind-invalid" }),
+    ]);
+  });
+});

--- a/packages/inspection/src/trusted-roots.test.ts
+++ b/packages/inspection/src/trusted-roots.test.ts
@@ -141,6 +141,31 @@ describe("trusted source roots", () => {
     ]);
   });
 
+  test("counts only admitted roots toward the configured-root limit", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
+    temporaryRoots.push(parent);
+    const safeRoot = path.join(parent, "safe");
+    await fs.mkdir(safeRoot);
+    const missing: TrustedRootInput[] = Array.from(
+      { length: 16 },
+      (_, index) => ({
+        rootKey: index.toString(36).padStart(32, "m"),
+        kind: "explicit",
+        path: path.join(parent, `missing-${index}`),
+      }),
+    );
+
+    const result = await admitTrustedRoots([
+      ...missing,
+      { rootKey: opaqueKey("s"), kind: "current-project", path: safeRoot },
+    ]);
+
+    expect(result.roots.map((root) => root.displayName)).toEqual(["safe"]);
+    expect(result.diagnostics.map((entry) => entry.code)).toEqual(
+      Array.from({ length: 16 }, () => "root-missing"),
+    );
+  });
+
   test("rejects a non-opaque root key without echoing it", async () => {
     const parent = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-roots-"));
     temporaryRoots.push(parent);

--- a/packages/inspection/src/trusted-roots.ts
+++ b/packages/inspection/src/trusted-roots.ts
@@ -1,0 +1,197 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  DiscoveryDiagnostic,
+  TrustedRoot,
+  TrustedRootAdmission,
+  TrustedRootInput,
+} from "./discovery-types.ts";
+import { TRUSTED_ROOT_KINDS } from "./discovery-types.ts";
+import { runDiscoveryTestHook } from "./discovery-test-hook.ts";
+
+interface TrustedRootDetails {
+  readonly canonicalRoot: string;
+}
+
+const admittedRoots = new WeakMap<object, TrustedRootDetails>();
+const MAX_TRUSTED_ROOTS = 16;
+const MAX_DISPLAY_NAME_CHARACTERS = 255;
+
+export async function admitTrustedRoots(
+  inputs: readonly TrustedRootInput[],
+): Promise<TrustedRootAdmission> {
+  const roots: TrustedRoot[] = [];
+  const diagnostics: DiscoveryDiagnostic[] = [];
+  const canonicalRoots = new Set<string>();
+  const rootKeys = new Set<string>();
+
+  for (const [index, input] of inputs.entries()) {
+    const displayPath = redactedBasename(input.path);
+    if (!/^[A-Za-z0-9_-]{32}$/u.test(input.rootKey)) {
+      diagnostics.push({
+        code: "root-key-invalid",
+        rootKey: null,
+        displayPath,
+        detail: `Configured root ${displayPath} has an invalid opaque key.`,
+      });
+      continue;
+    }
+    if (!(TRUSTED_ROOT_KINDS as readonly string[]).includes(input.kind)) {
+      diagnostics.push({
+        code: "root-kind-invalid",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} has an invalid source kind.`,
+      });
+      continue;
+    }
+    const displayName = input.displayName?.trim() ?? displayPath;
+    if (!isValidDisplayName(displayName)) {
+      diagnostics.push({
+        code: "root-display-invalid",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} has an invalid display label.`,
+      });
+      continue;
+    }
+    if (index >= MAX_TRUSTED_ROOTS) {
+      diagnostics.push({
+        code: "root-limit",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} exceeds the ${MAX_TRUSTED_ROOTS}-root limit.`,
+      });
+      continue;
+    }
+    const configuredStat = await fs.lstat(input.path).catch(() => null);
+    if (!configuredStat) {
+      diagnostics.push({
+        code: "root-missing",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} does not exist.`,
+      });
+      continue;
+    }
+    if (configuredStat?.isSymbolicLink()) {
+      diagnostics.push({
+        code: "root-symlink",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} is a symlink.`,
+      });
+      continue;
+    }
+    if (!configuredStat.isDirectory()) {
+      diagnostics.push({
+        code: "root-not-directory",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} is not a directory.`,
+      });
+      continue;
+    }
+    await runDiscoveryTestHook({ point: "after-root-lstat", path: input.path });
+    const canonicalRoot = await fs.realpath(input.path).catch(() => null);
+    const resolvedStat = await fs.lstat(input.path).catch(() => null);
+    const canonicalRootAfter = await fs.realpath(input.path).catch(() => null);
+    if (
+      canonicalRoot === null ||
+      canonicalRootAfter !== canonicalRoot ||
+      !sameIdentity(configuredStat, resolvedStat) ||
+      !resolvedStat?.isDirectory() ||
+      resolvedStat.isSymbolicLink()
+    ) {
+      diagnostics.push({
+        code: "root-changed",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} changed while it was admitted.`,
+      });
+      continue;
+    }
+    const canonicalHome = await fs.realpath(os.homedir()).catch(() => null);
+    if (
+      canonicalRoot === path.parse(canonicalRoot).root ||
+      canonicalRoot === canonicalHome
+    ) {
+      diagnostics.push({
+        code: "root-forbidden",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} is outside the bounded source policy.`,
+      });
+      continue;
+    }
+    if (rootKeys.has(input.rootKey)) {
+      diagnostics.push({
+        code: "root-key-duplicate",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} reuses an admitted root key.`,
+      });
+      continue;
+    }
+    if (canonicalRoots.has(canonicalRoot)) {
+      diagnostics.push({
+        code: "root-duplicate",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} duplicates an admitted root.`,
+      });
+      continue;
+    }
+    canonicalRoots.add(canonicalRoot);
+    rootKeys.add(input.rootKey);
+    const root = {
+      rootKey: input.rootKey,
+      kind: input.kind,
+      displayName,
+    };
+    Object.defineProperty(root, "toJSON", {
+      enumerable: false,
+      value: () => {
+        throw new TypeError("trusted roots are server-private");
+      },
+    });
+    Object.freeze(root);
+    admittedRoots.set(root, { canonicalRoot });
+    roots.push(root);
+  }
+
+  return {
+    roots: Object.freeze(roots),
+    diagnostics: Object.freeze(diagnostics),
+  };
+}
+
+function sameIdentity(
+  left: { dev: number; ino: number },
+  right: { dev: number; ino: number } | null,
+): boolean {
+  return right !== null && left.dev === right.dev && left.ino === right.ino;
+}
+
+function redactedBasename(inputPath: string): string {
+  const basename = path.basename(inputPath) || "root";
+  return basename.replace(/[\u0000-\u001f\u007f]/gu, "?").slice(0, 255);
+}
+
+function isValidDisplayName(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= MAX_DISPLAY_NAME_CHARACTERS &&
+    value !== "." &&
+    value !== ".." &&
+    !/[\\/\u0000-\u001f\u007f]/u.test(value)
+  );
+}
+
+export function trustedRootDetails(root: TrustedRoot): TrustedRootDetails {
+  const details = admittedRoots.get(root);
+  if (!details)
+    throw new TypeError("trusted root was not admitted by the server");
+  return details;
+}

--- a/packages/inspection/src/trusted-roots.ts
+++ b/packages/inspection/src/trusted-roots.ts
@@ -26,7 +26,7 @@ export async function admitTrustedRoots(
   const canonicalRoots = new Set<string>();
   const rootKeys = new Set<string>();
 
-  for (const [index, input] of inputs.entries()) {
+  for (const input of inputs) {
     const displayPath = redactedBasename(input.path);
     if (!/^[A-Za-z0-9_-]{32}$/u.test(input.rootKey)) {
       diagnostics.push({
@@ -53,15 +53,6 @@ export async function admitTrustedRoots(
         rootKey: input.rootKey,
         displayPath,
         detail: `Configured root ${displayPath} has an invalid display label.`,
-      });
-      continue;
-    }
-    if (index >= MAX_TRUSTED_ROOTS) {
-      diagnostics.push({
-        code: "root-limit",
-        rootKey: input.rootKey,
-        displayPath,
-        detail: `Configured root ${displayPath} exceeds the ${MAX_TRUSTED_ROOTS}-root limit.`,
       });
       continue;
     }
@@ -113,10 +104,7 @@ export async function admitTrustedRoots(
       continue;
     }
     const canonicalHome = await fs.realpath(os.homedir()).catch(() => null);
-    if (
-      canonicalRoot === path.parse(canonicalRoot).root ||
-      canonicalRoot === canonicalHome
-    ) {
+    if (isForbiddenCanonicalRoot(canonicalRoot, canonicalHome)) {
       diagnostics.push({
         code: "root-forbidden",
         rootKey: input.rootKey,
@@ -143,6 +131,15 @@ export async function admitTrustedRoots(
       });
       continue;
     }
+    if (roots.length >= MAX_TRUSTED_ROOTS) {
+      diagnostics.push({
+        code: "root-limit",
+        rootKey: input.rootKey,
+        displayPath,
+        detail: `Configured root ${displayPath} exceeds the ${MAX_TRUSTED_ROOTS}-root limit.`,
+      });
+      continue;
+    }
     canonicalRoots.add(canonicalRoot);
     rootKeys.add(input.rootKey);
     const root = {
@@ -165,6 +162,47 @@ export async function admitTrustedRoots(
     roots: Object.freeze(roots),
     diagnostics: Object.freeze(diagnostics),
   };
+}
+
+/**
+ * This structural deny policy also excludes bb's ordinary managed data roots,
+ * which live below hidden directories. An exact non-hidden installed-root deny
+ * set needs the native inventory owned by slice 57B; native inventory must not
+ * seed roots in this source-only slice.
+ */
+function isForbiddenCanonicalRoot(
+  canonicalRoot: string,
+  canonicalHome: string | null,
+): boolean {
+  const filesystemRoot = path.parse(canonicalRoot).root;
+  if (canonicalRoot === filesystemRoot) return true;
+  if (
+    canonicalHome !== null &&
+    (canonicalRoot === canonicalHome ||
+      isStrictDescendant(canonicalHome, canonicalRoot))
+  ) {
+    return true;
+  }
+  const components = path
+    .relative(filesystemRoot, canonicalRoot)
+    .split(path.sep)
+    .filter(Boolean);
+  return components.some((component) => {
+    const normalized = component.toLowerCase();
+    return (
+      component.startsWith(".") ||
+      ["node_modules", "dist", "cache", "caches"].includes(normalized)
+    );
+  });
+}
+
+function isStrictDescendant(candidate: string, parent: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative !== "" &&
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== ".."
+  );
 }
 
 function sameIdentity(

--- a/packages/runtime/src/discovery/catalog-integrity.test.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+} from "../contracts/ids.ts";
+import { openDevelopmentTargetCatalog } from "./catalog.ts";
+import { issueTrustedDevelopmentTargetCandidateFromInspection } from "./trusted-candidate.ts";
+
+const temporaryRoots: string[] = [];
+const principalId = PrincipalIdSchema.parse("p".repeat(32));
+const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+
+function candidate(canonicalRoot: string) {
+  return {
+    rootKey: OpaqueIdSchema.parse("r".repeat(32)),
+    rootKind: "current-project" as const,
+    canonicalRoot,
+    target: {
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered" as const,
+      manifest: {
+        pluginId: "notes",
+        packageName: "bb-plugin-notes",
+        version: "1.2.3",
+        hasServer: true,
+        hasApp: true,
+      },
+      native: { status: "absent" as const, observedAt: 1_000 },
+      capabilities: { fixture: true, harness: false, live: false },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("development-target private-source integrity", () => {
+  test("rejects invalid private field encodings without repairing them", async () => {
+    for (const [column, corruptValue] of [
+      ["root_key", "configured-label"],
+      ["root_kind", "unknown"],
+      ["canonical_root", "relative/plugin"],
+    ] as const) {
+      const temporaryRoot = await fs.realpath(os.tmpdir());
+      const parent = await fs.mkdtemp(
+        path.join(temporaryRoot, "bb-mate-private-integrity-"),
+      );
+      temporaryRoots.push(parent);
+      const pluginRoot = path.join(parent, "plugin");
+      await fs.mkdir(pluginRoot);
+      const dataRoot = path.join(parent, "data");
+      const catalog = await openDevelopmentTargetCatalog({
+        dataRoot,
+        id: () => ObjectIdSchema.parse("t".repeat(32)),
+        clock: () => 1_000,
+      });
+      await catalog.refresh({
+        principalId,
+        bbContextId,
+        candidate: await issueTrustedDevelopmentTargetCandidateFromInspection(
+          candidate(await fs.realpath(pluginRoot)),
+        ),
+      });
+      catalog.close();
+
+      const databasePath = path.join(dataRoot, "workbench.sqlite3");
+      const tamper = new Database(databasePath);
+      tamper.exec("PRAGMA ignore_check_constraints = ON");
+      tamper
+        .query(`UPDATE development_target_sources SET ${column} = ?`)
+        .run(corruptValue);
+      tamper.close();
+
+      await expect(
+        openDevelopmentTargetCatalog({ dataRoot }),
+      ).rejects.toMatchObject({ code: "corrupt_data" });
+      const inspect = new Database(databasePath, { readonly: true });
+      try {
+        expect(
+          inspect
+            .query<{ value: string }, []>(
+              `SELECT ${column} AS value FROM development_target_sources`,
+            )
+            .get(),
+        ).toEqual({ value: corruptValue });
+      } finally {
+        inspect.close();
+      }
+    }
+  });
+});

--- a/packages/runtime/src/discovery/catalog-integrity.test.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.test.ts
@@ -10,32 +10,41 @@ import {
   OpaqueIdSchema,
   PrincipalIdSchema,
 } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
 import { openDevelopmentTargetCatalog } from "./catalog.ts";
-import { issueTrustedDevelopmentTargetCandidateFromInspection } from "./trusted-candidate.ts";
+import {
+  createInspectionDevelopmentTargetCandidateBridge,
+  type InspectionSourceCandidateFacts,
+} from "./trusted-candidate.ts";
 
 const temporaryRoots: string[] = [];
 const principalId = PrincipalIdSchema.parse("p".repeat(32));
 const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+
+function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
+  const candidate = Object.freeze({ ...value });
+  const bridge = createInspectionDevelopmentTargetCandidateBridge({
+    clock: () => 1_000,
+    readIssuedSourceCandidate(input) {
+      if (input !== candidate) throw new RuntimeError("invalid_request");
+      return Object.freeze({ ...value });
+    },
+  });
+  return bridge.issue(candidate);
+}
 
 function candidate(canonicalRoot: string) {
   return {
     rootKey: OpaqueIdSchema.parse("r".repeat(32)),
     rootKind: "current-project" as const,
     canonicalRoot,
-    target: {
-      displayName: "Notes",
-      displayPath: "plugins/notes",
-      sourceKind: "workspace-discovered" as const,
-      manifest: {
-        pluginId: "notes",
-        packageName: "bb-plugin-notes",
-        version: "1.2.3",
-        hasServer: true,
-        hasApp: true,
-      },
-      native: { status: "absent" as const, observedAt: 1_000 },
-      capabilities: { fixture: true, harness: false, live: false },
-    },
+    displayName: "Notes",
+    displayPath: "plugins/notes",
+    packageName: "bb-plugin-notes",
+    version: "1.2.3",
+    pluginId: "notes",
+    hasServer: true,
+    hasApp: true,
   };
 }
 
@@ -70,7 +79,7 @@ describe("development-target private-source integrity", () => {
       await catalog.refresh({
         principalId,
         bbContextId,
-        candidate: await issueTrustedDevelopmentTargetCandidateFromInspection(
+        candidate: await issueInspectionCandidate(
           candidate(await fs.realpath(pluginRoot)),
         ),
       });

--- a/packages/runtime/src/discovery/catalog-integrity.test.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../contracts/ids.ts";
 import { RuntimeError } from "../errors.ts";
 import { openDevelopmentTargetCatalog } from "./catalog.ts";
+import { inspectDevelopmentSourceIdentity } from "./source-identity.ts";
 import {
   createInspectionDevelopmentTargetCandidateBridge,
   type InspectionSourceCandidateFacts,
@@ -21,13 +22,35 @@ const temporaryRoots: string[] = [];
 const principalId = PrincipalIdSchema.parse("p".repeat(32));
 const bbContextId = BbContextIdSchema.parse("b".repeat(32));
 
-function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
+async function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
   const candidate = Object.freeze({ ...value });
+  const transition = Object.freeze({ transition: true });
+  const identity = await inspectDevelopmentSourceIdentity(value.canonicalRoot);
+  let active = false;
   const bridge = createInspectionDevelopmentTargetCandidateBridge({
     clock: () => 1_000,
-    readIssuedSourceCandidate(input) {
+    async consumeIssuedSourceCandidate(input, consumer) {
       if (input !== candidate) throw new RuntimeError("invalid_request");
-      return Object.freeze({ ...value });
+      active = true;
+      try {
+        return await consumer(transition);
+      } finally {
+        active = false;
+      }
+    },
+    readSourceCandidateTransition(input) {
+      if (input !== transition || !active) {
+        throw new RuntimeError("invalid_request");
+      }
+      return {
+        ...value,
+        directoryIdentity: {
+          canonicalRoot: identity.canonicalRoot,
+          device: identity.device,
+          inode: identity.inode,
+        },
+        manifestIdentity: identity.manifest,
+      };
     },
   });
   return bridge.issue(candidate);
@@ -70,6 +93,10 @@ describe("development-target private-source integrity", () => {
       temporaryRoots.push(parent);
       const pluginRoot = path.join(parent, "plugin");
       await fs.mkdir(pluginRoot);
+      await fs.writeFile(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({ name: "bb-plugin-notes", version: "1.2.3" }),
+      );
       const dataRoot = path.join(parent, "data");
       const catalog = await openDevelopmentTargetCatalog({
         dataRoot,

--- a/packages/runtime/src/discovery/catalog-integrity.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.ts
@@ -1,9 +1,16 @@
 import type { Database } from "bun:sqlite";
 
 import { RuntimeError } from "../errors.ts";
+import { parsePrivateDevelopmentTargetSource } from "./private-source.ts";
 
 interface IntegrityRow {
   readonly invalid: number;
+}
+
+interface PrivateSourceRow {
+  readonly canonical_root: string;
+  readonly root_key: string;
+  readonly root_kind: string;
 }
 
 export function createDevelopmentTargetIntegrityCheck(
@@ -33,8 +40,23 @@ export function createDevelopmentTargetIntegrityCheck(
       )
     LIMIT 1
   `);
+  const selectPrivateSources = database.query<PrivateSourceRow, []>(`
+    SELECT canonical_root, root_key, root_kind
+    FROM development_target_sources
+  `);
 
   return () => {
     if (selectFailure.get()) throw new RuntimeError("corrupt_data");
+    try {
+      for (const row of selectPrivateSources.all()) {
+        parsePrivateDevelopmentTargetSource({
+          canonicalRoot: row.canonical_root,
+          rootKey: row.root_key,
+          rootKind: row.root_kind,
+        });
+      }
+    } catch (error) {
+      throw new RuntimeError("corrupt_data", { cause: error });
+    }
   };
 }

--- a/packages/runtime/src/discovery/catalog-integrity.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.ts
@@ -1,0 +1,40 @@
+import type { Database } from "bun:sqlite";
+
+import { RuntimeError } from "../errors.ts";
+
+interface IntegrityRow {
+  readonly invalid: number;
+}
+
+export function createDevelopmentTargetIntegrityCheck(
+  database: Database,
+): () => void {
+  const selectFailure = database.query<IntegrityRow, []>(`
+    SELECT 1 AS invalid
+    FROM development_target_sources s
+    LEFT JOIN runtime_objects o ON o.id = s.object_id
+    WHERE o.id IS NULL
+      OR o.kind != 'development-target'
+      OR o.principal_id != s.principal_id
+      OR o.bb_context_id != s.bb_context_id
+      OR o.target_id != o.id
+      OR o.session_id IS NOT NULL
+    UNION ALL
+    SELECT 1 AS invalid
+    FROM runtime_objects o
+    LEFT JOIN development_target_sources s ON s.object_id = o.id
+    WHERE o.kind = 'development-target'
+      AND (
+        s.object_id IS NULL
+        OR s.principal_id != o.principal_id
+        OR s.bb_context_id != o.bb_context_id
+        OR o.target_id != o.id
+        OR o.session_id IS NOT NULL
+      )
+    LIMIT 1
+  `);
+
+  return () => {
+    if (selectFailure.get()) throw new RuntimeError("corrupt_data");
+  };
+}

--- a/packages/runtime/src/discovery/catalog-storage.ts
+++ b/packages/runtime/src/discovery/catalog-storage.ts
@@ -9,10 +9,11 @@ import {
   parseDevelopmentTargetEnvelope,
   type DevelopmentTargetEnvelope,
 } from "./development-target.ts";
-import type {
-  DevelopmentTargetRootKind,
-  TrustedDevelopmentTargetCandidate,
-} from "./trusted-candidate.ts";
+import {
+  parsePrivateDevelopmentTargetSource,
+  type PrivateDevelopmentTargetSource,
+} from "./private-source.ts";
+import type { TrustedDevelopmentTargetCandidate } from "./trusted-candidate.ts";
 
 interface ObjectRow {
   readonly id: string;
@@ -30,7 +31,7 @@ interface ObjectRow {
 interface PrivateRow {
   readonly canonical_root: string;
   readonly root_key: string;
-  readonly root_kind: DevelopmentTargetRootKind;
+  readonly root_kind: string;
 }
 
 function parseRow(row: ObjectRow): DevelopmentTargetEnvelope {
@@ -79,13 +80,7 @@ export interface DevelopmentTargetCatalogStorage {
     principalId: PrincipalId,
     bbContextId: BbContextId,
     id: ObjectId,
-  ):
-    | {
-        readonly canonicalRoot: string;
-        readonly rootKey: string;
-        readonly rootKind: DevelopmentTargetRootKind;
-      }
-    | undefined;
+  ): PrivateDevelopmentTargetSource | undefined;
   persistCreation(
     envelope: DevelopmentTargetEnvelope,
     candidate: TrustedDevelopmentTargetCandidate,
@@ -223,11 +218,11 @@ export function createDevelopmentTargetCatalogStorage(
     resolvePrivate(principalId, bbContextId, id) {
       const row = selectPrivate.get(id, principalId, bbContextId);
       return row
-        ? {
+        ? parsePrivateDevelopmentTargetSource({
             canonicalRoot: row.canonical_root,
             rootKey: row.root_key,
             rootKind: row.root_kind,
-          }
+          })
         : undefined;
     },
     persistCreation,

--- a/packages/runtime/src/discovery/catalog-storage.ts
+++ b/packages/runtime/src/discovery/catalog-storage.ts
@@ -1,0 +1,236 @@
+import type { Database, SQLQueryBindings } from "bun:sqlite";
+
+import type { BbContextId, ObjectId, PrincipalId } from "../contracts/ids.ts";
+import { canonicalJson, type JsonValue } from "../contracts/objects.ts";
+import { RuntimeError } from "../errors.ts";
+import { createEventFeed } from "../events/feed.ts";
+import { createDevelopmentTargetIntegrityCheck } from "./catalog-integrity.ts";
+import {
+  parseDevelopmentTargetEnvelope,
+  type DevelopmentTargetEnvelope,
+} from "./development-target.ts";
+import type {
+  DevelopmentTargetRootKind,
+  TrustedDevelopmentTargetCandidate,
+} from "./trusted-candidate.ts";
+
+interface ObjectRow {
+  readonly id: string;
+  readonly kind: string;
+  readonly principal_id: string;
+  readonly bb_context_id: string;
+  readonly target_id: string;
+  readonly session_id: string | null;
+  readonly revision: number;
+  readonly created_at: number;
+  readonly updated_at: number;
+  readonly payload_json: string;
+}
+
+interface PrivateRow {
+  readonly canonical_root: string;
+  readonly root_key: string;
+  readonly root_kind: DevelopmentTargetRootKind;
+}
+
+function parseRow(row: ObjectRow): DevelopmentTargetEnvelope {
+  try {
+    const envelope = parseDevelopmentTargetEnvelope({
+      schemaVersion: 1,
+      id: row.id,
+      kind: row.kind,
+      bindings: {
+        principalId: row.principal_id,
+        bbContextId: row.bb_context_id,
+        targetId: row.target_id,
+        ...(row.session_id === null ? {} : { sessionId: row.session_id }),
+      },
+      revision: row.revision,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      payload: JSON.parse(row.payload_json) as JsonValue,
+    });
+    if (row.payload_json !== canonicalJson(envelope.payload)) {
+      throw new RuntimeError("corrupt_data");
+    }
+    return envelope;
+  } catch (error) {
+    throw new RuntimeError("corrupt_data", { cause: error });
+  }
+}
+
+export interface DevelopmentTargetCatalogStorage {
+  assertIntegrity(): void;
+  findByRoot(
+    principalId: PrincipalId,
+    bbContextId: BbContextId,
+    canonicalRoot: string,
+  ): DevelopmentTargetEnvelope | undefined;
+  list(
+    principalId: PrincipalId,
+    bbContextId: BbContextId,
+  ): readonly DevelopmentTargetEnvelope[];
+  get(
+    principalId: PrincipalId,
+    bbContextId: BbContextId,
+    id: ObjectId,
+  ): DevelopmentTargetEnvelope | undefined;
+  resolvePrivate(
+    principalId: PrincipalId,
+    bbContextId: BbContextId,
+    id: ObjectId,
+  ):
+    | {
+        readonly canonicalRoot: string;
+        readonly rootKey: string;
+        readonly rootKind: DevelopmentTargetRootKind;
+      }
+    | undefined;
+  persistCreation(
+    envelope: DevelopmentTargetEnvelope,
+    candidate: TrustedDevelopmentTargetCandidate,
+  ): void;
+  persistUpdate(
+    envelope: DevelopmentTargetEnvelope,
+    candidate: TrustedDevelopmentTargetCandidate,
+    expectedRevision: number,
+  ): void;
+}
+
+export function createDevelopmentTargetCatalogStorage(
+  database: Database,
+): DevelopmentTargetCatalogStorage {
+  const eventFeed = createEventFeed(database);
+  const assertIntegrity = createDevelopmentTargetIntegrityCheck(database);
+  const selectByRoot = database.query<ObjectRow, SQLQueryBindings[]>(`
+    SELECT o.*
+    FROM runtime_objects o
+    INNER JOIN development_target_sources s ON s.object_id = o.id
+    WHERE s.principal_id = ? AND s.bb_context_id = ? AND s.canonical_root = ?
+  `);
+  const selectList = database.query<ObjectRow, SQLQueryBindings[]>(`
+    SELECT o.*
+    FROM runtime_objects o
+    INNER JOIN development_target_sources s ON s.object_id = o.id
+    WHERE s.principal_id = ? AND s.bb_context_id = ?
+    ORDER BY o.created_at, o.id
+  `);
+  const selectById = database.query<ObjectRow, SQLQueryBindings[]>(`
+    SELECT o.*
+    FROM runtime_objects o
+    INNER JOIN development_target_sources s ON s.object_id = o.id
+    WHERE o.id = ? AND s.principal_id = ? AND s.bb_context_id = ?
+  `);
+  const selectPrivate = database.query<PrivateRow, SQLQueryBindings[]>(`
+    SELECT canonical_root, root_key, root_kind
+    FROM development_target_sources
+    WHERE object_id = ? AND principal_id = ? AND bb_context_id = ?
+  `);
+  const insertObject = database.query(`
+    INSERT INTO runtime_objects (
+      id, kind, principal_id, bb_context_id, target_id, session_id,
+      revision, created_at, updated_at, payload_json
+    ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
+  `);
+  const insertPrivate = database.query(`
+    INSERT INTO development_target_sources (
+      object_id, principal_id, bb_context_id, root_key, root_kind, canonical_root
+    ) VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  const updateObject = database.query(`
+    UPDATE runtime_objects
+    SET revision = ?, updated_at = ?, payload_json = ?
+    WHERE id = ? AND principal_id = ? AND bb_context_id = ?
+      AND target_id = ? AND session_id IS NULL AND revision = ?
+  `);
+  const updatePrivate = database.query(`
+    UPDATE development_target_sources
+    SET root_key = ?, root_kind = ?
+    WHERE object_id = ? AND principal_id = ? AND bb_context_id = ?
+  `);
+
+  const persistCreation = database.transaction(
+    (
+      envelope: DevelopmentTargetEnvelope,
+      candidate: TrustedDevelopmentTargetCandidate,
+    ) => {
+      insertObject.run(
+        envelope.id,
+        envelope.kind,
+        envelope.bindings.principalId,
+        envelope.bindings.bbContextId,
+        envelope.bindings.targetId,
+        envelope.revision,
+        envelope.createdAt,
+        envelope.updatedAt,
+        canonicalJson(envelope.payload),
+      );
+      insertPrivate.run(
+        envelope.id,
+        envelope.bindings.principalId,
+        envelope.bindings.bbContextId,
+        candidate.rootKey,
+        candidate.rootKind,
+        candidate.canonicalRoot,
+      );
+      eventFeed.append("object.created", envelope);
+    },
+  );
+  const persistUpdate = database.transaction(
+    (
+      envelope: DevelopmentTargetEnvelope,
+      candidate: TrustedDevelopmentTargetCandidate,
+      expectedRevision: number,
+    ) => {
+      const result = updateObject.run(
+        envelope.revision,
+        envelope.updatedAt,
+        canonicalJson(envelope.payload),
+        envelope.id,
+        envelope.bindings.principalId,
+        envelope.bindings.bbContextId,
+        envelope.bindings.targetId,
+        expectedRevision,
+      );
+      if (result.changes !== 1) throw new RuntimeError("conflict");
+      const privateResult = updatePrivate.run(
+        candidate.rootKey,
+        candidate.rootKind,
+        envelope.id,
+        envelope.bindings.principalId,
+        envelope.bindings.bbContextId,
+      );
+      if (privateResult.changes !== 1) {
+        throw new RuntimeError("corrupt_data");
+      }
+      eventFeed.append("object.updated", envelope);
+    },
+  );
+
+  return {
+    assertIntegrity,
+    findByRoot(principalId, bbContextId, canonicalRoot) {
+      const row = selectByRoot.get(principalId, bbContextId, canonicalRoot);
+      return row ? parseRow(row) : undefined;
+    },
+    list(principalId, bbContextId) {
+      return selectList.all(principalId, bbContextId).map(parseRow);
+    },
+    get(principalId, bbContextId, id) {
+      const row = selectById.get(id, principalId, bbContextId);
+      return row ? parseRow(row) : undefined;
+    },
+    resolvePrivate(principalId, bbContextId, id) {
+      const row = selectPrivate.get(id, principalId, bbContextId);
+      return row
+        ? {
+            canonicalRoot: row.canonical_root,
+            rootKey: row.root_key,
+            rootKind: row.root_kind,
+          }
+        : undefined;
+    },
+    persistCreation,
+    persistUpdate,
+  };
+}

--- a/packages/runtime/src/discovery/catalog.test.ts
+++ b/packages/runtime/src/discovery/catalog.test.ts
@@ -9,32 +9,55 @@ import {
   OpaqueIdSchema,
   PrincipalIdSchema,
 } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
 import { openDevelopmentTargetCatalog } from "./catalog.ts";
-import { issueTrustedDevelopmentTargetCandidateFromInspection } from "./trusted-candidate.ts";
+import {
+  createInspectionDevelopmentTargetCandidateBridge,
+  type InspectionSourceCandidateFacts,
+} from "./trusted-candidate.ts";
 
 const temporaryRoots: string[] = [];
 const principalId = PrincipalIdSchema.parse("p".repeat(32));
 const bbContextId = BbContextIdSchema.parse("b".repeat(32));
 
-function candidateInput(canonicalRoot: string) {
+function createInspectionHarness() {
+  const issuedFacts = new WeakMap<object, InspectionSourceCandidateFacts>();
+  const bridge = createInspectionDevelopmentTargetCandidateBridge({
+    clock: () => 1_000,
+    readIssuedSourceCandidate(candidate) {
+      if (typeof candidate !== "object" || candidate === null) {
+        throw new RuntimeError("invalid_request");
+      }
+      const value = issuedFacts.get(candidate);
+      if (!value) throw new RuntimeError("invalid_request");
+      return Object.freeze({ ...value });
+    },
+  });
+  return {
+    bridge,
+    issueSourceCandidate(
+      value: InspectionSourceCandidateFacts,
+      claims: object = {},
+    ) {
+      const candidate = Object.freeze({ ...value, ...claims });
+      issuedFacts.set(candidate, Object.freeze({ ...value }));
+      return candidate;
+    },
+  };
+}
+
+function facts(canonicalRoot: string) {
   return {
     rootKey: OpaqueIdSchema.parse("r".repeat(32)),
     rootKind: "current-project" as const,
     canonicalRoot,
-    target: {
-      displayName: "Notes",
-      displayPath: "plugins/notes",
-      sourceKind: "workspace-discovered" as const,
-      manifest: {
-        pluginId: "notes",
-        packageName: "bb-plugin-notes",
-        version: "1.2.3",
-        hasServer: true,
-        hasApp: true,
-      },
-      native: { status: "absent" as const, observedAt: 1_000 },
-      capabilities: { fixture: true, harness: false, live: false },
-    },
+    displayName: "Notes",
+    displayPath: "plugins/notes",
+    packageName: "bb-plugin-notes",
+    version: "1.2.3",
+    pluginId: "notes",
+    hasServer: true,
+    hasApp: true,
   };
 }
 
@@ -47,7 +70,7 @@ afterEach(async () => {
 });
 
 describe("DevelopmentTargetCatalog capability boundary", () => {
-  test("rejects raw and cloned candidates before direct catalog mutation", async () => {
+  test("persists only derived facts from an exact inspection and runtime capability", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(
       path.join(temporaryRoot, "bb-mate-catalog-capability-"),
@@ -56,32 +79,51 @@ describe("DevelopmentTargetCatalog capability boundary", () => {
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
     const canonicalRoot = await fs.realpath(pluginRoot);
-    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection(
-      candidateInput(canonicalRoot),
-    );
+    const harness = createInspectionHarness();
+    const source = harness.issueSourceCandidate(facts(canonicalRoot), {
+      native: { status: "exact-path", pluginId: "spoofed" },
+      capabilities: { fixture: true, harness: true, live: true },
+      target: { displayName: "Spoofed target", live: true },
+    });
+    const issued = await harness.bridge.issue(source);
     const catalog = await openDevelopmentTargetCatalog({
       dataRoot: path.join(parent, "data"),
       id: () => ObjectIdSchema.parse("t".repeat(32)),
       clock: () => 1_000,
     });
     try {
+      await expect(
+        harness.bridge.issue(facts(canonicalRoot)),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+      await expect(harness.bridge.issue({ ...source })).rejects.toMatchObject({
+        code: "invalid_request",
+      });
       for (const forged of [
-        candidateInput(canonicalRoot),
         { ...issued },
         Object.create(issued) as unknown,
         Object.fromEntries(Object.entries(issued)),
       ]) {
         await expect(
-          Promise.resolve().then(() =>
-            catalog.refresh({
-              principalId,
-              bbContextId,
-              candidate: forged as never,
-            }),
-          ),
+          catalog.refresh({
+            principalId,
+            bbContextId,
+            candidate: forged as never,
+          }),
         ).rejects.toMatchObject({ code: "invalid_request" });
       }
       expect(catalog.list({ principalId, bbContextId })).toEqual([]);
+
+      const persisted = await catalog.refresh({
+        principalId,
+        bbContextId,
+        candidate: issued,
+      });
+      expect(persisted.payload).toMatchObject({
+        native: { status: "absent", observedAt: 1_000 },
+        capabilities: { fixture: false, harness: false, live: false },
+      });
+      expect(JSON.stringify(persisted)).not.toContain("spoofed");
+      expect(JSON.stringify(persisted)).not.toContain("Spoofed target");
     } finally {
       catalog.close();
     }

--- a/packages/runtime/src/discovery/catalog.test.ts
+++ b/packages/runtime/src/discovery/catalog.test.ts
@@ -10,7 +10,7 @@ import {
   PrincipalIdSchema,
 } from "../contracts/ids.ts";
 import { openDevelopmentTargetCatalog } from "./catalog.ts";
-import { issueTrustedDevelopmentTargetCandidate } from "./trusted-candidate.ts";
+import { issueTrustedDevelopmentTargetCandidateFromInspection } from "./trusted-candidate.ts";
 
 const temporaryRoots: string[] = [];
 const principalId = PrincipalIdSchema.parse("p".repeat(32));
@@ -56,7 +56,7 @@ describe("DevelopmentTargetCatalog capability boundary", () => {
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
     const canonicalRoot = await fs.realpath(pluginRoot);
-    const issued = await issueTrustedDevelopmentTargetCandidate(
+    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection(
       candidateInput(canonicalRoot),
     );
     const catalog = await openDevelopmentTargetCatalog({

--- a/packages/runtime/src/discovery/catalog.test.ts
+++ b/packages/runtime/src/discovery/catalog.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../contracts/ids.ts";
 import { RuntimeError } from "../errors.ts";
 import { openDevelopmentTargetCatalog } from "./catalog.ts";
+import { inspectDevelopmentSourceIdentity } from "./source-identity.ts";
 import {
   createInspectionDevelopmentTargetCandidateBridge,
   type InspectionSourceCandidateFacts,
@@ -22,15 +23,42 @@ const bbContextId = BbContextIdSchema.parse("b".repeat(32));
 
 function createInspectionHarness() {
   const issuedFacts = new WeakMap<object, InspectionSourceCandidateFacts>();
+  const activeTransitions = new WeakMap<object, unknown>();
   const bridge = createInspectionDevelopmentTargetCandidateBridge({
     clock: () => 1_000,
-    readIssuedSourceCandidate(candidate) {
+    async consumeIssuedSourceCandidate(candidate, consumer) {
       if (typeof candidate !== "object" || candidate === null) {
         throw new RuntimeError("invalid_request");
       }
       const value = issuedFacts.get(candidate);
       if (!value) throw new RuntimeError("invalid_request");
-      return Object.freeze({ ...value });
+      issuedFacts.delete(candidate);
+      const identity = await inspectDevelopmentSourceIdentity(
+        value.canonicalRoot,
+      );
+      const transition = Object.freeze({ transition: true });
+      activeTransitions.set(transition, {
+        ...value,
+        directoryIdentity: {
+          canonicalRoot: identity.canonicalRoot,
+          device: identity.device,
+          inode: identity.inode,
+        },
+        manifestIdentity: identity.manifest,
+      });
+      try {
+        return await consumer(transition);
+      } finally {
+        activeTransitions.delete(transition);
+      }
+    },
+    readSourceCandidateTransition(transition) {
+      if (typeof transition !== "object" || transition === null) {
+        throw new RuntimeError("invalid_request");
+      }
+      const value = activeTransitions.get(transition);
+      if (!value) throw new RuntimeError("invalid_request");
+      return value;
     },
   });
   return {
@@ -78,6 +106,10 @@ describe("DevelopmentTargetCatalog capability boundary", () => {
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
+    await fs.writeFile(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({ name: "bb-plugin-notes", version: "1.2.3" }),
+    );
     const canonicalRoot = await fs.realpath(pluginRoot);
     const harness = createInspectionHarness();
     const source = harness.issueSourceCandidate(facts(canonicalRoot), {

--- a/packages/runtime/src/discovery/catalog.test.ts
+++ b/packages/runtime/src/discovery/catalog.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+} from "../contracts/ids.ts";
+import { openDevelopmentTargetCatalog } from "./catalog.ts";
+import { issueTrustedDevelopmentTargetCandidate } from "./trusted-candidate.ts";
+
+const temporaryRoots: string[] = [];
+const principalId = PrincipalIdSchema.parse("p".repeat(32));
+const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+
+function candidateInput(canonicalRoot: string) {
+  return {
+    rootKey: OpaqueIdSchema.parse("r".repeat(32)),
+    rootKind: "current-project" as const,
+    canonicalRoot,
+    target: {
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered" as const,
+      manifest: {
+        pluginId: "notes",
+        packageName: "bb-plugin-notes",
+        version: "1.2.3",
+        hasServer: true,
+        hasApp: true,
+      },
+      native: { status: "absent" as const, observedAt: 1_000 },
+      capabilities: { fixture: true, harness: false, live: false },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("DevelopmentTargetCatalog capability boundary", () => {
+  test("rejects raw and cloned candidates before direct catalog mutation", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-catalog-capability-"),
+    );
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    await fs.mkdir(pluginRoot);
+    const canonicalRoot = await fs.realpath(pluginRoot);
+    const issued = await issueTrustedDevelopmentTargetCandidate(
+      candidateInput(canonicalRoot),
+    );
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: path.join(parent, "data"),
+      id: () => ObjectIdSchema.parse("t".repeat(32)),
+      clock: () => 1_000,
+    });
+    try {
+      for (const forged of [
+        candidateInput(canonicalRoot),
+        { ...issued },
+        Object.create(issued) as unknown,
+        Object.fromEntries(Object.entries(issued)),
+      ]) {
+        await expect(
+          Promise.resolve().then(() =>
+            catalog.refresh({
+              principalId,
+              bbContextId,
+              candidate: forged as never,
+            }),
+          ),
+        ).rejects.toMatchObject({ code: "invalid_request" });
+      }
+      expect(catalog.list({ principalId, bbContextId })).toEqual([]);
+    } finally {
+      catalog.close();
+    }
+  });
+});

--- a/packages/runtime/src/discovery/catalog.ts
+++ b/packages/runtime/src/discovery/catalog.ts
@@ -1,0 +1,172 @@
+import {
+  BbContextIdSchema,
+  createOpaqueId,
+  ObjectIdSchema,
+  PrincipalIdSchema,
+  TargetIdSchema,
+  type BbContextId,
+  type ObjectId,
+  type PrincipalId,
+} from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
+import { openRuntimeDatabase } from "../persistence/database.ts";
+import { RUNTIME_MIGRATIONS } from "../persistence/runtime-migrations.ts";
+import { createDevelopmentTargetCatalogStorage } from "./catalog-storage.ts";
+import {
+  parseDevelopmentTargetEnvelope,
+  type DevelopmentTargetEnvelope,
+} from "./development-target.ts";
+import {
+  validateTrustedDevelopmentTargetCandidate,
+  type DevelopmentTargetRootKind,
+  type TrustedDevelopmentTargetCandidate,
+} from "./trusted-candidate.ts";
+
+export interface OpenDevelopmentTargetCatalogOptions {
+  readonly dataRoot: string;
+  readonly clock?: () => number;
+  readonly id?: () => ObjectId;
+}
+
+export interface PrivateDevelopmentTargetSource {
+  readonly canonicalRoot: string;
+  readonly rootKey: string;
+  readonly rootKind: DevelopmentTargetRootKind;
+}
+
+export interface RefreshDevelopmentTargetInput {
+  readonly principalId: PrincipalId;
+  readonly bbContextId: BbContextId;
+  readonly candidate: TrustedDevelopmentTargetCandidate;
+  readonly expectedRevision?: number;
+}
+
+export interface DevelopmentTargetCatalog {
+  refresh(
+    input: RefreshDevelopmentTargetInput,
+  ): Promise<DevelopmentTargetEnvelope>;
+  list(input: {
+    readonly principalId: PrincipalId;
+    readonly bbContextId: BbContextId;
+  }): readonly DevelopmentTargetEnvelope[];
+  get(input: {
+    readonly principalId: PrincipalId;
+    readonly bbContextId: BbContextId;
+    readonly id: ObjectId;
+  }): DevelopmentTargetEnvelope | undefined;
+  resolvePrivate(input: {
+    readonly principalId: PrincipalId;
+    readonly bbContextId: BbContextId;
+    readonly id: ObjectId;
+  }): PrivateDevelopmentTargetSource | undefined;
+  close(): void;
+}
+
+function storageError(error: unknown): never {
+  if (error instanceof RuntimeError) throw error;
+  throw new RuntimeError("internal", { cause: error });
+}
+
+export async function openDevelopmentTargetCatalog(
+  options: OpenDevelopmentTargetCatalogOptions,
+): Promise<DevelopmentTargetCatalog> {
+  const runtimeDatabase = await openRuntimeDatabase({
+    dataRoot: options.dataRoot,
+    migrations: RUNTIME_MIGRATIONS,
+  });
+  const clock = options.clock ?? Date.now;
+  const id = options.id ?? (() => ObjectIdSchema.parse(createOpaqueId()));
+  const storage = createDevelopmentTargetCatalogStorage(
+    runtimeDatabase.database,
+  );
+
+  try {
+    storage.assertIntegrity();
+  } catch (error) {
+    runtimeDatabase.close();
+    storageError(error);
+  }
+
+  return {
+    async refresh(input) {
+      try {
+        const candidate = await validateTrustedDevelopmentTargetCandidate(
+          input.candidate,
+        );
+        storage.assertIntegrity();
+        const existing = storage.findByRoot(
+          input.principalId,
+          input.bbContextId,
+          candidate.canonicalRoot,
+        );
+        if (existing) {
+          const expectedRevision = input.expectedRevision ?? existing.revision;
+          if (existing.revision !== expectedRevision) {
+            throw new RuntimeError("conflict");
+          }
+          const envelope = parseDevelopmentTargetEnvelope({
+            ...existing,
+            revision: existing.revision + 1,
+            updatedAt: clock(),
+            payload: candidate.target,
+          });
+          storage.persistUpdate(envelope, candidate, expectedRevision);
+          return envelope;
+        }
+        if (input.expectedRevision !== undefined) {
+          throw new RuntimeError("not_found");
+        }
+
+        const objectId = id();
+        const now = clock();
+        const envelope = parseDevelopmentTargetEnvelope({
+          schemaVersion: 1,
+          id: objectId,
+          kind: "development-target",
+          bindings: {
+            principalId: PrincipalIdSchema.parse(input.principalId),
+            bbContextId: BbContextIdSchema.parse(input.bbContextId),
+            targetId: TargetIdSchema.parse(objectId),
+          },
+          revision: 1,
+          createdAt: now,
+          updatedAt: now,
+          payload: candidate.target,
+        });
+        storage.persistCreation(envelope, candidate);
+        return envelope;
+      } catch (error) {
+        storageError(error);
+      }
+    },
+    list(input) {
+      try {
+        storage.assertIntegrity();
+        return storage.list(input.principalId, input.bbContextId);
+      } catch (error) {
+        storageError(error);
+      }
+    },
+    get(input) {
+      try {
+        storage.assertIntegrity();
+        return storage.get(input.principalId, input.bbContextId, input.id);
+      } catch (error) {
+        storageError(error);
+      }
+    },
+    resolvePrivate(input) {
+      try {
+        storage.assertIntegrity();
+        return storage.resolvePrivate(
+          input.principalId,
+          input.bbContextId,
+          input.id,
+        );
+      } catch (error) {
+        storageError(error);
+      }
+    },
+    close: runtimeDatabase.close,
+  };
+}

--- a/packages/runtime/src/discovery/catalog.ts
+++ b/packages/runtime/src/discovery/catalog.ts
@@ -16,9 +16,9 @@ import {
   parseDevelopmentTargetEnvelope,
   type DevelopmentTargetEnvelope,
 } from "./development-target.ts";
+import type { PrivateDevelopmentTargetSource } from "./private-source.ts";
 import {
   validateTrustedDevelopmentTargetCandidate,
-  type DevelopmentTargetRootKind,
   type TrustedDevelopmentTargetCandidate,
 } from "./trusted-candidate.ts";
 
@@ -28,11 +28,7 @@ export interface OpenDevelopmentTargetCatalogOptions {
   readonly id?: () => ObjectId;
 }
 
-export interface PrivateDevelopmentTargetSource {
-  readonly canonicalRoot: string;
-  readonly rootKey: string;
-  readonly rootKind: DevelopmentTargetRootKind;
-}
+export type { PrivateDevelopmentTargetSource } from "./private-source.ts";
 
 export interface RefreshDevelopmentTargetInput {
   readonly principalId: PrincipalId;

--- a/packages/runtime/src/discovery/development-target.test.ts
+++ b/packages/runtime/src/discovery/development-target.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  PrincipalIdSchema,
+  TargetIdSchema,
+} from "../contracts/ids.ts";
+import {
+  parseDevelopmentTargetEnvelope,
+  projectDevelopmentTarget,
+} from "./development-target.ts";
+import { RuntimeError } from "../errors.ts";
+
+const id = "t".repeat(32);
+
+function envelope() {
+  return {
+    schemaVersion: 1,
+    id: ObjectIdSchema.parse(id),
+    kind: "development-target",
+    bindings: {
+      principalId: PrincipalIdSchema.parse("p".repeat(32)),
+      bbContextId: BbContextIdSchema.parse("b".repeat(32)),
+      targetId: TargetIdSchema.parse(id),
+    },
+    revision: 1,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    payload: {
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered",
+      manifest: {
+        pluginId: "notes",
+        packageName: "bb-plugin-notes",
+        version: "1.2.3",
+        hasServer: true,
+        hasApp: true,
+      },
+      native: {
+        status: "absent",
+        observedAt: 1_000,
+      },
+      capabilities: {
+        fixture: true,
+        harness: false,
+        live: false,
+      },
+    },
+  } as const;
+}
+
+describe("DevelopmentTarget contract", () => {
+  test("parses a strict self-bound v1 envelope and projects only public fields", () => {
+    const parsed = parseDevelopmentTargetEnvelope(envelope());
+
+    expect(projectDevelopmentTarget(parsed)).toEqual({
+      schemaVersion: 1,
+      kind: "development-target",
+      id: TargetIdSchema.parse(id),
+      revision: 1,
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      ...envelope().payload,
+    });
+  });
+
+  test("rejects unbound, oversized, and non-public payload fields", () => {
+    expect(() =>
+      parseDevelopmentTargetEnvelope({
+        ...envelope(),
+        bindings: {
+          ...envelope().bindings,
+          targetId: TargetIdSchema.parse("x".repeat(32)),
+        },
+      }),
+    ).toThrow(new RuntimeError("invalid_request"));
+    expect(() =>
+      parseDevelopmentTargetEnvelope({
+        ...envelope(),
+        payload: { ...envelope().payload, displayName: "x".repeat(129) },
+      }),
+    ).toThrow(new RuntimeError("invalid_request"));
+    expect(() =>
+      parseDevelopmentTargetEnvelope({
+        ...envelope(),
+        payload: { ...envelope().payload, canonicalRoot: "/private/plugin" },
+      }),
+    ).toThrow(new RuntimeError("invalid_request"));
+  });
+});

--- a/packages/runtime/src/discovery/development-target.ts
+++ b/packages/runtime/src/discovery/development-target.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+
+import { TargetIdSchema, type TargetId } from "../contracts/ids.ts";
+import {
+  defineObjectCodec,
+  ObjectCodecRegistry,
+  type ObjectEnvelope,
+} from "../contracts/objects.ts";
+import { RuntimeError } from "../errors.ts";
+
+const boundedText = (maximum: number) => z.string().trim().min(1).max(maximum);
+
+export const DevelopmentTargetSourceKindSchema = z.enum([
+  "current-project",
+  "workspace-discovered",
+  "explicit",
+  "pinned",
+]);
+
+export const NativeReconciliationStatusSchema = z.enum([
+  "exact-path",
+  "other-path",
+  "managed",
+  "builtin-conflict",
+  "absent",
+  "duplicate",
+  "malformed",
+  "stale",
+]);
+
+const developmentTargetShape = {
+  displayName: boundedText(128),
+  displayPath: boundedText(256).refine(
+    (value) =>
+      !value.startsWith("/") &&
+      !/^[A-Za-z]:[\\/]/u.test(value) &&
+      !value.split(/[\\/]/u).includes(".."),
+    "displayPath must be redacted and relative",
+  ),
+  sourceKind: DevelopmentTargetSourceKindSchema,
+  manifest: z.strictObject({
+    pluginId: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(/^[a-z0-9][a-z0-9-]*$/u),
+    packageName: boundedText(214),
+    version: boundedText(64),
+    hasServer: z.boolean(),
+    hasApp: z.boolean(),
+  }),
+  native: z.strictObject({
+    status: NativeReconciliationStatusSchema,
+    pluginId: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(/^[a-z0-9][a-z0-9-]*$/u)
+      .optional(),
+    observedAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+  }),
+  capabilities: z.strictObject({
+    fixture: z.boolean(),
+    harness: z.boolean(),
+    live: z.boolean(),
+  }),
+} satisfies z.ZodRawShape;
+
+export const DevelopmentTargetPayloadSchema = z.strictObject(
+  developmentTargetShape,
+);
+export type DevelopmentTargetPayload = z.infer<
+  typeof DevelopmentTargetPayloadSchema
+>;
+
+export const DevelopmentTargetCodec = defineObjectCodec(
+  "development-target",
+  developmentTargetShape,
+);
+
+const developmentTargetRegistry = new ObjectCodecRegistry([
+  DevelopmentTargetCodec,
+]);
+
+export type DevelopmentTargetEnvelope = ObjectEnvelope<
+  "development-target",
+  DevelopmentTargetPayload
+>;
+
+export interface DevelopmentTargetProjection extends DevelopmentTargetPayload {
+  readonly schemaVersion: 1;
+  readonly kind: "development-target";
+  readonly id: TargetId;
+  readonly revision: number;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+export function parseDevelopmentTargetEnvelope(
+  input: unknown,
+): DevelopmentTargetEnvelope {
+  const envelope = developmentTargetRegistry.parse(input);
+  if (
+    envelope.kind !== "development-target" ||
+    String(envelope.id) !== String(envelope.bindings.targetId) ||
+    envelope.bindings.sessionId !== undefined
+  ) {
+    throw new RuntimeError("invalid_request");
+  }
+
+  return {
+    ...envelope,
+    kind: "development-target",
+    payload: DevelopmentTargetPayloadSchema.parse(envelope.payload),
+  };
+}
+
+export function projectDevelopmentTarget(
+  envelope: DevelopmentTargetEnvelope,
+): DevelopmentTargetProjection {
+  const parsed = parseDevelopmentTargetEnvelope(envelope);
+  return {
+    schemaVersion: 1,
+    kind: "development-target",
+    id: TargetIdSchema.parse(parsed.id),
+    revision: parsed.revision,
+    createdAt: parsed.createdAt,
+    updatedAt: parsed.updatedAt,
+    ...parsed.payload,
+  };
+}

--- a/packages/runtime/src/discovery/private-source.ts
+++ b/packages/runtime/src/discovery/private-source.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import { OpaqueIdSchema, type OpaqueId } from "../contracts/ids.ts";
+import {
+  DevelopmentTargetRootKindSchema,
+  type DevelopmentTargetRootKind,
+} from "./trusted-candidate.ts";
+import { isCanonicalSourcePathFormat } from "./source-path-policy.ts";
+
+const PrivateDevelopmentTargetSourceSchema = z.strictObject({
+  canonicalRoot: z.string().refine(isCanonicalSourcePathFormat),
+  rootKey: OpaqueIdSchema,
+  rootKind: DevelopmentTargetRootKindSchema,
+});
+
+export interface PrivateDevelopmentTargetSource {
+  readonly canonicalRoot: string;
+  readonly rootKey: OpaqueId;
+  readonly rootKind: DevelopmentTargetRootKind;
+}
+
+export function parsePrivateDevelopmentTargetSource(
+  input: unknown,
+): PrivateDevelopmentTargetSource {
+  return PrivateDevelopmentTargetSourceSchema.parse(input);
+}

--- a/packages/runtime/src/discovery/schema.ts
+++ b/packages/runtime/src/discovery/schema.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+
+import type { RuntimeMigration } from "../persistence/migrations.ts";
+import {
+  verifyOwnedSchema,
+  type ExpectedSchemaEntry,
+} from "../persistence/schema-verification.ts";
+
+const SOURCES_TABLE = `CREATE TABLE development_target_sources (
+    object_id TEXT PRIMARY KEY,
+    principal_id TEXT NOT NULL,
+    bb_context_id TEXT NOT NULL,
+    root_key TEXT NOT NULL,
+    root_kind TEXT NOT NULL CHECK (root_kind IN ('current-project', 'explicit', 'pinned')),
+    canonical_root TEXT NOT NULL,
+    FOREIGN KEY (object_id) REFERENCES runtime_objects(id) ON DELETE RESTRICT,
+    UNIQUE (principal_id, bb_context_id, canonical_root)
+  ) STRICT`;
+
+const SOURCES_INDEX = `CREATE INDEX development_target_sources_context
+    ON development_target_sources (principal_id, bb_context_id, object_id)`;
+
+const SOURCE_SCHEMA_ENTRIES: readonly ExpectedSchemaEntry[] = [
+  {
+    type: "table",
+    name: "development_target_sources",
+    sql: SOURCES_TABLE,
+  },
+  {
+    type: "index",
+    name: "development_target_sources_context",
+    sql: SOURCES_INDEX,
+  },
+];
+const SOURCE_SCHEMA = `${SOURCES_TABLE};\n${SOURCES_INDEX};`;
+
+export const DEVELOPMENT_TARGET_MIGRATIONS: readonly RuntimeMigration[] = [
+  {
+    version: 3,
+    checksum: createHash("sha256").update(SOURCE_SCHEMA).digest("hex"),
+    apply(database) {
+      database.exec(SOURCE_SCHEMA);
+    },
+    verify(database) {
+      verifyOwnedSchema(
+        database,
+        "development_target_sources",
+        SOURCE_SCHEMA_ENTRIES,
+      );
+    },
+  },
+];

--- a/packages/runtime/src/discovery/source-identity.ts
+++ b/packages/runtime/src/discovery/source-identity.ts
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+import { constants, promises as fs } from "node:fs";
+import * as path from "node:path";
+
+const MAX_MANIFEST_BYTES = 256 * 1024;
+
+export interface DevelopmentSourceIdentity {
+  readonly canonicalRoot: string;
+  readonly device: number;
+  readonly inode: number;
+  readonly manifest: {
+    readonly device: number;
+    readonly inode: number;
+    readonly sha256: string;
+  };
+}
+
+export async function inspectDevelopmentSourceIdentity(
+  canonicalRoot: string,
+): Promise<DevelopmentSourceIdentity> {
+  const before = await inspectDirectory(canonicalRoot);
+  const manifest = await inspectManifest(
+    path.join(canonicalRoot, "package.json"),
+  );
+  const after = await inspectDirectory(canonicalRoot);
+  if (!sameIdentity(before, after)) throw new TypeError("source changed");
+  return { ...after, manifest };
+}
+
+export function sameDevelopmentSourceIdentity(
+  left: DevelopmentSourceIdentity,
+  right: DevelopmentSourceIdentity,
+): boolean {
+  return (
+    sameIdentity(left, right) &&
+    left.manifest.device === right.manifest.device &&
+    left.manifest.inode === right.manifest.inode &&
+    left.manifest.sha256 === right.manifest.sha256
+  );
+}
+
+async function inspectDirectory(canonicalRoot: string) {
+  const before = await fs.lstat(canonicalRoot);
+  const resolved = await fs.realpath(canonicalRoot);
+  const after = await fs.lstat(canonicalRoot);
+  if (
+    before.isSymbolicLink() ||
+    !before.isDirectory() ||
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    resolved !== canonicalRoot ||
+    !sameIdentity(before, after)
+  ) {
+    throw new TypeError("invalid source directory");
+  }
+  return {
+    canonicalRoot,
+    device: after.dev,
+    inode: after.ino,
+  };
+}
+
+async function inspectManifest(packagePath: string) {
+  const leaf = await fs.lstat(packagePath);
+  if (
+    leaf.isSymbolicLink() ||
+    !leaf.isFile() ||
+    leaf.size > MAX_MANIFEST_BYTES
+  ) {
+    throw new TypeError("invalid source manifest");
+  }
+  const handle = await fs.open(
+    packagePath,
+    constants.O_RDONLY | constants.O_NOFOLLOW,
+  );
+  try {
+    const before = await handle.stat();
+    if (!sameIdentity(leaf, before)) throw new TypeError("source changed");
+    const buffer = Buffer.allocUnsafe(MAX_MANIFEST_BYTES + 1);
+    let bytesRead = 0;
+    while (bytesRead < buffer.byteLength) {
+      const result = await handle.read(
+        buffer,
+        bytesRead,
+        buffer.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (result.bytesRead === 0) break;
+      bytesRead += result.bytesRead;
+    }
+    if (bytesRead > MAX_MANIFEST_BYTES) {
+      throw new TypeError("source manifest is too large");
+    }
+    const [after, leafAfter] = await Promise.all([
+      handle.stat(),
+      fs.lstat(packagePath),
+    ]);
+    if (
+      !sameIdentity(before, after) ||
+      !sameIdentity(after, leafAfter) ||
+      after.size !== bytesRead
+    ) {
+      throw new TypeError("source changed");
+    }
+    return {
+      device: after.dev,
+      inode: after.ino,
+      sha256: createHash("sha256")
+        .update(buffer.subarray(0, bytesRead))
+        .digest("hex"),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+function sameIdentity(
+  left: { dev?: number; ino?: number; device?: number; inode?: number },
+  right: { dev?: number; ino?: number; device?: number; inode?: number },
+): boolean {
+  return (
+    (left.dev ?? left.device) === (right.dev ?? right.device) &&
+    (left.ino ?? left.inode) === (right.ino ?? right.inode)
+  );
+}

--- a/packages/runtime/src/discovery/source-path-policy.ts
+++ b/packages/runtime/src/discovery/source-path-policy.ts
@@ -1,0 +1,39 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const MAX_CANONICAL_SOURCE_PATH_CHARACTERS = 4_096;
+
+const IGNORED_SOURCE_DIRECTORIES = new Set([
+  "node_modules",
+  "dist",
+  "cache",
+  "caches",
+]);
+
+export function isCanonicalSourcePathFormat(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > MAX_CANONICAL_SOURCE_PATH_CHARACTERS ||
+    !path.isAbsolute(value) ||
+    path.resolve(value) !== value
+  ) {
+    return false;
+  }
+  const root = path.parse(value).root;
+  const home = path.resolve(os.homedir());
+  if (
+    value === root ||
+    value === home ||
+    home.startsWith(`${value}${path.sep}`)
+  ) {
+    return false;
+  }
+  return !path
+    .relative(root, value)
+    .split(path.sep)
+    .some(
+      (segment) =>
+        segment.startsWith(".") || IGNORED_SOURCE_DIRECTORIES.has(segment),
+    );
+}

--- a/packages/runtime/src/discovery/trusted-candidate.test.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.test.ts
@@ -6,6 +6,10 @@ import * as path from "node:path";
 import { OpaqueIdSchema } from "../contracts/ids.ts";
 import { RuntimeError } from "../errors.ts";
 import {
+  inspectDevelopmentSourceIdentity,
+  sameDevelopmentSourceIdentity,
+} from "./source-identity.ts";
+import {
   createInspectionDevelopmentTargetCandidateBridge,
   validateTrustedDevelopmentTargetCandidate,
   type InspectionSourceCandidateFacts,
@@ -13,17 +17,64 @@ import {
 
 const temporaryRoots: string[] = [];
 
+async function writeManifest(root: string, version = "1.2.3") {
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "bb-plugin-notes", version }),
+  );
+}
+
 function createInspectionHarness(clock = () => 1_000) {
   const issuedFacts = new WeakMap<object, InspectionSourceCandidateFacts>();
+  const consumedCandidates = new WeakSet<object>();
+  const activeTransitions = new WeakMap<object, unknown>();
   const bridge = createInspectionDevelopmentTargetCandidateBridge({
     clock,
-    readIssuedSourceCandidate(candidate) {
+    async consumeIssuedSourceCandidate(candidate, consumer) {
       if (typeof candidate !== "object" || candidate === null) {
         throw new RuntimeError("invalid_request");
       }
       const value = issuedFacts.get(candidate);
+      if (!value || consumedCandidates.has(candidate)) {
+        throw new RuntimeError("invalid_request");
+      }
+      consumedCandidates.add(candidate);
+      const before = await inspectDevelopmentSourceIdentity(
+        value.canonicalRoot,
+      );
+      const transition = Object.freeze({ transition: true });
+      activeTransitions.set(
+        transition,
+        Object.freeze({
+          ...value,
+          directoryIdentity: Object.freeze({
+            canonicalRoot: before.canonicalRoot,
+            device: before.device,
+            inode: before.inode,
+          }),
+          manifestIdentity: Object.freeze({ ...before.manifest }),
+        }),
+      );
+      try {
+        const result = await consumer(transition);
+        const after = await inspectDevelopmentSourceIdentity(
+          value.canonicalRoot,
+        );
+        if (!sameDevelopmentSourceIdentity(before, after)) {
+          throw new RuntimeError("invalid_request");
+        }
+        return result;
+      } finally {
+        activeTransitions.delete(transition);
+      }
+    },
+    readSourceCandidateTransition(transition) {
+      if (typeof transition !== "object" || transition === null) {
+        throw new RuntimeError("invalid_request");
+      }
+      const value = activeTransitions.get(transition);
       if (!value) throw new RuntimeError("invalid_request");
-      return Object.freeze({ ...value });
+      return value;
     },
   });
   return {
@@ -63,25 +114,24 @@ afterEach(async () => {
 });
 
 describe("trusted development-target candidates", () => {
-  test("awaits inspection revalidation before issuing a runtime capability", async () => {
+  test("issues only through an active inspection transition", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
-    const source = Object.freeze({ source: true });
-    const bridge = createInspectionDevelopmentTargetCandidateBridge({
-      clock: () => 1_000,
-      async readIssuedSourceCandidate(candidate) {
-        await Promise.resolve();
-        if (candidate !== source) throw new RuntimeError("invalid_request");
-        return facts(await fs.realpath(pluginRoot));
-      },
-    });
+    await writeManifest(pluginRoot);
+    const harness = createInspectionHarness();
+    const source = harness.issueSourceCandidate(
+      facts(await fs.realpath(pluginRoot)),
+    );
 
-    const issued = await bridge.issue(source);
+    const issued = await harness.bridge.issue(source);
 
     expect(issued.canonicalRoot).toBe(await fs.realpath(pluginRoot));
+    await expect(harness.bridge.issue(source)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
   });
 
   test("derives conservative target state only from an issued inspection candidate", async () => {
@@ -90,6 +140,7 @@ describe("trusted development-target candidates", () => {
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
+    await writeManifest(pluginRoot);
     const canonicalRoot = await fs.realpath(pluginRoot);
     const harness = createInspectionHarness();
     const source = harness.issueSourceCandidate(facts(canonicalRoot), {
@@ -164,6 +215,7 @@ describe("trusted development-target candidates", () => {
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
+    await writeManifest(pluginRoot);
     const harness = createInspectionHarness();
     const issued = await harness.bridge.issue(
       harness.issueSourceCandidate(facts(await fs.realpath(pluginRoot))),
@@ -184,6 +236,24 @@ describe("trusted development-target candidates", () => {
     const originalRoot = path.join(parent, "original-plugin");
     await fs.rename(pluginRoot, originalRoot);
     await fs.mkdir(pluginRoot);
+    await expect(
+      validateTrustedDevelopmentTargetCandidate(issued),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+  });
+
+  test("rejects manifest mutation after runtime issuance and before persistence", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    await fs.mkdir(pluginRoot);
+    await writeManifest(pluginRoot);
+    const harness = createInspectionHarness();
+    const issued = await harness.bridge.issue(
+      harness.issueSourceCandidate(facts(await fs.realpath(pluginRoot))),
+    );
+    await writeManifest(pluginRoot, "9.9.9");
+
     await expect(
       validateTrustedDevelopmentTargetCandidate(issued),
     ).rejects.toMatchObject({ code: "invalid_request" });

--- a/packages/runtime/src/discovery/trusted-candidate.test.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 
 import { OpaqueIdSchema } from "../contracts/ids.ts";
 import {
-  issueTrustedDevelopmentTargetCandidate,
+  issueTrustedDevelopmentTargetCandidateFromInspection,
   validateTrustedDevelopmentTargetCandidate,
 } from "./trusted-candidate.ts";
 
@@ -50,14 +50,14 @@ describe("trusted development-target candidates", () => {
     await fs.mkdir(pluginRoot);
     const canonicalRoot = await fs.realpath(pluginRoot);
 
-    const issued = await issueTrustedDevelopmentTargetCandidate(
+    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection(
       candidate(canonicalRoot),
     );
     expect(Object.fromEntries(Object.entries(issued))).toEqual(
       candidate(canonicalRoot),
     );
     await expect(
-      issueTrustedDevelopmentTargetCandidate({
+      issueTrustedDevelopmentTargetCandidateFromInspection({
         ...candidate(canonicalRoot),
         id: "x".repeat(32),
         bindings: {},
@@ -76,19 +76,41 @@ describe("trusted development-target candidates", () => {
     await fs.symlink(pluginRoot, alias);
 
     await expect(
-      issueTrustedDevelopmentTargetCandidate(candidate(alias)),
+      issueTrustedDevelopmentTargetCandidateFromInspection(candidate(alias)),
     ).rejects.toMatchObject({ code: "invalid_request" });
     await expect(
-      issueTrustedDevelopmentTargetCandidate(
+      issueTrustedDevelopmentTargetCandidateFromInspection(
         candidate(path.join(parent, "missing")),
       ),
     ).rejects.toMatchObject({ code: "invalid_request" });
     await expect(
-      issueTrustedDevelopmentTargetCandidate({
+      issueTrustedDevelopmentTargetCandidateFromInspection({
         ...candidate(await fs.realpath(pluginRoot)),
         rootKind: "explicit",
       }),
     ).rejects.toMatchObject({ code: "invalid_request" });
+  });
+
+  test("rejects filesystem-wide, home, and ignored source roots", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
+    temporaryRoots.push(parent);
+    const ignoredRoot = path.join(parent, "node_modules", "plugin");
+    await fs.mkdir(ignoredRoot, { recursive: true });
+
+    const canonicalHome = await fs.realpath(os.homedir());
+    for (const forbidden of [
+      await fs.realpath(path.parse(parent).root),
+      canonicalHome,
+      path.dirname(canonicalHome),
+      await fs.realpath(ignoredRoot),
+    ]) {
+      await expect(
+        issueTrustedDevelopmentTargetCandidateFromInspection(
+          candidate(forbidden),
+        ),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+    }
   });
 
   test("recognizes only the exact issued capability and rejects structural clones", async () => {
@@ -97,7 +119,7 @@ describe("trusted development-target candidates", () => {
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
-    const issued = await issueTrustedDevelopmentTargetCandidate(
+    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection(
       candidate(await fs.realpath(pluginRoot)),
     );
 
@@ -114,7 +136,9 @@ describe("trusted development-target candidates", () => {
         validateTrustedDevelopmentTargetCandidate(forged),
       ).rejects.toMatchObject({ code: "invalid_request" });
     }
-    await fs.rm(pluginRoot, { recursive: true });
+    const originalRoot = path.join(parent, "original-plugin");
+    await fs.rename(pluginRoot, originalRoot);
+    await fs.mkdir(pluginRoot);
     await expect(
       validateTrustedDevelopmentTargetCandidate(issued),
     ).rejects.toMatchObject({ code: "invalid_request" });

--- a/packages/runtime/src/discovery/trusted-candidate.test.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.test.ts
@@ -4,32 +4,53 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { OpaqueIdSchema } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
 import {
-  issueTrustedDevelopmentTargetCandidateFromInspection,
+  createInspectionDevelopmentTargetCandidateBridge,
   validateTrustedDevelopmentTargetCandidate,
+  type InspectionSourceCandidateFacts,
 } from "./trusted-candidate.ts";
 
 const temporaryRoots: string[] = [];
 
-function candidate(canonicalRoot: string) {
+function createInspectionHarness(clock = () => 1_000) {
+  const issuedFacts = new WeakMap<object, InspectionSourceCandidateFacts>();
+  const bridge = createInspectionDevelopmentTargetCandidateBridge({
+    clock,
+    readIssuedSourceCandidate(candidate) {
+      if (typeof candidate !== "object" || candidate === null) {
+        throw new RuntimeError("invalid_request");
+      }
+      const value = issuedFacts.get(candidate);
+      if (!value) throw new RuntimeError("invalid_request");
+      return Object.freeze({ ...value });
+    },
+  });
+  return {
+    bridge,
+    issueSourceCandidate(
+      value: InspectionSourceCandidateFacts,
+      claims: object = {},
+    ) {
+      const candidate = Object.freeze({ ...value, ...claims });
+      issuedFacts.set(candidate, Object.freeze({ ...value }));
+      return candidate;
+    },
+  };
+}
+
+function facts(canonicalRoot: string) {
   return {
     rootKey: OpaqueIdSchema.parse("r".repeat(32)),
     rootKind: "current-project" as const,
     canonicalRoot,
-    target: {
-      displayName: "Notes",
-      displayPath: "plugins/notes",
-      sourceKind: "workspace-discovered" as const,
-      manifest: {
-        pluginId: "notes",
-        packageName: "bb-plugin-notes",
-        version: "1.2.3",
-        hasServer: true,
-        hasApp: true,
-      },
-      native: { status: "absent" as const, observedAt: 1_000 },
-      capabilities: { fixture: true, harness: false, live: false },
-    },
+    displayName: "Notes",
+    displayPath: "plugins/notes",
+    packageName: "bb-plugin-notes",
+    version: "1.2.3",
+    pluginId: "notes",
+    hasServer: true,
+    hasApp: true,
   };
 }
 
@@ -42,31 +63,58 @@ afterEach(async () => {
 });
 
 describe("trusted development-target candidates", () => {
-  test("accepts only an existing canonical directory with no caller identity fields", async () => {
+  test("awaits inspection revalidation before issuing a runtime capability", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    await fs.mkdir(pluginRoot);
+    const source = Object.freeze({ source: true });
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      clock: () => 1_000,
+      async readIssuedSourceCandidate(candidate) {
+        await Promise.resolve();
+        if (candidate !== source) throw new RuntimeError("invalid_request");
+        return facts(await fs.realpath(pluginRoot));
+      },
+    });
+
+    const issued = await bridge.issue(source);
+
+    expect(issued.canonicalRoot).toBe(await fs.realpath(pluginRoot));
+  });
+
+  test("derives conservative target state only from an issued inspection candidate", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
     const canonicalRoot = await fs.realpath(pluginRoot);
+    const harness = createInspectionHarness();
+    const source = harness.issueSourceCandidate(facts(canonicalRoot), {
+      native: { status: "exact-path" },
+      capabilities: { fixture: true, harness: true, live: true },
+    });
 
-    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection(
-      candidate(canonicalRoot),
-    );
-    expect(Object.fromEntries(Object.entries(issued))).toEqual(
-      candidate(canonicalRoot),
-    );
+    const issued = await harness.bridge.issue(source);
+
+    expect(issued.target).toMatchObject({
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered",
+      native: { status: "absent", observedAt: 1_000 },
+      capabilities: { fixture: false, harness: false, live: false },
+    });
     await expect(
-      issueTrustedDevelopmentTargetCandidateFromInspection({
-        ...candidate(canonicalRoot),
-        id: "x".repeat(32),
-        bindings: {},
-        path: canonicalRoot,
-      }),
+      harness.bridge.issue(facts(canonicalRoot)),
     ).rejects.toMatchObject({ code: "invalid_request" });
+    await expect(harness.bridge.issue({ ...source })).rejects.toMatchObject({
+      code: "invalid_request",
+    });
   });
 
-  test("rejects missing roots, symlink aliases, and mismatched admission kinds", async () => {
+  test("rejects missing roots, symlink aliases, and invalid discovery facts", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
     temporaryRoots.push(parent);
@@ -74,21 +122,18 @@ describe("trusted development-target candidates", () => {
     const alias = path.join(parent, "alias");
     await fs.mkdir(pluginRoot);
     await fs.symlink(pluginRoot, alias);
+    const harness = createInspectionHarness();
 
-    await expect(
-      issueTrustedDevelopmentTargetCandidateFromInspection(candidate(alias)),
-    ).rejects.toMatchObject({ code: "invalid_request" });
-    await expect(
-      issueTrustedDevelopmentTargetCandidateFromInspection(
-        candidate(path.join(parent, "missing")),
-      ),
-    ).rejects.toMatchObject({ code: "invalid_request" });
-    await expect(
-      issueTrustedDevelopmentTargetCandidateFromInspection({
-        ...candidate(await fs.realpath(pluginRoot)),
-        rootKind: "explicit",
-      }),
-    ).rejects.toMatchObject({ code: "invalid_request" });
+    for (const invalidFacts of [
+      facts(alias),
+      facts(path.join(parent, "missing")),
+      { ...facts(await fs.realpath(pluginRoot)), rootKind: "unknown" },
+    ]) {
+      const source = harness.issueSourceCandidate(invalidFacts as never);
+      await expect(harness.bridge.issue(source)).rejects.toMatchObject({
+        code: "invalid_request",
+      });
+    }
   });
 
   test("rejects filesystem-wide, home, and ignored source roots", async () => {
@@ -97,37 +142,37 @@ describe("trusted development-target candidates", () => {
     temporaryRoots.push(parent);
     const ignoredRoot = path.join(parent, "node_modules", "plugin");
     await fs.mkdir(ignoredRoot, { recursive: true });
-
     const canonicalHome = await fs.realpath(os.homedir());
+    const harness = createInspectionHarness();
+
     for (const forbidden of [
       await fs.realpath(path.parse(parent).root),
       canonicalHome,
       path.dirname(canonicalHome),
       await fs.realpath(ignoredRoot),
     ]) {
-      await expect(
-        issueTrustedDevelopmentTargetCandidateFromInspection(
-          candidate(forbidden),
-        ),
-      ).rejects.toMatchObject({ code: "invalid_request" });
+      const source = harness.issueSourceCandidate(facts(forbidden));
+      await expect(harness.bridge.issue(source)).rejects.toMatchObject({
+        code: "invalid_request",
+      });
     }
   });
 
-  test("recognizes only the exact issued capability and rejects structural clones", async () => {
+  test("recognizes only the exact runtime capability and its source identity", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
     temporaryRoots.push(parent);
     const pluginRoot = path.join(parent, "plugin");
     await fs.mkdir(pluginRoot);
-    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection(
-      candidate(await fs.realpath(pluginRoot)),
+    const harness = createInspectionHarness();
+    const issued = await harness.bridge.issue(
+      harness.issueSourceCandidate(facts(await fs.realpath(pluginRoot))),
     );
 
     await expect(
       validateTrustedDevelopmentTargetCandidate(issued),
     ).resolves.toBe(issued);
     for (const forged of [
-      candidate(await fs.realpath(pluginRoot)),
       { ...issued },
       Object.create(issued) as unknown,
       Object.fromEntries(Object.entries(issued)),

--- a/packages/runtime/src/discovery/trusted-candidate.test.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import {
+  issueTrustedDevelopmentTargetCandidate,
+  validateTrustedDevelopmentTargetCandidate,
+} from "./trusted-candidate.ts";
+
+const temporaryRoots: string[] = [];
+
+function candidate(canonicalRoot: string) {
+  return {
+    rootKey: OpaqueIdSchema.parse("r".repeat(32)),
+    rootKind: "current-project" as const,
+    canonicalRoot,
+    target: {
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered" as const,
+      manifest: {
+        pluginId: "notes",
+        packageName: "bb-plugin-notes",
+        version: "1.2.3",
+        hasServer: true,
+        hasApp: true,
+      },
+      native: { status: "absent" as const, observedAt: 1_000 },
+      capabilities: { fixture: true, harness: false, live: false },
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("trusted development-target candidates", () => {
+  test("accepts only an existing canonical directory with no caller identity fields", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    await fs.mkdir(pluginRoot);
+    const canonicalRoot = await fs.realpath(pluginRoot);
+
+    const issued = await issueTrustedDevelopmentTargetCandidate(
+      candidate(canonicalRoot),
+    );
+    expect(Object.fromEntries(Object.entries(issued))).toEqual(
+      candidate(canonicalRoot),
+    );
+    await expect(
+      issueTrustedDevelopmentTargetCandidate({
+        ...candidate(canonicalRoot),
+        id: "x".repeat(32),
+        bindings: {},
+        path: canonicalRoot,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+  });
+
+  test("rejects missing roots, symlink aliases, and mismatched admission kinds", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    const alias = path.join(parent, "alias");
+    await fs.mkdir(pluginRoot);
+    await fs.symlink(pluginRoot, alias);
+
+    await expect(
+      issueTrustedDevelopmentTargetCandidate(candidate(alias)),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+    await expect(
+      issueTrustedDevelopmentTargetCandidate(
+        candidate(path.join(parent, "missing")),
+      ),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+    await expect(
+      issueTrustedDevelopmentTargetCandidate({
+        ...candidate(await fs.realpath(pluginRoot)),
+        rootKind: "explicit",
+      }),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+  });
+
+  test("recognizes only the exact issued capability and rejects structural clones", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(path.join(temporaryRoot, "bb-mate-root-"));
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    await fs.mkdir(pluginRoot);
+    const issued = await issueTrustedDevelopmentTargetCandidate(
+      candidate(await fs.realpath(pluginRoot)),
+    );
+
+    await expect(
+      validateTrustedDevelopmentTargetCandidate(issued),
+    ).resolves.toBe(issued);
+    for (const forged of [
+      candidate(await fs.realpath(pluginRoot)),
+      { ...issued },
+      Object.create(issued) as unknown,
+      Object.fromEntries(Object.entries(issued)),
+    ]) {
+      await expect(
+        validateTrustedDevelopmentTargetCandidate(forged),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+    }
+    await fs.rm(pluginRoot, { recursive: true });
+    await expect(
+      validateTrustedDevelopmentTargetCandidate(issued),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+  });
+});

--- a/packages/runtime/src/discovery/trusted-candidate.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.ts
@@ -1,5 +1,3 @@
-import * as fs from "node:fs/promises";
-
 import { z } from "zod";
 
 import { OpaqueIdSchema, type OpaqueId } from "../contracts/ids.ts";
@@ -9,6 +7,11 @@ import {
   type DevelopmentTargetPayload,
 } from "./development-target.ts";
 import { isCanonicalSourcePathFormat } from "./source-path-policy.ts";
+import {
+  inspectDevelopmentSourceIdentity,
+  sameDevelopmentSourceIdentity,
+  type DevelopmentSourceIdentity,
+} from "./source-identity.ts";
 
 export const DevelopmentTargetRootKindSchema = z.enum([
   "current-project",
@@ -22,13 +25,7 @@ export type DevelopmentTargetRootKind = z.infer<
 const trustedCandidateBrand: unique symbol = Symbol(
   "bb-mate.trusted-development-target-candidate",
 );
-interface IssuedSourceIdentity {
-  readonly canonicalRoot: string;
-  readonly device: number;
-  readonly inode: number;
-}
-
-const issuedCandidates = new WeakMap<object, IssuedSourceIdentity>();
+const issuedCandidates = new WeakMap<object, DevelopmentSourceIdentity>();
 
 const TrustedDevelopmentTargetCandidateSchema = z.strictObject({
   rootKey: OpaqueIdSchema,
@@ -50,6 +47,20 @@ const InspectionSourceCandidateFactsSchema = z.strictObject({
   hasApp: z.boolean(),
 });
 
+const SourceCandidateTransitionFactsSchema =
+  InspectionSourceCandidateFactsSchema.extend({
+    directoryIdentity: z.strictObject({
+      canonicalRoot: z.string(),
+      device: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+      inode: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    }),
+    manifestIdentity: z.strictObject({
+      device: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+      inode: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+      sha256: z.string().regex(/^[0-9a-f]{64}$/u),
+    }),
+  });
+
 export type InspectionSourceCandidateFacts = z.infer<
   typeof InspectionSourceCandidateFactsSchema
 >;
@@ -66,35 +77,8 @@ export interface TrustedDevelopmentTargetCandidate {
   readonly [trustedCandidateBrand]: true;
 }
 
-async function inspectCanonicalRoot(
-  canonicalRoot: string,
-): Promise<IssuedSourceIdentity> {
-  const before = await fs.lstat(canonicalRoot);
-  const resolvedRoot = await fs.realpath(canonicalRoot);
-  const after = await fs.lstat(canonicalRoot);
-  const resolvedRootAfter = await fs.realpath(canonicalRoot);
-  if (
-    !isCanonicalSourcePathFormat(canonicalRoot) ||
-    before.isSymbolicLink() ||
-    !before.isDirectory() ||
-    after.isSymbolicLink() ||
-    !after.isDirectory() ||
-    resolvedRoot !== canonicalRoot ||
-    resolvedRootAfter !== resolvedRoot ||
-    before.dev !== after.dev ||
-    before.ino !== after.ino
-  ) {
-    throw new RuntimeError("invalid_request");
-  }
-  return {
-    canonicalRoot,
-    device: after.dev,
-    inode: after.ino,
-  };
-}
-
 async function issueTrustedDevelopmentTargetCandidate(
-  input: InspectionSourceCandidateFacts,
+  input: z.infer<typeof SourceCandidateTransitionFactsSchema>,
   observedAt: number,
 ): Promise<TrustedDevelopmentTargetCandidate> {
   try {
@@ -134,7 +118,19 @@ async function issueTrustedDevelopmentTargetCandidate(
       throw new RuntimeError("invalid_request");
     }
 
-    const identity = await inspectCanonicalRoot(candidate.canonicalRoot);
+    const identity = await inspectDevelopmentSourceIdentity(
+      candidate.canonicalRoot,
+    );
+    const expectedIdentity: DevelopmentSourceIdentity = {
+      ...input.directoryIdentity,
+      manifest: input.manifestIdentity,
+    };
+    if (
+      input.directoryIdentity.canonicalRoot !== input.canonicalRoot ||
+      !sameDevelopmentSourceIdentity(identity, expectedIdentity)
+    ) {
+      throw new RuntimeError("invalid_request");
+    }
     const issued = Object.freeze({
       ...candidate,
       target: Object.freeze({
@@ -153,26 +149,51 @@ async function issueTrustedDevelopmentTargetCandidate(
 }
 
 export function createInspectionDevelopmentTargetCandidateBridge(options: {
-  readonly readIssuedSourceCandidate: (
+  readonly consumeIssuedSourceCandidate: (
     candidate: unknown,
+    consumer: (transition: unknown) => unknown | Promise<unknown>,
   ) => unknown | Promise<unknown>;
+  readonly readSourceCandidateTransition: (transition: unknown) => unknown;
   readonly clock?: () => number;
 }): InspectionDevelopmentTargetCandidateBridge {
-  if (typeof options.readIssuedSourceCandidate !== "function") {
-    throw new TypeError("Inspection candidate reader must be a function");
+  if (
+    typeof options.consumeIssuedSourceCandidate !== "function" ||
+    typeof options.readSourceCandidateTransition !== "function"
+  ) {
+    throw new TypeError("Inspection transition functions must be provided");
   }
   const clock = options.clock ?? Date.now;
   return Object.freeze({
     async issue(candidate: unknown) {
       try {
-        const facts = InspectionSourceCandidateFactsSchema.parse(
-          await options.readIssuedSourceCandidate(candidate),
+        let consumed = false;
+        const issued = await options.consumeIssuedSourceCandidate(
+          candidate,
+          async (transition) => {
+            if (consumed) throw new RuntimeError("invalid_request");
+            consumed = true;
+            const facts = SourceCandidateTransitionFactsSchema.parse(
+              options.readSourceCandidateTransition(transition),
+            );
+            const observedAt = clock();
+            if (!Number.isSafeInteger(observedAt) || observedAt < 0) {
+              throw new RuntimeError("invalid_request");
+            }
+            return await issueTrustedDevelopmentTargetCandidate(
+              facts,
+              observedAt,
+            );
+          },
         );
-        const observedAt = clock();
-        if (!Number.isSafeInteger(observedAt) || observedAt < 0) {
+        if (
+          !consumed ||
+          typeof issued !== "object" ||
+          issued === null ||
+          !issuedCandidates.has(issued)
+        ) {
           throw new RuntimeError("invalid_request");
         }
-        return await issueTrustedDevelopmentTargetCandidate(facts, observedAt);
+        return issued as TrustedDevelopmentTargetCandidate;
       } catch (error) {
         if (error instanceof RuntimeError) throw error;
         throw new RuntimeError("invalid_request", { cause: error });
@@ -194,12 +215,10 @@ export async function validateTrustedDevelopmentTargetCandidate(
   const candidate = input as TrustedDevelopmentTargetCandidate;
   const expectedIdentity = issuedCandidates.get(candidate)!;
   try {
-    const actualIdentity = await inspectCanonicalRoot(candidate.canonicalRoot);
-    if (
-      actualIdentity.canonicalRoot !== expectedIdentity.canonicalRoot ||
-      actualIdentity.device !== expectedIdentity.device ||
-      actualIdentity.inode !== expectedIdentity.inode
-    ) {
+    const actualIdentity = await inspectDevelopmentSourceIdentity(
+      candidate.canonicalRoot,
+    );
+    if (!sameDevelopmentSourceIdentity(actualIdentity, expectedIdentity)) {
       throw new RuntimeError("invalid_request");
     }
     return candidate;

--- a/packages/runtime/src/discovery/trusted-candidate.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.ts
@@ -37,6 +37,27 @@ const TrustedDevelopmentTargetCandidateSchema = z.strictObject({
   target: DevelopmentTargetPayloadSchema,
 });
 
+const InspectionSourceCandidateFactsSchema = z.strictObject({
+  rootKey: OpaqueIdSchema,
+  rootKind: DevelopmentTargetRootKindSchema,
+  canonicalRoot: z.string(),
+  displayPath: z.string(),
+  packageName: z.string(),
+  version: z.string(),
+  pluginId: z.string(),
+  displayName: z.string(),
+  hasServer: z.boolean(),
+  hasApp: z.boolean(),
+});
+
+export type InspectionSourceCandidateFacts = z.infer<
+  typeof InspectionSourceCandidateFactsSchema
+>;
+
+export interface InspectionDevelopmentTargetCandidateBridge {
+  issue(candidate: unknown): Promise<TrustedDevelopmentTargetCandidate>;
+}
+
 export interface TrustedDevelopmentTargetCandidate {
   readonly rootKey: OpaqueId;
   readonly rootKind: DevelopmentTargetRootKind;
@@ -72,11 +93,34 @@ async function inspectCanonicalRoot(
   };
 }
 
-export async function issueTrustedDevelopmentTargetCandidateFromInspection(
-  input: unknown,
+async function issueTrustedDevelopmentTargetCandidate(
+  input: InspectionSourceCandidateFacts,
+  observedAt: number,
 ): Promise<TrustedDevelopmentTargetCandidate> {
   try {
-    const candidate = TrustedDevelopmentTargetCandidateSchema.parse(input);
+    const sourceKind =
+      input.rootKind === "current-project"
+        ? "workspace-discovered"
+        : input.rootKind;
+    const candidate = TrustedDevelopmentTargetCandidateSchema.parse({
+      rootKey: input.rootKey,
+      rootKind: input.rootKind,
+      canonicalRoot: input.canonicalRoot,
+      target: {
+        displayName: input.displayName,
+        displayPath: input.displayPath,
+        sourceKind,
+        manifest: {
+          pluginId: input.pluginId,
+          packageName: input.packageName,
+          version: input.version,
+          hasServer: input.hasServer,
+          hasApp: input.hasApp,
+        },
+        native: { status: "absent", observedAt },
+        capabilities: { fixture: false, harness: false, live: false },
+      },
+    });
     if (
       !isCanonicalSourcePathFormat(candidate.canonicalRoot) ||
       (candidate.rootKind === "explicit" &&
@@ -106,6 +150,35 @@ export async function issueTrustedDevelopmentTargetCandidateFromInspection(
     if (error instanceof RuntimeError) throw error;
     throw new RuntimeError("invalid_request", { cause: error });
   }
+}
+
+export function createInspectionDevelopmentTargetCandidateBridge(options: {
+  readonly readIssuedSourceCandidate: (
+    candidate: unknown,
+  ) => unknown | Promise<unknown>;
+  readonly clock?: () => number;
+}): InspectionDevelopmentTargetCandidateBridge {
+  if (typeof options.readIssuedSourceCandidate !== "function") {
+    throw new TypeError("Inspection candidate reader must be a function");
+  }
+  const clock = options.clock ?? Date.now;
+  return Object.freeze({
+    async issue(candidate: unknown) {
+      try {
+        const facts = InspectionSourceCandidateFactsSchema.parse(
+          await options.readIssuedSourceCandidate(candidate),
+        );
+        const observedAt = clock();
+        if (!Number.isSafeInteger(observedAt) || observedAt < 0) {
+          throw new RuntimeError("invalid_request");
+        }
+        return await issueTrustedDevelopmentTargetCandidate(facts, observedAt);
+      } catch (error) {
+        if (error instanceof RuntimeError) throw error;
+        throw new RuntimeError("invalid_request", { cause: error });
+      }
+    },
+  });
 }
 
 export async function validateTrustedDevelopmentTargetCandidate(

--- a/packages/runtime/src/discovery/trusted-candidate.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs/promises";
-import * as path from "node:path";
 
 import { z } from "zod";
 
@@ -9,6 +8,7 @@ import {
   DevelopmentTargetPayloadSchema,
   type DevelopmentTargetPayload,
 } from "./development-target.ts";
+import { isCanonicalSourcePathFormat } from "./source-path-policy.ts";
 
 export const DevelopmentTargetRootKindSchema = z.enum([
   "current-project",
@@ -22,12 +22,18 @@ export type DevelopmentTargetRootKind = z.infer<
 const trustedCandidateBrand: unique symbol = Symbol(
   "bb-mate.trusted-development-target-candidate",
 );
-const issuedCandidates = new WeakSet<object>();
+interface IssuedSourceIdentity {
+  readonly canonicalRoot: string;
+  readonly device: number;
+  readonly inode: number;
+}
+
+const issuedCandidates = new WeakMap<object, IssuedSourceIdentity>();
 
 const TrustedDevelopmentTargetCandidateSchema = z.strictObject({
   rootKey: OpaqueIdSchema,
   rootKind: DevelopmentTargetRootKindSchema,
-  canonicalRoot: z.string().min(1).max(4_096),
+  canonicalRoot: z.string(),
   target: DevelopmentTargetPayloadSchema,
 });
 
@@ -39,28 +45,40 @@ export interface TrustedDevelopmentTargetCandidate {
   readonly [trustedCandidateBrand]: true;
 }
 
-async function validateCanonicalRoot(canonicalRoot: string): Promise<void> {
-  const [metadata, resolvedRoot] = await Promise.all([
-    fs.lstat(canonicalRoot),
-    fs.realpath(canonicalRoot),
-  ]);
+async function inspectCanonicalRoot(
+  canonicalRoot: string,
+): Promise<IssuedSourceIdentity> {
+  const before = await fs.lstat(canonicalRoot);
+  const resolvedRoot = await fs.realpath(canonicalRoot);
+  const after = await fs.lstat(canonicalRoot);
+  const resolvedRootAfter = await fs.realpath(canonicalRoot);
   if (
-    metadata.isSymbolicLink() ||
-    !metadata.isDirectory() ||
-    resolvedRoot !== canonicalRoot
+    !isCanonicalSourcePathFormat(canonicalRoot) ||
+    before.isSymbolicLink() ||
+    !before.isDirectory() ||
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    resolvedRoot !== canonicalRoot ||
+    resolvedRootAfter !== resolvedRoot ||
+    before.dev !== after.dev ||
+    before.ino !== after.ino
   ) {
     throw new RuntimeError("invalid_request");
   }
+  return {
+    canonicalRoot,
+    device: after.dev,
+    inode: after.ino,
+  };
 }
 
-export async function issueTrustedDevelopmentTargetCandidate(
+export async function issueTrustedDevelopmentTargetCandidateFromInspection(
   input: unknown,
 ): Promise<TrustedDevelopmentTargetCandidate> {
   try {
     const candidate = TrustedDevelopmentTargetCandidateSchema.parse(input);
     if (
-      !path.isAbsolute(candidate.canonicalRoot) ||
-      path.normalize(candidate.canonicalRoot) !== candidate.canonicalRoot ||
+      !isCanonicalSourcePathFormat(candidate.canonicalRoot) ||
       (candidate.rootKind === "explicit" &&
         candidate.target.sourceKind !== "explicit") ||
       (candidate.rootKind === "pinned" &&
@@ -72,7 +90,7 @@ export async function issueTrustedDevelopmentTargetCandidate(
       throw new RuntimeError("invalid_request");
     }
 
-    await validateCanonicalRoot(candidate.canonicalRoot);
+    const identity = await inspectCanonicalRoot(candidate.canonicalRoot);
     const issued = Object.freeze({
       ...candidate,
       target: Object.freeze({
@@ -82,7 +100,7 @@ export async function issueTrustedDevelopmentTargetCandidate(
         capabilities: Object.freeze({ ...candidate.target.capabilities }),
       }),
     }) as TrustedDevelopmentTargetCandidate;
-    issuedCandidates.add(issued);
+    issuedCandidates.set(issued, identity);
     return issued;
   } catch (error) {
     if (error instanceof RuntimeError) throw error;
@@ -101,8 +119,16 @@ export async function validateTrustedDevelopmentTargetCandidate(
     throw new RuntimeError("invalid_request");
   }
   const candidate = input as TrustedDevelopmentTargetCandidate;
+  const expectedIdentity = issuedCandidates.get(candidate)!;
   try {
-    await validateCanonicalRoot(candidate.canonicalRoot);
+    const actualIdentity = await inspectCanonicalRoot(candidate.canonicalRoot);
+    if (
+      actualIdentity.canonicalRoot !== expectedIdentity.canonicalRoot ||
+      actualIdentity.device !== expectedIdentity.device ||
+      actualIdentity.inode !== expectedIdentity.inode
+    ) {
+      throw new RuntimeError("invalid_request");
+    }
     return candidate;
   } catch (error) {
     if (error instanceof RuntimeError) throw error;

--- a/packages/runtime/src/discovery/trusted-candidate.ts
+++ b/packages/runtime/src/discovery/trusted-candidate.ts
@@ -1,0 +1,111 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { z } from "zod";
+
+import { OpaqueIdSchema, type OpaqueId } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
+import {
+  DevelopmentTargetPayloadSchema,
+  type DevelopmentTargetPayload,
+} from "./development-target.ts";
+
+export const DevelopmentTargetRootKindSchema = z.enum([
+  "current-project",
+  "explicit",
+  "pinned",
+]);
+export type DevelopmentTargetRootKind = z.infer<
+  typeof DevelopmentTargetRootKindSchema
+>;
+
+const trustedCandidateBrand: unique symbol = Symbol(
+  "bb-mate.trusted-development-target-candidate",
+);
+const issuedCandidates = new WeakSet<object>();
+
+const TrustedDevelopmentTargetCandidateSchema = z.strictObject({
+  rootKey: OpaqueIdSchema,
+  rootKind: DevelopmentTargetRootKindSchema,
+  canonicalRoot: z.string().min(1).max(4_096),
+  target: DevelopmentTargetPayloadSchema,
+});
+
+export interface TrustedDevelopmentTargetCandidate {
+  readonly rootKey: OpaqueId;
+  readonly rootKind: DevelopmentTargetRootKind;
+  readonly canonicalRoot: string;
+  readonly target: DevelopmentTargetPayload;
+  readonly [trustedCandidateBrand]: true;
+}
+
+async function validateCanonicalRoot(canonicalRoot: string): Promise<void> {
+  const [metadata, resolvedRoot] = await Promise.all([
+    fs.lstat(canonicalRoot),
+    fs.realpath(canonicalRoot),
+  ]);
+  if (
+    metadata.isSymbolicLink() ||
+    !metadata.isDirectory() ||
+    resolvedRoot !== canonicalRoot
+  ) {
+    throw new RuntimeError("invalid_request");
+  }
+}
+
+export async function issueTrustedDevelopmentTargetCandidate(
+  input: unknown,
+): Promise<TrustedDevelopmentTargetCandidate> {
+  try {
+    const candidate = TrustedDevelopmentTargetCandidateSchema.parse(input);
+    if (
+      !path.isAbsolute(candidate.canonicalRoot) ||
+      path.normalize(candidate.canonicalRoot) !== candidate.canonicalRoot ||
+      (candidate.rootKind === "explicit" &&
+        candidate.target.sourceKind !== "explicit") ||
+      (candidate.rootKind === "pinned" &&
+        candidate.target.sourceKind !== "pinned") ||
+      (candidate.rootKind === "current-project" &&
+        candidate.target.sourceKind !== "current-project" &&
+        candidate.target.sourceKind !== "workspace-discovered")
+    ) {
+      throw new RuntimeError("invalid_request");
+    }
+
+    await validateCanonicalRoot(candidate.canonicalRoot);
+    const issued = Object.freeze({
+      ...candidate,
+      target: Object.freeze({
+        ...candidate.target,
+        manifest: Object.freeze({ ...candidate.target.manifest }),
+        native: Object.freeze({ ...candidate.target.native }),
+        capabilities: Object.freeze({ ...candidate.target.capabilities }),
+      }),
+    }) as TrustedDevelopmentTargetCandidate;
+    issuedCandidates.add(issued);
+    return issued;
+  } catch (error) {
+    if (error instanceof RuntimeError) throw error;
+    throw new RuntimeError("invalid_request", { cause: error });
+  }
+}
+
+export async function validateTrustedDevelopmentTargetCandidate(
+  input: unknown,
+): Promise<TrustedDevelopmentTargetCandidate> {
+  if (
+    typeof input !== "object" ||
+    input === null ||
+    !issuedCandidates.has(input)
+  ) {
+    throw new RuntimeError("invalid_request");
+  }
+  const candidate = input as TrustedDevelopmentTargetCandidate;
+  try {
+    await validateCanonicalRoot(candidate.canonicalRoot);
+    return candidate;
+  } catch (error) {
+    if (error instanceof RuntimeError) throw error;
+    throw new RuntimeError("invalid_request", { cause: error });
+  }
+}

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -42,6 +42,9 @@ describe("@bb-mate/runtime public surface", () => {
     expect(runtime).not.toHaveProperty(
       "issueTrustedDevelopmentTargetCandidateFromInspection",
     );
+    expect(runtime).not.toHaveProperty(
+      "createInspectionDevelopmentTargetCandidateBridge",
+    );
     expect(runtime).not.toHaveProperty("openRuntimeDatabase");
     expect(runtime).not.toHaveProperty("applyRuntimeMigrations");
     expect(runtime).not.toHaveProperty("createEventFeed");

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -7,6 +7,11 @@ describe("@bb-mate/runtime public surface", () => {
     expect(Object.keys(runtime).sort()).toEqual([
       "AuthenticatedPrincipalSchema",
       "BbContextIdSchema",
+      "DevelopmentTargetCodec",
+      "DevelopmentTargetPayloadSchema",
+      "DevelopmentTargetRootKindSchema",
+      "DevelopmentTargetSourceKindSchema",
+      "NativeReconciliationStatusSchema",
       "ObjectBindingsSchema",
       "ObjectCodecRegistry",
       "ObjectIdSchema",
@@ -21,12 +26,15 @@ describe("@bb-mate/runtime public surface", () => {
       "TargetIdSchema",
       "authorize",
       "canonicalJson",
+      "createDevelopmentTargetService",
       "createOpaqueId",
       "createRequestContext",
       "createRuntimeHttpHandler",
       "createWorkbenchService",
       "defineObjectCodec",
       "isRequestContext",
+      "issueTrustedDevelopmentTargetCandidate",
+      "openDevelopmentTargetCatalog",
       "openRuntimeStore",
     ]);
   });

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -33,13 +33,15 @@ describe("@bb-mate/runtime public surface", () => {
       "createWorkbenchService",
       "defineObjectCodec",
       "isRequestContext",
-      "issueTrustedDevelopmentTargetCandidate",
       "openDevelopmentTargetCatalog",
       "openRuntimeStore",
     ]);
   });
 
   test("does not expose persistence, event-feed, or schema internals", () => {
+    expect(runtime).not.toHaveProperty(
+      "issueTrustedDevelopmentTargetCandidateFromInspection",
+    );
     expect(runtime).not.toHaveProperty("openRuntimeDatabase");
     expect(runtime).not.toHaveProperty("applyRuntimeMigrations");
     expect(runtime).not.toHaveProperty("createEventFeed");

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -55,10 +55,7 @@ export type {
   PrivateDevelopmentTargetSource,
   RefreshDevelopmentTargetInput,
 } from "./discovery/catalog.ts";
-export {
-  DevelopmentTargetRootKindSchema,
-  issueTrustedDevelopmentTargetCandidate,
-} from "./discovery/trusted-candidate.ts";
+export { DevelopmentTargetRootKindSchema } from "./discovery/trusted-candidate.ts";
 export type {
   DevelopmentTargetRootKind,
   TrustedDevelopmentTargetCandidate,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -37,6 +37,32 @@ export {
   ObjectCodecRegistry,
   ObjectKindSchema,
 } from "./contracts/objects.ts";
+export {
+  DevelopmentTargetCodec,
+  DevelopmentTargetPayloadSchema,
+  DevelopmentTargetSourceKindSchema,
+  NativeReconciliationStatusSchema,
+} from "./discovery/development-target.ts";
+export type {
+  DevelopmentTargetEnvelope,
+  DevelopmentTargetPayload,
+  DevelopmentTargetProjection,
+} from "./discovery/development-target.ts";
+export { openDevelopmentTargetCatalog } from "./discovery/catalog.ts";
+export type {
+  DevelopmentTargetCatalog,
+  OpenDevelopmentTargetCatalogOptions,
+  PrivateDevelopmentTargetSource,
+  RefreshDevelopmentTargetInput,
+} from "./discovery/catalog.ts";
+export {
+  DevelopmentTargetRootKindSchema,
+  issueTrustedDevelopmentTargetCandidate,
+} from "./discovery/trusted-candidate.ts";
+export type {
+  DevelopmentTargetRootKind,
+  TrustedDevelopmentTargetCandidate,
+} from "./discovery/trusted-candidate.ts";
 export type {
   JsonPrimitive,
   JsonValue,
@@ -68,3 +94,4 @@ export type {
   UpdateObjectInput,
 } from "./persistence/store.ts";
 export { createWorkbenchService } from "./service/workbench-service.ts";
+export { createDevelopmentTargetService } from "./service/development-target-service.ts";

--- a/packages/runtime/src/persistence/development-target-schema.test.ts
+++ b/packages/runtime/src/persistence/development-target-schema.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("development-target source schema attestation", () => {
+  test("rejects a missing private-source index without recreating it", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-target-schema-"),
+    );
+    temporaryRoots.push(parent);
+    const dataRoot = path.join(parent, "data");
+    (await openDevelopmentTargetCatalog({ dataRoot })).close();
+
+    const databasePath = path.join(dataRoot, "workbench.sqlite3");
+    const tamper = new Database(databasePath);
+    tamper.exec("DROP INDEX development_target_sources_context");
+    tamper.close();
+
+    await expect(
+      openDevelopmentTargetCatalog({ dataRoot }),
+    ).rejects.toMatchObject({ code: "corrupt_data" });
+
+    const inspect = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        inspect
+          .query(
+            "SELECT name FROM sqlite_schema WHERE name = 'development_target_sources_context'",
+          )
+          .get(),
+      ).toBeNull();
+    } finally {
+      inspect.close();
+    }
+  });
+});

--- a/packages/runtime/src/persistence/runtime-migrations.ts
+++ b/packages/runtime/src/persistence/runtime-migrations.ts
@@ -1,0 +1,10 @@
+import { DEVELOPMENT_TARGET_MIGRATIONS } from "../discovery/schema.ts";
+import { EVENT_MIGRATIONS } from "../events/schema.ts";
+import type { RuntimeMigration } from "./migrations.ts";
+import { OBJECT_MIGRATIONS } from "./schema.ts";
+
+export const RUNTIME_MIGRATIONS: readonly RuntimeMigration[] = [
+  ...OBJECT_MIGRATIONS,
+  ...EVENT_MIGRATIONS,
+  ...DEVELOPMENT_TARGET_MIGRATIONS,
+];

--- a/packages/runtime/src/persistence/store.ts
+++ b/packages/runtime/src/persistence/store.ts
@@ -16,9 +16,8 @@ import {
   type EventPage,
   type PullEventsInput,
 } from "../events/feed.ts";
-import { EVENT_MIGRATIONS } from "../events/schema.ts";
 import { openRuntimeDatabase } from "./database.ts";
-import { OBJECT_MIGRATIONS } from "./schema.ts";
+import { RUNTIME_MIGRATIONS } from "./runtime-migrations.ts";
 
 export interface OpenRuntimeStoreOptions {
   readonly dataRoot: string;
@@ -74,7 +73,7 @@ export async function openRuntimeStore(
 ): Promise<RuntimeStore> {
   const runtimeDatabase = await openRuntimeDatabase({
     dataRoot: options.dataRoot,
-    migrations: [...OBJECT_MIGRATIONS, ...EVENT_MIGRATIONS],
+    migrations: RUNTIME_MIGRATIONS,
   });
   const { database } = runtimeDatabase;
   const clock = options.clock ?? Date.now;

--- a/packages/runtime/src/service/development-target-service.test.ts
+++ b/packages/runtime/src/service/development-target-service.test.ts
@@ -15,7 +15,10 @@ import {
 import { ObjectCodecRegistry } from "../contracts/objects.ts";
 import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
 import { DevelopmentTargetCodec } from "../discovery/development-target.ts";
-import { issueTrustedDevelopmentTargetCandidateFromInspection } from "../discovery/trusted-candidate.ts";
+import {
+  createInspectionDevelopmentTargetCandidateBridge,
+  type InspectionSourceCandidateFacts,
+} from "../discovery/trusted-candidate.ts";
 import { RuntimeError } from "../errors.ts";
 import { openRuntimeStore } from "../persistence/store.ts";
 import { createWorkbenchService } from "./workbench-service.ts";
@@ -26,6 +29,17 @@ const objectId = ObjectIdSchema.parse("t".repeat(32));
 const targetId = TargetIdSchema.parse("t".repeat(32));
 const principalId = PrincipalIdSchema.parse("p".repeat(32));
 const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+
+function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
+  const source = Object.freeze({ ...value });
+  return createInspectionDevelopmentTargetCandidateBridge({
+    clock: () => 1_000,
+    readIssuedSourceCandidate(candidate) {
+      if (candidate !== source) throw new RuntimeError("invalid_request");
+      return Object.freeze({ ...value });
+    },
+  }).issue(source);
+}
 
 async function makeFixture() {
   const temporaryRoot = await fs.realpath(os.tmpdir());
@@ -74,9 +88,35 @@ function candidateInput(canonicalRoot: string) {
 }
 
 async function candidate(canonicalRoot: string) {
-  return issueTrustedDevelopmentTargetCandidateFromInspection(
-    candidateInput(canonicalRoot),
-  );
+  const input = candidateInput(canonicalRoot);
+  return issueInspectionCandidate({
+    rootKey: input.rootKey,
+    rootKind: input.rootKind,
+    canonicalRoot: input.canonicalRoot,
+    displayName: input.target.displayName,
+    displayPath: input.target.displayPath,
+    packageName: input.target.manifest.packageName,
+    version: input.target.manifest.version,
+    pluginId: input.target.manifest.pluginId,
+    hasServer: input.target.manifest.hasServer,
+    hasApp: input.target.manifest.hasApp,
+  });
+}
+
+async function candidateNamed(canonicalRoot: string, displayName: string) {
+  const input = candidateInput(canonicalRoot);
+  return issueInspectionCandidate({
+    rootKey: input.rootKey,
+    rootKind: input.rootKind,
+    canonicalRoot: input.canonicalRoot,
+    displayName,
+    displayPath: input.target.displayPath,
+    packageName: input.target.manifest.packageName,
+    version: input.target.manifest.version,
+    pluginId: input.target.manifest.pluginId,
+    hasServer: input.target.manifest.hasServer,
+    hasApp: input.target.manifest.hasApp,
+  });
 }
 
 afterEach(async () => {
@@ -253,13 +293,7 @@ describe("DevelopmentTargetService", () => {
       );
       const refreshed = await service.refreshFromTrustedCandidate(
         context(),
-        await issueTrustedDevelopmentTargetCandidateFromInspection({
-          ...candidateInput(fixture.pluginRoot),
-          target: {
-            ...candidateInput(fixture.pluginRoot).target,
-            displayName: "Notes refreshed",
-          },
-        }),
+        await candidateNamed(fixture.pluginRoot, "Notes refreshed"),
         { expectedRevision: 1 },
       );
       expect(refreshed.revision).toBe(2);

--- a/packages/runtime/src/service/development-target-service.test.ts
+++ b/packages/runtime/src/service/development-target-service.test.ts
@@ -15,6 +15,7 @@ import {
 import { ObjectCodecRegistry } from "../contracts/objects.ts";
 import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
 import { DevelopmentTargetCodec } from "../discovery/development-target.ts";
+import { inspectDevelopmentSourceIdentity } from "../discovery/source-identity.ts";
 import {
   createInspectionDevelopmentTargetCandidateBridge,
   type InspectionSourceCandidateFacts,
@@ -30,13 +31,35 @@ const targetId = TargetIdSchema.parse("t".repeat(32));
 const principalId = PrincipalIdSchema.parse("p".repeat(32));
 const bbContextId = BbContextIdSchema.parse("b".repeat(32));
 
-function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
+async function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
   const source = Object.freeze({ ...value });
+  const transition = Object.freeze({ transition: true });
+  const identity = await inspectDevelopmentSourceIdentity(value.canonicalRoot);
+  let active = false;
   return createInspectionDevelopmentTargetCandidateBridge({
     clock: () => 1_000,
-    readIssuedSourceCandidate(candidate) {
+    async consumeIssuedSourceCandidate(candidate, consumer) {
       if (candidate !== source) throw new RuntimeError("invalid_request");
-      return Object.freeze({ ...value });
+      active = true;
+      try {
+        return await consumer(transition);
+      } finally {
+        active = false;
+      }
+    },
+    readSourceCandidateTransition(candidate) {
+      if (candidate !== transition || !active) {
+        throw new RuntimeError("invalid_request");
+      }
+      return {
+        ...value,
+        directoryIdentity: {
+          canonicalRoot: identity.canonicalRoot,
+          device: identity.device,
+          inode: identity.inode,
+        },
+        manifestIdentity: identity.manifest,
+      };
     },
   }).issue(source);
 }
@@ -49,6 +72,10 @@ async function makeFixture() {
   temporaryRoots.push(parent);
   const pluginRoot = path.join(parent, "plugin");
   await fs.mkdir(pluginRoot);
+  await fs.writeFile(
+    path.join(pluginRoot, "package.json"),
+    JSON.stringify({ name: "bb-plugin-notes", version: "1.2.3" }),
+  );
   return {
     dataRoot: path.join(parent, "data"),
     pluginRoot: await fs.realpath(pluginRoot),

--- a/packages/runtime/src/service/development-target-service.test.ts
+++ b/packages/runtime/src/service/development-target-service.test.ts
@@ -1,0 +1,441 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { createRequestContext } from "../auth/context.ts";
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+  TargetIdSchema,
+} from "../contracts/ids.ts";
+import { ObjectCodecRegistry } from "../contracts/objects.ts";
+import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
+import { DevelopmentTargetCodec } from "../discovery/development-target.ts";
+import { issueTrustedDevelopmentTargetCandidate } from "../discovery/trusted-candidate.ts";
+import { RuntimeError } from "../errors.ts";
+import { openRuntimeStore } from "../persistence/store.ts";
+import { createWorkbenchService } from "./workbench-service.ts";
+import { createDevelopmentTargetService } from "./development-target-service.ts";
+
+const temporaryRoots: string[] = [];
+const objectId = ObjectIdSchema.parse("t".repeat(32));
+const targetId = TargetIdSchema.parse("t".repeat(32));
+const principalId = PrincipalIdSchema.parse("p".repeat(32));
+const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+
+async function makeFixture() {
+  const temporaryRoot = await fs.realpath(os.tmpdir());
+  const parent = await fs.mkdtemp(
+    path.join(temporaryRoot, "bb-mate-development-target-"),
+  );
+  temporaryRoots.push(parent);
+  const pluginRoot = path.join(parent, "plugin");
+  await fs.mkdir(pluginRoot);
+  return {
+    dataRoot: path.join(parent, "data"),
+    pluginRoot: await fs.realpath(pluginRoot),
+  };
+}
+
+function context() {
+  return createRequestContext({
+    id: principalId,
+    kind: "supervisor",
+    scopes: ["targets:read", "targets:write"],
+    revoked: false,
+    bbContextId,
+  });
+}
+
+function candidateInput(canonicalRoot: string) {
+  return {
+    rootKey: OpaqueIdSchema.parse("r".repeat(32)),
+    rootKind: "current-project" as const,
+    canonicalRoot,
+    target: {
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered" as const,
+      manifest: {
+        pluginId: "notes",
+        packageName: "bb-plugin-notes",
+        version: "1.2.3",
+        hasServer: true,
+        hasApp: true,
+      },
+      native: { status: "absent" as const, observedAt: 1_000 },
+      capabilities: { fixture: true, harness: false, live: false },
+    },
+  };
+}
+
+async function candidate(canonicalRoot: string) {
+  return issueTrustedDevelopmentTargetCandidate(candidateInput(canonicalRoot));
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("DevelopmentTargetService", () => {
+  test("persists and reopens one self-bound target while keeping its root private", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    const service = createDevelopmentTargetService(catalog);
+
+    const created = await service.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    expect(created.id).toBe(targetId);
+    expect(created.revision).toBe(1);
+    expect(service.listTargets(context())).toEqual([created]);
+    expect(
+      catalog.resolvePrivate({
+        principalId,
+        bbContextId,
+        id: ObjectIdSchema.parse(created.id),
+      }),
+    ).toEqual({
+      canonicalRoot: fixture.pluginRoot,
+      rootKey: "r".repeat(32),
+      rootKind: "current-project",
+    });
+    expect(JSON.stringify(created)).not.toContain(fixture.pluginRoot);
+    expect(JSON.stringify(created)).not.toContain("r".repeat(32));
+    expect(JSON.stringify(created)).not.toContain(principalId);
+    expect(JSON.stringify(created)).not.toContain(bbContextId);
+    catalog.close();
+
+    const reopened = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => ObjectIdSchema.parse("u".repeat(32)),
+      clock: () => 2_000,
+    });
+    try {
+      const refreshed = await createDevelopmentTargetService(
+        reopened,
+      ).refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      expect(refreshed.id).toBe(targetId);
+      expect(refreshed.revision).toBe(2);
+      expect(refreshed.updatedAt).toBe(2_000);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  test("default-denies unscoped and target-bound credentials and does not enumerate across subjects", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      const created = await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      expect(service.getTarget(context(), created.id)).toEqual(created);
+
+      const unscoped = createRequestContext({
+        id: principalId,
+        kind: "mcp-client",
+        scopes: [],
+        revoked: false,
+        bbContextId,
+      });
+      expect(() => service.listTargets(unscoped)).toThrow(
+        new RuntimeError("forbidden"),
+      );
+
+      const targetBound = createRequestContext({
+        id: principalId,
+        kind: "plugin-adapter",
+        scopes: ["targets:read"],
+        revoked: false,
+        bbContextId,
+        targetId: TargetIdSchema.parse(objectId),
+      });
+      expect(() => service.listTargets(targetBound)).toThrow(
+        new RuntimeError("forbidden"),
+      );
+
+      const revoked = createRequestContext({
+        id: principalId,
+        kind: "browser-session",
+        scopes: ["targets:read"],
+        revoked: true,
+        bbContextId,
+      });
+      expect(() => service.listTargets(revoked)).toThrow(
+        new RuntimeError("unauthenticated"),
+      );
+
+      const otherSubject = createRequestContext({
+        id: PrincipalIdSchema.parse("q".repeat(32)),
+        kind: "supervisor",
+        scopes: ["targets:read"],
+        revoked: false,
+        bbContextId,
+      });
+      expect(service.listTargets(otherSubject)).toEqual([]);
+      expect(() => service.getTarget(otherSubject, created.id)).toThrow(
+        new RuntimeError("not_found"),
+      );
+    } finally {
+      catalog.close();
+    }
+  });
+
+  test("rejects raw path DTOs and cloned capabilities before catalog mutation", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      const issued = await candidate(fixture.pluginRoot);
+      for (const forged of [
+        candidateInput(fixture.pluginRoot),
+        { ...issued },
+        Object.create(issued) as unknown,
+        Object.fromEntries(Object.entries(issued)),
+      ]) {
+        await expect(
+          service.refreshFromTrustedCandidate(context(), forged as never),
+        ).rejects.toMatchObject({ code: "invalid_request" });
+      }
+      await fs.rm(fixture.pluginRoot, { recursive: true });
+      await expect(
+        service.refreshFromTrustedCandidate(context(), issued),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+      expect(service.listTargets(context())).toEqual([]);
+    } finally {
+      catalog.close();
+    }
+  });
+
+  test("uses optimistic revisions when refreshing a known source root", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      const refreshed = await service.refreshFromTrustedCandidate(
+        context(),
+        await issueTrustedDevelopmentTargetCandidate({
+          ...candidateInput(fixture.pluginRoot),
+          target: {
+            ...candidateInput(fixture.pluginRoot).target,
+            displayName: "Notes refreshed",
+          },
+        }),
+        { expectedRevision: 1 },
+      );
+      expect(refreshed.revision).toBe(2);
+      await expect(
+        service.refreshFromTrustedCandidate(
+          context(),
+          await candidate(fixture.pluginRoot),
+          { expectedRevision: 1 },
+        ),
+      ).rejects.toEqual(new RuntimeError("conflict"));
+      expect(service.getTarget(context(), objectId)).toEqual(refreshed);
+    } finally {
+      catalog.close();
+    }
+  });
+
+  test("rolls back public, private, and event writes atomically", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    const database = new Database(
+      path.join(fixture.dataRoot, "workbench.sqlite3"),
+    );
+    try {
+      database.exec(`
+        CREATE TRIGGER test_fail_target_event
+        BEFORE INSERT ON runtime_events
+        BEGIN
+          SELECT RAISE(ABORT, 'injected failure');
+        END
+      `);
+      await expect(
+        createDevelopmentTargetService(catalog).refreshFromTrustedCandidate(
+          context(),
+          await candidate(fixture.pluginRoot),
+        ),
+      ).rejects.toMatchObject({ code: "internal" });
+      expect(catalog.list({ principalId, bbContextId })).toEqual([]);
+      expect(database.query("SELECT * FROM runtime_objects").all()).toEqual([]);
+      expect(
+        database.query("SELECT * FROM development_target_sources").all(),
+      ).toEqual([]);
+      expect(database.query("SELECT * FROM runtime_events").all()).toEqual([]);
+      database.exec("DROP TRIGGER test_fail_target_event");
+    } finally {
+      database.close();
+      catalog.close();
+    }
+  });
+
+  test("stores the canonical root privately and emits only a redacted event", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    await createDevelopmentTargetService(catalog).refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    catalog.close();
+
+    const database = new Database(
+      path.join(fixture.dataRoot, "workbench.sqlite3"),
+      { readonly: true },
+    );
+    try {
+      const publicRow = database
+        .query<{ payload_json: string }, []>(
+          "SELECT payload_json FROM runtime_objects",
+        )
+        .get()!;
+      const privateRow = database
+        .query<
+          { canonical_root: string; root_key: string; root_kind: string },
+          []
+        >(
+          "SELECT canonical_root, root_key, root_kind FROM development_target_sources",
+        )
+        .get()!;
+      const eventRow = database.query("SELECT * FROM runtime_events").get()!;
+
+      expect(privateRow).toEqual({
+        canonical_root: fixture.pluginRoot,
+        root_key: "r".repeat(32),
+        root_kind: "current-project",
+      });
+      expect(publicRow.payload_json).not.toContain(fixture.pluginRoot);
+      expect(publicRow.payload_json).not.toContain("r".repeat(32));
+      expect(JSON.stringify(eventRow)).not.toContain(fixture.pluginRoot);
+      expect(JSON.stringify(eventRow)).not.toContain("r".repeat(32));
+    } finally {
+      database.close();
+    }
+  });
+
+  test("fails closed without repairing a target whose private source row is missing", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    await createDevelopmentTargetService(catalog).refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    catalog.close();
+
+    const databasePath = path.join(fixture.dataRoot, "workbench.sqlite3");
+    const tamper = new Database(databasePath);
+    tamper.exec("DELETE FROM development_target_sources");
+    tamper.close();
+
+    await expect(
+      openDevelopmentTargetCatalog({
+        dataRoot: fixture.dataRoot,
+        id: () => ObjectIdSchema.parse("u".repeat(32)),
+        clock: () => 2_000,
+      }),
+    ).rejects.toMatchObject({ code: "corrupt_data" });
+
+    const inspect = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        inspect.query("SELECT COUNT(*) AS count FROM runtime_objects").get(),
+      ).toEqual({ count: 1 });
+      expect(
+        inspect
+          .query("SELECT COUNT(*) AS count FROM development_target_sources")
+          .get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      inspect.close();
+    }
+  });
+
+  test("leaves the generic object service target-bound", async () => {
+    const fixture = await makeFixture();
+    const store = await openRuntimeStore({
+      dataRoot: fixture.dataRoot,
+      codecs: new ObjectCodecRegistry([DevelopmentTargetCodec]),
+      id: () => objectId,
+      clock: () => 1_000,
+    });
+    try {
+      const targetBound = createRequestContext({
+        id: principalId,
+        kind: "plugin-adapter",
+        scopes: ["targets:read", "targets:write"],
+        revoked: false,
+        bbContextId,
+        targetId: TargetIdSchema.parse("z".repeat(32)),
+      });
+      expect(() =>
+        createWorkbenchService(store).createObject(targetBound, {
+          kind: "development-target",
+          payload: candidateInput(fixture.pluginRoot).target,
+        }),
+      ).toThrow(new RuntimeError("invalid_request"));
+      expect(() =>
+        createWorkbenchService(store).getObject(targetBound, {
+          id: objectId,
+          kind: "development-target",
+        }),
+      ).toThrow(new RuntimeError("invalid_request"));
+      expect(() =>
+        createWorkbenchService(store).updateObject(targetBound, {
+          id: objectId,
+          kind: "development-target",
+          expectedRevision: 1,
+          payload: candidateInput(fixture.pluginRoot).target,
+        }),
+      ).toThrow(new RuntimeError("invalid_request"));
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/runtime/src/service/development-target-service.test.ts
+++ b/packages/runtime/src/service/development-target-service.test.ts
@@ -15,7 +15,7 @@ import {
 import { ObjectCodecRegistry } from "../contracts/objects.ts";
 import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
 import { DevelopmentTargetCodec } from "../discovery/development-target.ts";
-import { issueTrustedDevelopmentTargetCandidate } from "../discovery/trusted-candidate.ts";
+import { issueTrustedDevelopmentTargetCandidateFromInspection } from "../discovery/trusted-candidate.ts";
 import { RuntimeError } from "../errors.ts";
 import { openRuntimeStore } from "../persistence/store.ts";
 import { createWorkbenchService } from "./workbench-service.ts";
@@ -74,7 +74,9 @@ function candidateInput(canonicalRoot: string) {
 }
 
 async function candidate(canonicalRoot: string) {
-  return issueTrustedDevelopmentTargetCandidate(candidateInput(canonicalRoot));
+  return issueTrustedDevelopmentTargetCandidateFromInspection(
+    candidateInput(canonicalRoot),
+  );
 }
 
 afterEach(async () => {
@@ -110,7 +112,7 @@ describe("DevelopmentTargetService", () => {
       }),
     ).toEqual({
       canonicalRoot: fixture.pluginRoot,
-      rootKey: "r".repeat(32),
+      rootKey: OpaqueIdSchema.parse("r".repeat(32)),
       rootKind: "current-project",
     });
     expect(JSON.stringify(created)).not.toContain(fixture.pluginRoot);
@@ -224,7 +226,9 @@ describe("DevelopmentTargetService", () => {
           service.refreshFromTrustedCandidate(context(), forged as never),
         ).rejects.toMatchObject({ code: "invalid_request" });
       }
-      await fs.rm(fixture.pluginRoot, { recursive: true });
+      const originalRoot = `${fixture.pluginRoot}-original`;
+      await fs.rename(fixture.pluginRoot, originalRoot);
+      await fs.mkdir(fixture.pluginRoot);
       await expect(
         service.refreshFromTrustedCandidate(context(), issued),
       ).rejects.toMatchObject({ code: "invalid_request" });
@@ -249,7 +253,7 @@ describe("DevelopmentTargetService", () => {
       );
       const refreshed = await service.refreshFromTrustedCandidate(
         context(),
-        await issueTrustedDevelopmentTargetCandidate({
+        await issueTrustedDevelopmentTargetCandidateFromInspection({
           ...candidateInput(fixture.pluginRoot),
           target: {
             ...candidateInput(fixture.pluginRoot).target,

--- a/packages/runtime/src/service/development-target-service.ts
+++ b/packages/runtime/src/service/development-target-service.ts
@@ -1,0 +1,78 @@
+import { authorize } from "../auth/authorize.ts";
+import type { RequestContext } from "../auth/context.ts";
+import { ObjectIdSchema, type ObjectId } from "../contracts/ids.ts";
+import type { Scope } from "../auth/principals.ts";
+import type { DevelopmentTargetCatalog } from "../discovery/catalog.ts";
+import { projectDevelopmentTarget } from "../discovery/development-target.ts";
+import { type TrustedDevelopmentTargetCandidate } from "../discovery/trusted-candidate.ts";
+import { RuntimeError } from "../errors.ts";
+
+function authorizeUnboundTargetContext(
+  context: RequestContext,
+  scope: Extract<Scope, "targets:read" | "targets:write">,
+) {
+  const authorized = authorize(context, { scope });
+  if (
+    authorized.principal.targetId !== undefined ||
+    authorized.principal.sessionId !== undefined
+  ) {
+    throw new RuntimeError("forbidden");
+  }
+  return authorized.principal;
+}
+
+export function createDevelopmentTargetService(
+  catalog: DevelopmentTargetCatalog,
+) {
+  return {
+    async refreshFromTrustedCandidate(
+      context: RequestContext,
+      input: TrustedDevelopmentTargetCandidate,
+      options: { readonly expectedRevision?: number } = {},
+    ) {
+      const principal = authorizeUnboundTargetContext(context, "targets:write");
+      if (
+        options.expectedRevision !== undefined &&
+        (!Number.isSafeInteger(options.expectedRevision) ||
+          options.expectedRevision < 1)
+      ) {
+        throw new RuntimeError("invalid_request");
+      }
+      return projectDevelopmentTarget(
+        await catalog.refresh({
+          principalId: principal.id,
+          bbContextId: principal.bbContextId,
+          candidate: input,
+          ...(options.expectedRevision === undefined
+            ? {}
+            : { expectedRevision: options.expectedRevision }),
+        }),
+      );
+    },
+    listTargets(context: RequestContext) {
+      const principal = authorizeUnboundTargetContext(context, "targets:read");
+      return catalog
+        .list({
+          principalId: principal.id,
+          bbContextId: principal.bbContextId,
+        })
+        .map(projectDevelopmentTarget);
+    },
+    getTarget(context: RequestContext, input: unknown) {
+      const principal = authorizeUnboundTargetContext(context, "targets:read");
+      let id: ObjectId;
+      try {
+        id = ObjectIdSchema.parse(input);
+      } catch (error) {
+        throw new RuntimeError("invalid_request", { cause: error });
+      }
+      const target = catalog.get({
+        principalId: principal.id,
+        bbContextId: principal.bbContextId,
+        id,
+      });
+      if (!target) throw new RuntimeError("not_found");
+      return projectDevelopmentTarget(target);
+    },
+  };
+}

--- a/packages/runtime/src/service/workbench-service.scopes.test.ts
+++ b/packages/runtime/src/service/workbench-service.scopes.test.ts
@@ -22,7 +22,6 @@ import { createWorkbenchService } from "./workbench-service.ts";
 
 const temporaryRoots: string[] = [];
 const scopeCases = [
-  ["development-target", "targets:read", "targets:write"],
   ["session", "sessions:read", "sessions:write"],
   ["surface", "surfaces:read", "surfaces:write"],
   ["annotation", "annotations:read", "annotations:write"],
@@ -50,7 +49,7 @@ afterEach(async () => {
 });
 
 describe("WorkbenchService scope mapping", () => {
-  test("uses the least-privilege write scope for every reserved object kind", async () => {
+  test("uses the least-privilege write scope for every generic object kind", async () => {
     let nextId = 0;
     const store = await openRuntimeStore({
       dataRoot: await makeDataRoot(),
@@ -83,7 +82,7 @@ describe("WorkbenchService scope mapping", () => {
     }
   });
 
-  test("uses the least-privilege read scope for every reserved object kind", async () => {
+  test("uses the least-privilege read scope for every generic object kind", async () => {
     const ids = scopeCases.map((_, index) =>
       ObjectIdSchema.parse(String(index).repeat(32)),
     );

--- a/packages/runtime/src/service/workbench-service.ts
+++ b/packages/runtime/src/service/workbench-service.ts
@@ -12,19 +12,24 @@ import {
 import { RuntimeError } from "../errors.ts";
 import type { RuntimeStore } from "../persistence/store.ts";
 
+const GenericObjectKindSchema = ObjectKindSchema.exclude([
+  "development-target",
+]);
+type GenericObjectKind = Exclude<ObjectKind, "development-target">;
+
 const CreateObjectInputSchema = z.strictObject({
-  kind: ObjectKindSchema,
+  kind: GenericObjectKindSchema,
   payload: z.unknown(),
 });
 
 const GetObjectInputSchema = z.strictObject({
   id: ObjectIdSchema,
-  kind: ObjectKindSchema,
+  kind: GenericObjectKindSchema,
 });
 
 const UpdateObjectInputSchema = z.strictObject({
   id: ObjectIdSchema,
-  kind: ObjectKindSchema,
+  kind: GenericObjectKindSchema,
   expectedRevision: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   payload: z.unknown(),
 });
@@ -35,7 +40,6 @@ const PullEventsInputSchema = z.strictObject({
 });
 
 const READ_SCOPE = {
-  "development-target": "targets:read",
   session: "sessions:read",
   surface: "surfaces:read",
   annotation: "annotations:read",
@@ -43,10 +47,9 @@ const READ_SCOPE = {
   comparison: "comparisons:read",
   "plugin-brief": "plugin-briefs:read",
   review: "reviews:read",
-} as const satisfies Record<ObjectKind, Scope>;
+} as const satisfies Record<GenericObjectKind, Scope>;
 
 const WRITE_SCOPE = {
-  "development-target": "targets:write",
   session: "sessions:write",
   surface: "surfaces:write",
   annotation: "annotations:write",
@@ -54,7 +57,7 @@ const WRITE_SCOPE = {
   comparison: "comparisons:write",
   "plugin-brief": "plugin-briefs:write",
   review: "reviews:write",
-} as const satisfies Record<ObjectKind, Scope>;
+} as const satisfies Record<GenericObjectKind, Scope>;
 
 function parseDto<T>(schema: z.ZodType<T>, input: unknown): T {
   try {

--- a/scripts/development-target-catalog.integration.test.ts
+++ b/scripts/development-target-catalog.integration.test.ts
@@ -4,7 +4,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { discoverSourceCandidates } from "../packages/inspection/src/discover-source-candidates.ts";
-import { readIssuedSourceCandidate } from "../packages/inspection/src/discovery-manifest.ts";
+import {
+  consumeIssuedSourceCandidate,
+  readSourceCandidateTransition,
+} from "../packages/inspection/src/source-candidate-transition.ts";
 import { admitTrustedRoots } from "../packages/inspection/src/trusted-roots.ts";
 import { createRequestContext } from "../packages/runtime/src/auth/context.ts";
 import {
@@ -31,7 +34,142 @@ afterEach(async () => {
   );
 });
 
+async function createDiscoveredFixture() {
+  const temporaryRoot = await fs.realpath(os.tmpdir());
+  const parent = await fs.mkdtemp(
+    path.join(temporaryRoot, "bb-mate-source-transition-"),
+  );
+  temporaryRoots.push(parent);
+  const workspaceRoot = path.join(parent, "workspace");
+  const pluginRoot = path.join(workspaceRoot, "plugins", "example");
+  await fs.mkdir(path.join(pluginRoot, "dist"), { recursive: true });
+  const manifest = JSON.stringify({
+    name: "bb-plugin-example",
+    version: "1.2.3",
+    bb: {
+      name: "Example plugin",
+      description: "A passive source transition fixture.",
+      branding: { icon: "extension" },
+      server: "dist/server.js",
+    },
+  });
+  await fs.writeFile(path.join(pluginRoot, "package.json"), manifest);
+  await fs.writeFile(path.join(pluginRoot, "dist", "server.js"), "");
+  const admission = await admitTrustedRoots([
+    {
+      rootKey: ROOT_KEY,
+      kind: "current-project",
+      path: workspaceRoot,
+      displayName: "workspace",
+    },
+  ]);
+  const discovery = await discoverSourceCandidates(admission.roots);
+  expect(discovery.diagnostics).toEqual([]);
+  expect(discovery.candidates).toHaveLength(1);
+  return {
+    parent,
+    pluginRoot,
+    manifest,
+    candidate: discovery.candidates[0]!,
+  };
+}
+
 describe("source discovery to development-target catalog", () => {
+  test("rejects in-place manifest mutation during inspection-to-runtime transition", async () => {
+    const fixture = await createDiscoveredFixture();
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      consumeIssuedSourceCandidate: (candidate, consumer) =>
+        consumeIssuedSourceCandidate(candidate, async (transition) => {
+          await fs.writeFile(
+            path.join(fixture.pluginRoot, "package.json"),
+            fixture.manifest.replace('"1.2.3"', '"9.9.9"'),
+          );
+          return await consumer(transition);
+        }),
+      readSourceCandidateTransition,
+    });
+
+    await expect(bridge.issue(fixture.candidate)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+  });
+
+  test("rejects package inode replacement during inspection-to-runtime transition", async () => {
+    const fixture = await createDiscoveredFixture();
+    const packagePath = path.join(fixture.pluginRoot, "package.json");
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      consumeIssuedSourceCandidate: (candidate, consumer) =>
+        consumeIssuedSourceCandidate(candidate, async (transition) => {
+          await fs.rename(packagePath, `${packagePath}.original`);
+          await fs.writeFile(packagePath, fixture.manifest);
+          return await consumer(transition);
+        }),
+      readSourceCandidateTransition,
+    });
+
+    await expect(bridge.issue(fixture.candidate)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+  });
+
+  test("rejects directory replacement during inspection-to-runtime transition", async () => {
+    const fixture = await createDiscoveredFixture();
+    const originalRoot = `${fixture.pluginRoot}.original`;
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      consumeIssuedSourceCandidate: (candidate, consumer) =>
+        consumeIssuedSourceCandidate(candidate, async (transition) => {
+          await fs.rename(fixture.pluginRoot, originalRoot);
+          await fs.mkdir(path.join(fixture.pluginRoot, "dist"), {
+            recursive: true,
+          });
+          await fs.writeFile(
+            path.join(fixture.pluginRoot, "package.json"),
+            fixture.manifest,
+          );
+          await fs.writeFile(
+            path.join(fixture.pluginRoot, "dist", "server.js"),
+            "",
+          );
+          return await consumer(transition);
+        }),
+      readSourceCandidateTransition,
+    });
+
+    await expect(bridge.issue(fixture.candidate)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+  });
+
+  test("rejects manifest mutation after runtime issuance and before catalog persistence", async () => {
+    const fixture = await createDiscoveredFixture();
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      consumeIssuedSourceCandidate,
+      readSourceCandidateTransition,
+    });
+    const issued = await bridge.issue(fixture.candidate);
+    await fs.writeFile(
+      path.join(fixture.pluginRoot, "package.json"),
+      fixture.manifest.replace('"1.2.3"', '"9.9.9"'),
+    );
+    const context = createRequestContext({
+      id: PRINCIPAL_ID,
+      kind: "plugin-adapter",
+      scopes: ["targets:read", "targets:write"],
+      revoked: false,
+      bbContextId: BB_CONTEXT_ID,
+    });
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: path.join(fixture.parent, "runtime-data"),
+    });
+    const service = createDevelopmentTargetService(catalog);
+
+    await expect(
+      service.refreshFromTrustedCandidate(context, issued),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+    expect(service.listTargets(context)).toEqual([]);
+    catalog.close();
+  });
+
   test("rejects a discovered candidate whose directory is replaced before runtime admission", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(
@@ -70,7 +208,8 @@ describe("source discovery to development-target catalog", () => {
     await fs.writeFile(path.join(pluginRoot, "dist", "server.js"), "");
 
     const bridge = createInspectionDevelopmentTargetCandidateBridge({
-      readIssuedSourceCandidate,
+      consumeIssuedSourceCandidate,
+      readSourceCandidateTransition,
     });
 
     await expect(bridge.issue(candidate)).rejects.toMatchObject({
@@ -125,7 +264,8 @@ describe("source discovery to development-target catalog", () => {
     expect(candidate.canonicalRoot).toBe(pluginRoot);
 
     const bridge = createInspectionDevelopmentTargetCandidateBridge({
-      readIssuedSourceCandidate,
+      consumeIssuedSourceCandidate,
+      readSourceCandidateTransition,
       clock: () => 1_000,
     });
     for (const forged of [

--- a/scripts/development-target-catalog.integration.test.ts
+++ b/scripts/development-target-catalog.integration.test.ts
@@ -9,13 +9,14 @@ import { createRequestContext } from "../packages/runtime/src/auth/context.ts";
 import {
   BbContextIdSchema,
   ObjectIdSchema,
+  OpaqueIdSchema,
   PrincipalIdSchema,
 } from "../packages/runtime/src/contracts/ids.ts";
 import { openDevelopmentTargetCatalog } from "../packages/runtime/src/discovery/catalog.ts";
-import { issueTrustedDevelopmentTargetCandidate } from "../packages/runtime/src/discovery/trusted-candidate.ts";
+import { issueTrustedDevelopmentTargetCandidateFromInspection } from "../packages/runtime/src/discovery/trusted-candidate.ts";
 import { createDevelopmentTargetService } from "../packages/runtime/src/service/development-target-service.ts";
 
-const ROOT_KEY = "r".repeat(32);
+const ROOT_KEY = OpaqueIdSchema.parse("r".repeat(32));
 const PRINCIPAL_ID = PrincipalIdSchema.parse("p".repeat(32));
 const BB_CONTEXT_ID = BbContextIdSchema.parse("b".repeat(32));
 const TARGET_ID = ObjectIdSchema.parse("t".repeat(32));
@@ -50,6 +51,8 @@ describe("source discovery to development-target catalog", () => {
         },
         bb: {
           name: "Example plugin",
+          description: "A passive source-catalog integration fixture.",
+          branding: { icon: "extension" },
           server: "dist/server.js",
         },
       }),
@@ -74,7 +77,7 @@ describe("source discovery to development-target catalog", () => {
     const candidate = discovery.candidates[0]!;
     expect(candidate.canonicalRoot).toBe(pluginRoot);
 
-    const issued = await issueTrustedDevelopmentTargetCandidate({
+    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection({
       rootKey: candidate.rootKey,
       rootKind: "current-project",
       canonicalRoot: candidate.canonicalRoot,

--- a/scripts/development-target-catalog.integration.test.ts
+++ b/scripts/development-target-catalog.integration.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { discoverSourceCandidates } from "../packages/inspection/src/discover-source-candidates.ts";
+import { admitTrustedRoots } from "../packages/inspection/src/trusted-roots.ts";
+import { createRequestContext } from "../packages/runtime/src/auth/context.ts";
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  PrincipalIdSchema,
+} from "../packages/runtime/src/contracts/ids.ts";
+import { openDevelopmentTargetCatalog } from "../packages/runtime/src/discovery/catalog.ts";
+import { issueTrustedDevelopmentTargetCandidate } from "../packages/runtime/src/discovery/trusted-candidate.ts";
+import { createDevelopmentTargetService } from "../packages/runtime/src/service/development-target-service.ts";
+
+const ROOT_KEY = "r".repeat(32);
+const PRINCIPAL_ID = PrincipalIdSchema.parse("p".repeat(32));
+const BB_CONTEXT_ID = BbContextIdSchema.parse("b".repeat(32));
+const TARGET_ID = ObjectIdSchema.parse("t".repeat(32));
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("source discovery to development-target catalog", () => {
+  test("persists and reopens one passive source target without revealing or executing its root", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-source-catalog-"),
+    );
+    temporaryRoots.push(parent);
+    const workspaceRoot = path.join(parent, "workspace");
+    const pluginRoot = path.join(workspaceRoot, "plugins", "example");
+    const executionSentinel = path.join(parent, "target-executed");
+    await fs.mkdir(path.join(pluginRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-example",
+        version: "1.2.3",
+        scripts: {
+          preinstall: `touch ${JSON.stringify(executionSentinel)}`,
+        },
+        bb: {
+          name: "Example plugin",
+          server: "dist/server.js",
+        },
+      }),
+    );
+    await fs.writeFile(
+      path.join(pluginRoot, "dist", "server.js"),
+      `await Bun.write(${JSON.stringify(executionSentinel)}, "executed");`,
+    );
+
+    const admission = await admitTrustedRoots([
+      {
+        rootKey: ROOT_KEY,
+        kind: "current-project",
+        path: workspaceRoot,
+        displayName: "workspace",
+      },
+    ]);
+    expect(admission.diagnostics).toEqual([]);
+    const discovery = await discoverSourceCandidates(admission.roots);
+    expect(discovery.diagnostics).toEqual([]);
+    expect(discovery.candidates).toHaveLength(1);
+    const candidate = discovery.candidates[0]!;
+    expect(candidate.canonicalRoot).toBe(pluginRoot);
+
+    const issued = await issueTrustedDevelopmentTargetCandidate({
+      rootKey: candidate.rootKey,
+      rootKind: "current-project",
+      canonicalRoot: candidate.canonicalRoot,
+      target: {
+        displayName: candidate.displayName,
+        displayPath: candidate.displayPath,
+        sourceKind: "workspace-discovered",
+        manifest: {
+          pluginId: candidate.pluginId,
+          packageName: candidate.packageName,
+          version: candidate.version,
+          hasServer: candidate.hasServer,
+          hasApp: candidate.hasApp,
+        },
+        native: {
+          status: "absent",
+          observedAt: 1_000,
+        },
+        capabilities: {
+          fixture: true,
+          harness: false,
+          live: false,
+        },
+      },
+    });
+    const context = createRequestContext({
+      id: PRINCIPAL_ID,
+      kind: "plugin-adapter",
+      scopes: ["targets:read", "targets:write"],
+      revoked: false,
+      bbContextId: BB_CONTEXT_ID,
+    });
+    const dataRoot = path.join(parent, "runtime-data");
+    let catalog = await openDevelopmentTargetCatalog({
+      dataRoot,
+      id: () => TARGET_ID,
+      clock: () => 1_000,
+    });
+    let service = createDevelopmentTargetService(catalog);
+    const created = await service.refreshFromTrustedCandidate(context, issued);
+    expect(String(created.id)).toBe(String(TARGET_ID));
+    expect(created.revision).toBe(1);
+    expect(JSON.stringify(created)).not.toContain(parent);
+    expect(JSON.stringify(created)).not.toContain(ROOT_KEY);
+    expect(
+      catalog.resolvePrivate({
+        principalId: PRINCIPAL_ID,
+        bbContextId: BB_CONTEXT_ID,
+        id: TARGET_ID,
+      }),
+    ).toEqual({
+      canonicalRoot: pluginRoot,
+      rootKey: ROOT_KEY,
+      rootKind: "current-project",
+    });
+    catalog.close();
+
+    catalog = await openDevelopmentTargetCatalog({ dataRoot });
+    service = createDevelopmentTargetService(catalog);
+    expect(service.listTargets(context)).toEqual([created]);
+    expect(service.getTarget(context, TARGET_ID)).toEqual(created);
+    catalog.close();
+
+    expect(
+      await fs
+        .stat(executionSentinel)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(false);
+  });
+});

--- a/scripts/development-target-catalog.integration.test.ts
+++ b/scripts/development-target-catalog.integration.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { discoverSourceCandidates } from "../packages/inspection/src/discover-source-candidates.ts";
+import { readIssuedSourceCandidate } from "../packages/inspection/src/discovery-manifest.ts";
 import { admitTrustedRoots } from "../packages/inspection/src/trusted-roots.ts";
 import { createRequestContext } from "../packages/runtime/src/auth/context.ts";
 import {
@@ -13,7 +14,7 @@ import {
   PrincipalIdSchema,
 } from "../packages/runtime/src/contracts/ids.ts";
 import { openDevelopmentTargetCatalog } from "../packages/runtime/src/discovery/catalog.ts";
-import { issueTrustedDevelopmentTargetCandidateFromInspection } from "../packages/runtime/src/discovery/trusted-candidate.ts";
+import { createInspectionDevelopmentTargetCandidateBridge } from "../packages/runtime/src/discovery/trusted-candidate.ts";
 import { createDevelopmentTargetService } from "../packages/runtime/src/service/development-target-service.ts";
 
 const ROOT_KEY = OpaqueIdSchema.parse("r".repeat(32));
@@ -31,6 +32,52 @@ afterEach(async () => {
 });
 
 describe("source discovery to development-target catalog", () => {
+  test("rejects a discovered candidate whose directory is replaced before runtime admission", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-source-catalog-"),
+    );
+    temporaryRoots.push(parent);
+    const workspaceRoot = path.join(parent, "workspace");
+    const pluginRoot = path.join(workspaceRoot, "plugins", "example");
+    const originalRoot = path.join(workspaceRoot, "plugins", "example-old");
+    await fs.mkdir(path.join(pluginRoot, "dist"), { recursive: true });
+    const manifest = JSON.stringify({
+      name: "bb-plugin-example",
+      version: "1.2.3",
+      bb: {
+        name: "Example plugin",
+        description: "A passive source-catalog integration fixture.",
+        branding: { icon: "extension" },
+        server: "dist/server.js",
+      },
+    });
+    await fs.writeFile(path.join(pluginRoot, "package.json"), manifest);
+    await fs.writeFile(path.join(pluginRoot, "dist", "server.js"), "");
+    const admission = await admitTrustedRoots([
+      {
+        rootKey: ROOT_KEY,
+        kind: "current-project",
+        path: workspaceRoot,
+        displayName: "workspace",
+      },
+    ]);
+    const discovery = await discoverSourceCandidates(admission.roots);
+    const candidate = discovery.candidates[0]!;
+    await fs.rename(pluginRoot, originalRoot);
+    await fs.mkdir(path.join(pluginRoot, "dist"), { recursive: true });
+    await fs.writeFile(path.join(pluginRoot, "package.json"), manifest);
+    await fs.writeFile(path.join(pluginRoot, "dist", "server.js"), "");
+
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      readIssuedSourceCandidate,
+    });
+
+    await expect(bridge.issue(candidate)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+  });
+
   test("persists and reopens one passive source target without revealing or executing its root", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(
@@ -77,32 +124,23 @@ describe("source discovery to development-target catalog", () => {
     const candidate = discovery.candidates[0]!;
     expect(candidate.canonicalRoot).toBe(pluginRoot);
 
-    const issued = await issueTrustedDevelopmentTargetCandidateFromInspection({
-      rootKey: candidate.rootKey,
-      rootKind: "current-project",
-      canonicalRoot: candidate.canonicalRoot,
-      target: {
-        displayName: candidate.displayName,
-        displayPath: candidate.displayPath,
-        sourceKind: "workspace-discovered",
-        manifest: {
-          pluginId: candidate.pluginId,
-          packageName: candidate.packageName,
-          version: candidate.version,
-          hasServer: candidate.hasServer,
-          hasApp: candidate.hasApp,
-        },
-        native: {
-          status: "absent",
-          observedAt: 1_000,
-        },
-        capabilities: {
-          fixture: true,
-          harness: false,
-          live: false,
-        },
-      },
+    const bridge = createInspectionDevelopmentTargetCandidateBridge({
+      readIssuedSourceCandidate,
+      clock: () => 1_000,
     });
+    for (const forged of [
+      { ...candidate },
+      {
+        ...candidate,
+        native: { status: "exact-path", pluginId: "spoofed" },
+        capabilities: { fixture: true, harness: true, live: true },
+      },
+    ]) {
+      await expect(bridge.issue(forged)).rejects.toMatchObject({
+        code: "invalid_request",
+      });
+    }
+    const issued = await bridge.issue(candidate);
     const context = createRequestContext({
       id: PRINCIPAL_ID,
       kind: "plugin-adapter",
@@ -117,9 +155,24 @@ describe("source discovery to development-target catalog", () => {
       clock: () => 1_000,
     });
     let service = createDevelopmentTargetService(catalog);
+    expect(service.listTargets(context)).toEqual([]);
+    await expect(
+      service.refreshFromTrustedCandidate(context, {
+        ...candidate,
+        native: { status: "exact-path" },
+        capabilities: { fixture: true, harness: true, live: true },
+      } as never),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+    expect(service.listTargets(context)).toEqual([]);
     const created = await service.refreshFromTrustedCandidate(context, issued);
     expect(String(created.id)).toBe(String(TARGET_ID));
     expect(created.revision).toBe(1);
+    expect(created.native).toEqual({ status: "absent", observedAt: 1_000 });
+    expect(created.capabilities).toEqual({
+      fixture: false,
+      harness: false,
+      live: false,
+    });
     expect(JSON.stringify(created)).not.toContain(parent);
     expect(JSON.stringify(created)).not.toContain(ROOT_KEY);
     expect(

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "Bundler",
     "noEmit": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
     "types": ["bun", "node"]


### PR DESCRIPTION
## Context

Begins #57 with the secure persisted source-catalog slice. It admits only server-trusted source roots, persists self-bound opaque development targets and private canonical roots atomically, and exposes redacted projections without executing target code.

## What changed

- added bounded passive discovery under current, explicit, and pinned trusted roots
- reject filesystem/home ancestors, ignored trees, traversal, symlink leaves/ancestors, directory swaps, oversized or growing manifests, and unsafe declared assets
- reserve scan capacity for every admitted root, then redistribute unused global entry/candidate capacity without exceeding the 2,048/128 limits
- validate the released bb manifest contract, including engines and bounded no-follow compact-SVG bytes, and emit bounded diagnostics for malformed manifests and unreadable directories
- consume source candidates through a one-use WeakMap transition that pre/post-attests candidate-directory identity and bounded manifest inode/hash around runtime admission
- derive conservative runtime target state only through a second exact capability stage that retains and revalidates the full source identity before persistence; raw native/live claims have no input path
- added strict DevelopmentTarget codec, dedicated target-unbound authorization, stable private/public SQLite catalog, optimistic revisions, and redacted events
- attest stored private source rows on reopen and fail closed without repair
- removed development-target CRUD from the generic object service
- added real discovery-to-SQLite reopen plus transition-time and post-issuance filesystem-race integration attacks

Native reconciliation and the Workbench opaque-target adapter remain the second #57 slice.

## Verification

- inspection: 120 tests, 274 assertions
- runtime: 117 tests, 617 assertions
- scripts: 48 tests, 130 assertions
- aggregate: 401 tests
- `bun run format:check && bun run check && bun run test && bun run build`
- package clean room: 41 files, 13 stories, SHA-256 `622b4c8148f0b449c6321c8625b27ac24a84f8a0b662a4b0efcad7997715bed4`

## Boundary

No target execution, build/install/dev/reload, browser bootstrap, Connect, MCP, normal-profile mutation, publication, release, signing, or upstream submission.

Part of #57.
