### PR TITLE
feat: reconcile native development targets

### DIFF
--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -461,7 +461,7 @@ and all builds.
 - `bun run format:check`: passed for the reviewed packet and design record.
 - Slice 57B1 local implementation gate passed `bun run format:check`, `bun run
 check`, `bun run test`, `bun run build`, and `git diff --check`. The aggregate
-  run passed 468 tests: inspection 136, runtime 167, CLI 42, Workbench 53,
+  run passed 469 tests: inspection 136, runtime 168, CLI 42, Workbench 53,
   Linear plugin 21, and scripts 49. The package clean room passed with 41
   files, 13 stories, and SHA-256
   `e4e726bb0209adb43673942f9a33cc7243f5c82064eddea1231ff8bb82c73e6d`.
@@ -490,6 +490,10 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   and exact equality between private `observedAt` and the canonical public
   native timestamp. Missing, corrupt, or valid-looking divergent private rows
   fail closed without repair.
+- Coordinator integration found that a future-dated observation could be
+  classified as malformed and committed even though the next integrity check
+  correctly rejected its timestamp. The catalog now rejects that capability
+  before mutation; focused persistence proof reopens the unchanged target.
 - The coordinator walking skeleton proves passive source discovery to stable
   catalog target to released-shape managed inventory to reconciliation and
   reopen. The inventory invokes only `bb plugin list --json`, creates no

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -10,9 +10,10 @@ released-capability Gate 0 PR #68, and standalone-runtime PR #69 are merged.
 The narrowed runtime domain/security foundation #55 is merged through PR #71
 and reconciled. Source-first development-target discovery #57 is the active
 milestone. Slice 57A is merged and reconciled. Slice 57B1 native inventory,
-reconciliation, and private-host persistence are implemented and locally
-verified on draft PR #74; exact-head review, hosted CI, merge, and
-reconciliation remain before the 57B2 Workbench adapter begins.
+reconciliation, and private-host persistence have passed local verification,
+hosted CI, and two 5/5 exact-head review lanes on draft PR #74. Final
+docs-only exact-head review, ready/merge, and reconciliation remain before the
+57B2 Workbench adapter begins.
 
 ## Readiness
 
@@ -23,8 +24,9 @@ evidence and is reconciled. The transport-neutral runtime foundation #55 has
 passed focused/aggregate verification, two independent exact-head reviews, and
 hosted CI, then merged and reconciled. Source-catalog slice 57A is also merged
 and reconciled. Slice 57B1 has passed its local implementation gate; it is not
-done until dual exact-head review, hosted CI, merge, and GitButler
-reconciliation pass. Browser bootstrap/topology is isolated in #70.
+done until the final docs-only exact head is re-pinned clean, then ready/merge
+and GitButler reconciliation pass. Browser bootstrap/topology is isolated in
+#70.
 
 ## Baseline
 
@@ -499,6 +501,13 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   persistence now requires a strictly newer per-target observation; replay
   tests prove the public target, private host row, event ledger, and reopened
   database remain unchanged.
+- Standing and targeted round two each awarded exact head
+  `990ea0be027347192f37f39527ef7e81d8b5e9c5` 5/5 with zero P0-P3 findings.
+  Hosted verify, visual, standalone-arm64, and GitGuardian checks were terminal
+  green; the PR was mergeable, thread-free, fully pushed, and GitButler-clean.
+  Superseded non-clean round-one scratch reports were archived only after their
+  findings and fixed dispositions were recorded here; the packet doctor then
+  passed with 21 active reports.
 - The coordinator walking skeleton proves passive source discovery to stable
   catalog target to released-shape managed inventory to reconciliation and
   reopen. The inventory invokes only `bb plugin list --json`, creates no
@@ -523,7 +532,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
 source-catalog slice 57A are merged and reconciled. Slice 57B1 implementation
-and local verification are complete on draft PR #74; exact-head review,
-hosted CI, merge, and reconciliation remain. Issue #57 stays open for 57B1 and
-the later 57B2 opaque-target Workbench adapter. All
+and review are complete on draft PR #74; final docs-only exact-head review,
+ready/merge, and reconciliation remain. Issue #57 stays open for 57B1 and the
+later 57B2 opaque-target Workbench adapter. All
 release/upstream/Connect/normal-profile stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -461,7 +461,7 @@ and all builds.
 - `bun run format:check`: passed for the reviewed packet and design record.
 - Slice 57B1 local implementation gate passed `bun run format:check`, `bun run
 check`, `bun run test`, `bun run build`, and `git diff --check`. The aggregate
-  run passed 469 tests: inspection 136, runtime 168, CLI 42, Workbench 53,
+  run passed 470 tests: inspection 136, runtime 169, CLI 42, Workbench 53,
   Linear plugin 21, and scripts 49. The package clean room passed with 41
   files, 13 stories, and SHA-256
   `e4e726bb0209adb43673942f9a33cc7243f5c82064eddea1231ff8bb82c73e6d`.
@@ -475,8 +475,8 @@ test && bun run build && bun run compatibility:latest` passed; package clean
 - 57B1 normalizes only released bb 0.36 `plugin list --json` evidence through a
   fixed no-shell command, 1 MiB output bound, 256-row bound, and UTF-8 field
   bounds. It canonicalizes only direct path rows; npm/Git/builtin/catalog roots
-  are never read. One-use inspection and runtime capabilities reject clones,
-  replays, forged facts, and failed transitions.
+  are never read. One-use inspection transitions reject reuse, and runtime
+  capabilities reject clones, forged facts, and failed transitions.
 - The pure reconciler covers malformed, duplicate, future/stale, exact path,
   other path, npm/Git managed, builtin/catalog conflict, and absent precedence.
   A safely canonicalized malformed root hint protects a matching target while
@@ -494,6 +494,11 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   classified as malformed and committed even though the next integrity check
   correctly rejected its timestamp. The catalog now rejects that capability
   before mutation; focused persistence proof reopens the unchanged target.
+- Round-one standing and targeted review independently found that an older or
+  equal issued inventory could overwrite newer accepted host evidence. Native
+  persistence now requires a strictly newer per-target observation; replay
+  tests prove the public target, private host row, event ledger, and reopened
+  database remain unchanged.
 - The coordinator walking skeleton proves passive source discovery to stable
   catalog target to released-shape managed inventory to reconciliation and
   reopen. The inventory invokes only `bb plugin list --json`, creates no

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -427,6 +427,19 @@ and all builds.
   `/tmp/bb-mate-plugin-workbench-reviews-20260810/source-catalog/` after their
   findings and dispositions were preserved here. Prompt validation and the
   canonical goal-loop doctor then passed with 17 active review reports.
+- Source-catalog final docs review found one P2 wording mismatch at
+  `7e2cec6c928a00c2ec655c0c172ad37855af440f`: the RETRO said the docs-only
+  head remained even though it was already current. Exact head
+  `cb8c3f362390e1985db671b4a8ed2b0c1f7fc1d7` fixed that statement; standing
+  and targeted round 6 each reached 5/5 with zero P0-P3, hosted checks were
+  terminal green, and the goal doctor passed after the superseded scratch
+  report was archived.
+- PR #72 was made ready only after the exact final head was re-pinned as clean,
+  mergeable, fully green, thread-free, and GitButler-clean. GitHub async request
+  `f0a90de8-4a3c-425d-92cb-313ff0b6f70d` merged it as
+  `52a3274f9981f94a37d296e3f0bfa46bafd7b867`. `but pull` removed the integrated
+  57A branch and advanced the workspace base without uncommitted changes. #57
+  remains open for native reconciliation and the browser adapter.
 
 ## Verification Log
 
@@ -460,9 +473,8 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 ## Final State
 
-Execution active. Gate 0, standalone-runtime #56, and runtime foundation #55
-are merged, closed, and reconciled. Source-catalog slice 57A implementation
-and code review are complete on draft PR #72; this docs-only readiness head
-still needs its narrow exact-head review, ready transition, merge, and
-reconciliation before 57B starts. All release/upstream/Connect/normal-profile
+Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
+source-catalog slice 57A are merged and reconciled. Issue #57 remains open;
+57B1 native reconciliation/private host evidence is next, followed by the 57B2
+opaque-target Workbench adapter. All release/upstream/Connect/normal-profile
 stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -9,8 +9,10 @@ The execution goal is active. Compatibility baseline #52, spec/goal PR #53,
 released-capability Gate 0 PR #68, and standalone-runtime PR #69 are merged.
 The narrowed runtime domain/security foundation #55 is merged through PR #71
 and reconciled. Source-first development-target discovery #57 is the active
-milestone. Slice 57A implementation and local verification are complete on
-draft PR #72; exact-head review, hosted CI, merge, and reconciliation remain.
+milestone. Slice 57A is merged and reconciled. Slice 57B1 native inventory,
+reconciliation, and private-host persistence are implemented and locally
+verified on draft PR #74; exact-head review, hosted CI, merge, and
+reconciliation remain before the 57B2 Workbench adapter begins.
 
 ## Readiness
 
@@ -19,14 +21,17 @@ merged. Gate 0 admits all released host-plugin rows to downstream execution.
 Standalone #69 passed green local, hosted, and two-lane exact-head review
 evidence and is reconciled. The transport-neutral runtime foundation #55 has
 passed focused/aggregate verification, two independent exact-head reviews, and
-hosted CI, then merged and reconciled. Browser bootstrap/topology is isolated
-in #70.
+hosted CI, then merged and reconciled. Source-catalog slice 57A is also merged
+and reconciled. Slice 57B1 has passed its local implementation gate; it is not
+done until dual exact-head review, hosted CI, merge, and GitButler
+reconciliation pass. Browser bootstrap/topology is isolated in #70.
 
 ## Baseline
 
 - Repository: `/Users/mg/Developer/bb/bb-mate`
-- Active branch: `feat/runtime/development-target-discovery`; issue #57.
-- Current merge base: `ac419ae1c87f7c5186b848bc937591cf45f57560`.
+- Active branch: `feat/runtime/native-target-reconciliation`; issue #57; draft
+  PR #74.
+- Current merge base: `52a3274f9981f94a37d296e3f0bfa46bafd7b867`.
 - Compatibility PR #52 merged from exact head
   `1b047598b52f49ed8e6e0f7dd88387ff02c10445` to baseline merge commit
   `fa02c6d0d7c4ffb2f8855029def1589ed7ce7824`; issue #51 is closed.
@@ -45,10 +50,11 @@ in #70.
   `b4327b73ba8d8e1acd6c43572df417a126d71922` through GitHub async request
   `690f515a-0651-47ef-aa7a-852e9efe02cd` to merge commit
   `ac419ae1c87f7c5186b848bc937591cf45f57560`; issue #55 is closed.
-- GitButler reconciled to clean `main`; a fresh #57 branch was then applied.
-- Source-catalog PR #72 was opened from merge base
-  `ac419ae1c87f7c5186b848bc937591cf45f57560`; its implementation head is not
-  yet frozen because exact-head review and merge remain pending.
+- Source-catalog PR #72 merged from exact reviewed head
+  `cb8c3f362390e1985db671b4a8ed2b0c1f7fc1d7` through GitHub async request
+  `f0a90de8-4a3c-425d-92cb-313ff0b6f70d` to merge commit
+  `52a3274f9981f94a37d296e3f0bfa46bafd7b867`. GitButler removed the integrated
+  branch and a fresh 57B1 branch/PR #74 was opened from that base.
 
 ## Preparation findings
 
@@ -75,6 +81,13 @@ in #70.
 
 ## Goal Amendments
 
+- Source discovery #57 is delivered as three merge-first slices rather than a
+  single cross-layer change: 57A owns the secure persisted source catalog,
+  57B1 owns bounded native inventory and atomic reconciliation, and 57B2 owns
+  the opaque-target Workbench adapter. This preserves the merged completion
+  horizon and verification gates while making the storage/native and browser
+  boundaries independently reviewable. Issue #57 remains open until all three
+  slices merge.
 - Packet review clarified Gate 0 from one frontend verdict to a per-capability
   matrix. This preserves rather than narrows the original maximum-independent-
   work objective.
@@ -446,6 +459,12 @@ and all builds.
 - `check-goal-prompt --no-placeholders`: passed at 3,216/4,000 characters.
 - `goal-loop-doctor`: passed with every active review report clean.
 - `bun run format:check`: passed for the reviewed packet and design record.
+- Slice 57B1 local implementation gate passed `bun run format:check`, `bun run
+check`, `bun run test`, `bun run build`, and `git diff --check`. The aggregate
+  run passed 468 tests: inspection 136, runtime 167, CLI 42, Workbench 53,
+  Linear plugin 21, and scripts 49. The package clean room passed with 41
+  files, 13 stories, and SHA-256
+  `e4e726bb0209adb43673942f9a33cc7243f5c82064eddea1231ff8bb82c73e6d`.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
   room produced 41 files, 13 stories, SHA-256
@@ -453,9 +472,29 @@ test && bun run build && bun run compatibility:latest` passed; package clean
 
 ## Evidence ledger
 
-Append milestone entries with date/time, exact head/base, commands, results,
-review reports/findings/dispositions, PR/CI/thread state, issue changes, and
-merge/reconciliation proof.
+- 57B1 normalizes only released bb 0.36 `plugin list --json` evidence through a
+  fixed no-shell command, 1 MiB output bound, 256-row bound, and UTF-8 field
+  bounds. It canonicalizes only direct path rows; npm/Git/builtin/catalog roots
+  are never read. One-use inspection and runtime capabilities reject clones,
+  replays, forged facts, and failed transitions.
+- The pure reconciler covers malformed, duplicate, future/stale, exact path,
+  other path, npm/Git managed, builtin/catalog conflict, and absent precedence.
+  A safely canonicalized malformed root hint protects a matching target while
+  unrelated malformed rows do not hide a safe result.
+- The catalog service requires an unbound branded `targets:write` principal,
+  scoped target ID, freshly revalidated same-root source capability, trusted
+  inventory capability, and optimistic revision. Public native state, private
+  host evidence, and a redacted `target.native-reconciled` event commit in one
+  transaction; failure rolls all three back.
+- Reopen integrity attests strict schema, event/binding/revision consistency,
+  and exact equality between private `observedAt` and the canonical public
+  native timestamp. Missing, corrupt, or valid-looking divergent private rows
+  fail closed without repair.
+- The coordinator walking skeleton proves passive source discovery to stable
+  catalog target to released-shape managed inventory to reconciliation and
+  reopen. The inventory invokes only `bb plugin list --json`, creates no
+  additional target, exposes no private root/hostname publicly, and executes
+  neither package scripts nor the target entrypoint.
 
 ## Prompt / Goal Alignment
 
@@ -474,7 +513,8 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 ## Final State
 
 Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
-source-catalog slice 57A are merged and reconciled. Issue #57 remains open;
-57B1 native reconciliation/private host evidence is next, followed by the 57B2
-opaque-target Workbench adapter. All release/upstream/Connect/normal-profile
-stop boundaries remain intact.
+source-catalog slice 57A are merged and reconciled. Slice 57B1 implementation
+and local verification are complete on draft PR #74; exact-head review,
+hosted CI, merge, and reconciliation remain. Issue #57 stays open for 57B1 and
+the later 57B2 opaque-target Workbench adapter. All
+release/upstream/Connect/normal-profile stop boundaries remain intact.

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,7 +1,7 @@
 # Source-first development-target discovery
 
 Date: 2026-08-10
-Status: Slice A implementation and review complete; merge pending
+Status: Slice 57A merged; slice 57B1 native reconciliation next
 Issue: #57
 Parent: #21
 Depends on: #55 (merged through PR #71)
@@ -15,18 +15,21 @@ discovery, and browser/model projections never receive a raw source path.
 
 ## Delivery shape
 
-Deliver #57 as two independently reviewable, merge-first slices:
+Deliver #57 as three independently reviewable, merge-first slices:
 
 1. **57A — secure persisted source catalog.** Admit bounded trusted roots,
    discover passive manifests, persist a self-bound target plus its private
    canonical root atomically, reopen it with a stable ID, and expose an
    allowlist-built redacted projection.
-2. **57B — native reconciliation and Workbench adapter.** Classify exact path,
-   other path, managed, builtin conflict, absent, duplicate, malformed, and
-   stale states from a bounded read-only inventory; adapt inspection and the
-   browser Workbench to server-issued target IDs.
+2. **57B1 — native reconciliation.** Normalize a bounded read-only released
+   bb 0.36 inventory, classify exact path, other path, managed, builtin
+   conflict, absent, duplicate, malformed, and stale states, and atomically
+   persist only the public result plus bounded private host evidence.
+3. **57B2 — Workbench adapter.** Adapt inspection and the browser Workbench to
+   server-issued target IDs, resolve roots only in server composition, and
+   remove the former external-symlink acceptance path.
 
-Issue #57 closes only after both slices merge and reconcile.
+Issue #57 closes only after all three slices merge and reconcile.
 
 ## Contract decisions
 
@@ -92,14 +95,15 @@ decision; #70 owns that gate.
 3. [x] Add atomic private/public catalog persistence, target-unbound dedicated
        authorization, stable reopen/refresh IDs, optimistic revisions, and
        redacted events.
-4. [ ] Review, verify, merge, and reconcile slice 57A with two 5/5 lanes.
-5. [ ] Add bounded native inventory and pure reconciliation fixtures for all
-       required states without lifecycle mutation or candidate seeding.
-6. [ ] Adapt one-authorized-target inspection and Workbench selection to
+4. [x] Review, verify, merge, and reconcile slice 57A with two 5/5 lanes.
+5. [ ] Add a one-use bounded native-inventory capability, pure reconciliation
+       fixtures for every required state, and atomic private host observations
+       without lifecycle mutation, candidate seeding, or topology conclusions.
+6. [ ] Run aggregate gates and two 5/5 lanes, then merge and reconcile 57B1.
+7. [ ] Adapt one-authorized-target inspection and Workbench selection to
        opaque target IDs; reverse the prior external-symlink acceptance test.
-7. [ ] Record bounded private host observations without topology conclusions.
 8. [ ] Run visual/accessibility and aggregate gates, two 5/5 reviews, hosted
-       CI, merge #57, close the issue, and reconcile GitButler.
+       CI, merge 57B2, close #57, and reconcile GitButler.
 
 ## Verification
 

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,7 +1,7 @@
 # Source-first development-target discovery
 
 Date: 2026-08-10
-Status: Slice 57A merged; slice 57B1 implemented and locally verified; review pending
+Status: Slice 57A merged; slice 57B1 implementation and review complete; merge pending
 Issue: #57
 Parent: #21
 Depends on: #55 (merged through PR #71)

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,7 +1,7 @@
 # Source-first development-target discovery
 
 Date: 2026-08-10
-Status: Slice 57A merged; slice 57B1 native reconciliation next
+Status: Slice 57A merged; slice 57B1 implemented and locally verified; review pending
 Issue: #57
 Parent: #21
 Depends on: #55 (merged through PR #71)
@@ -96,7 +96,7 @@ decision; #70 owns that gate.
        authorization, stable reopen/refresh IDs, optimistic revisions, and
        redacted events.
 4. [x] Review, verify, merge, and reconcile slice 57A with two 5/5 lanes.
-5. [ ] Add a one-use bounded native-inventory capability, pure reconciliation
+5. [x] Add a one-use bounded native-inventory capability, pure reconciliation
        fixtures for every required state, and atomic private host observations
        without lifecycle mutation, candidate seeding, or topology conclusions.
 6. [ ] Run aggregate gates and two 5/5 lanes, then merge and reconcile 57B1.
@@ -127,6 +127,6 @@ leave the dependent behavior unavailable and track the exact unblock.
 
 ## Done
 
-Both slices are merged to `main`; #57 and #21 are current; exact local and
-hosted gates pass; two independent review lanes score 5/5 with zero P0-P2;
+All three slices are merged to `main`; #57 and #21 are current; exact local and
+hosted gates pass; two independent review lanes score 5/5 with zero P0-P3;
 GitButler is clean/reconciled; and the goal retrospective records exact proof.

--- a/packages/inspection/src/index.ts
+++ b/packages/inspection/src/index.ts
@@ -6,6 +6,11 @@ export { runCapturedCommand } from "./captured-command.ts";
 export type { CapturedCommandOptions } from "./captured-command.ts";
 export { nativeCommandEnv } from "./native-env.ts";
 export {
+  consumeIssuedNativeInventory,
+  observeNativePluginInventory,
+  readNativeInventoryTransition,
+} from "./native-inventory.ts";
+export {
   formatInspection,
   inspectionOutcome,
   provenanceKind,
@@ -34,6 +39,18 @@ export type {
   SdkPublicationState,
   TrustReport,
 } from "./types.ts";
+export type {
+  NativeInventoryEntry,
+  NativeInventoryMalformedRow,
+  NativeInventoryObservation,
+  NativeInventoryPluginStatus,
+  NativeInventoryProvenance,
+  NativeInventoryRowIssue,
+  NativeInventorySourceKind,
+  NativeInventoryTopLevelStatus,
+  NativeInventoryTransitionFacts,
+  ObserveNativePluginInventoryOptions,
+} from "./native-inventory.ts";
 export type {
   DiscoveryDiagnostic,
   SourceCandidate,

--- a/packages/inspection/src/native-inventory-observer.test.ts
+++ b/packages/inspection/src/native-inventory-observer.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  NATIVE_INVENTORY_MAX_OUTPUT_BYTES,
+  observeNativePluginInventoryForTest,
+} from "./native-inventory.ts";
+import {
+  command,
+  readObservation,
+  runtimeInstanceId,
+} from "./native-inventory-test-helpers.ts";
+
+describe("native inventory observer", () => {
+  test("normalizes the released bb 0.36 path row through one passive command", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-mate-native-"));
+    const calls: string[][] = [];
+    try {
+      const observation = await observeNativePluginInventoryForTest({
+        runtimeInstanceId,
+        now: () => 1_000,
+        hostname: () => "studio.local",
+        runBb: async (args) => {
+          calls.push([...args]);
+          return command(
+            JSON.stringify({
+              plugins: [
+                {
+                  id: "notes",
+                  source: `path:${root}`,
+                  rootDir: root,
+                  version: "1.2.3",
+                  provenance: "direct",
+                  isOrphanedBuiltin: false,
+                  enabled: true,
+                  status: "running",
+                  sourceDisplay: root,
+                  capabilities: [],
+                  services: [],
+                  app: { status: "ready" },
+                },
+              ],
+            }),
+          );
+        },
+      });
+
+      expect(calls).toEqual([["plugin", "list", "--json"]]);
+      expect(await readObservation(observation)).toEqual({
+        schemaVersion: 1,
+        observedAt: 1_000,
+        runtimeInstanceId,
+        hostname: "studio.local",
+        topLevelStatus: "ok",
+        entries: [
+          {
+            id: "notes",
+            sourceKind: "path",
+            canonicalRoot: await fs.realpath(root),
+            version: "1.2.3",
+            provenance: "direct",
+            isOrphanedBuiltin: false,
+            enabled: true,
+            status: "running",
+          },
+        ],
+        malformedRows: [],
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects oversized UTF-8 before parsing even with an injected runner", async () => {
+    const observation = await observeNativePluginInventoryForTest({
+      runtimeInstanceId,
+      now: () => 3_000,
+      hostname: () => "studio.local",
+      runBb: async () =>
+        command(`${" ".repeat(NATIVE_INVENTORY_MAX_OUTPUT_BYTES)}{}`),
+    });
+
+    expect(await readObservation(observation)).toMatchObject({
+      topLevelStatus: "output-limit",
+      entries: [],
+      malformedRows: [],
+    });
+  });
+
+  test("rejects topology-shaped host metadata before invoking bb", async () => {
+    let called = false;
+    await expect(
+      observeNativePluginInventoryForTest({
+        runtimeInstanceId,
+        now: () => 5_000,
+        hostname: () => "https://studio.local:4100/token@secret",
+        runBb: async () => {
+          called = true;
+          return command(JSON.stringify({ plugins: [] }));
+        },
+      }),
+    ).rejects.toThrow("Invalid native inventory hostname");
+    expect(called).toBe(false);
+  });
+
+  test.each([
+    ["command-error", { stdout: "secret", stderr: "private", exitCode: 1 }],
+    ["malformed", command("not json")],
+    ["malformed", command(JSON.stringify({ plugin: [] }))],
+    [
+      "entry-limit",
+      command(
+        JSON.stringify({
+          plugins: Array.from({ length: 257 }, (_, index) => ({
+            id: `row-${index}`,
+          })),
+        }),
+      ),
+    ],
+  ] as const)("returns typed %s top-level evidence", async (status, result) => {
+    const observation = await observeNativePluginInventoryForTest({
+      runtimeInstanceId,
+      now: () => 9_000,
+      hostname: () => "studio.local",
+      runBb: async () => result,
+    });
+
+    const facts = await readObservation(observation);
+    expect(facts).toMatchObject({
+      topLevelStatus: status,
+      entries: [],
+      malformedRows: [],
+    });
+    expect(JSON.stringify(facts)).not.toContain("secret");
+    expect(JSON.stringify(facts)).not.toContain("private");
+  });
+});

--- a/packages/inspection/src/native-inventory-observer.ts
+++ b/packages/inspection/src/native-inventory-observer.ts
@@ -1,0 +1,175 @@
+import os from "node:os";
+
+import { defaultRunBb } from "./native.ts";
+import { parseReleasedNativeInventoryRow } from "./native-inventory-row.ts";
+import { issueNativeInventoryObservation } from "./native-inventory-transition.ts";
+import {
+  NATIVE_INVENTORY_MAX_ENTRIES,
+  NATIVE_INVENTORY_MAX_OUTPUT_BYTES,
+  type NativeInventoryEntry,
+  type NativeInventoryMalformedRow,
+  type NativeInventoryObservation,
+  type NativeInventoryTopLevelStatus,
+  type NativeInventoryTransitionFacts,
+  type ObserveNativePluginInventoryOptions,
+  type ObserveNativePluginInventoryTestOptions,
+} from "./native-inventory-types.ts";
+
+export async function observeNativePluginInventory(
+  options: ObserveNativePluginInventoryOptions,
+): Promise<NativeInventoryObservation> {
+  return observeNativePluginInventoryWithDependencies(options);
+}
+
+/** Test-only deterministic seam. It is intentionally not package-root exported. */
+export async function observeNativePluginInventoryForTest(
+  options: ObserveNativePluginInventoryTestOptions,
+): Promise<NativeInventoryObservation> {
+  return observeNativePluginInventoryWithDependencies(options);
+}
+
+async function observeNativePluginInventoryWithDependencies(
+  options: ObserveNativePluginInventoryTestOptions,
+): Promise<NativeInventoryObservation> {
+  const observedAt = options.now?.() ?? Date.now();
+  const hostname = normalizeHostname(options.hostname?.() ?? os.hostname());
+  assertObservationIdentity(options.runtimeInstanceId, observedAt);
+  const runner =
+    options.runBb ??
+    ((args) =>
+      defaultRunBb(args, {
+        timeoutMs: 5_000,
+        maxOutputBytes: NATIVE_INVENTORY_MAX_OUTPUT_BYTES,
+      }));
+  let result;
+  try {
+    result = await runner(["plugin", "list", "--json"]);
+  } catch {
+    return issueTopLevelObservation(
+      options.runtimeInstanceId,
+      hostname,
+      observedAt,
+      "command-error",
+    );
+  }
+  if (
+    result.exitCode === 125 ||
+    Buffer.byteLength(result.stdout, "utf8") > NATIVE_INVENTORY_MAX_OUTPUT_BYTES
+  ) {
+    return issueTopLevelObservation(
+      options.runtimeInstanceId,
+      hostname,
+      observedAt,
+      "output-limit",
+    );
+  }
+  if (result.exitCode !== 0) {
+    return issueTopLevelObservation(
+      options.runtimeInstanceId,
+      hostname,
+      observedAt,
+      "command-error",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return issueTopLevelObservation(
+      options.runtimeInstanceId,
+      hostname,
+      observedAt,
+      "malformed",
+    );
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.plugins)) {
+    return issueTopLevelObservation(
+      options.runtimeInstanceId,
+      hostname,
+      observedAt,
+      "malformed",
+    );
+  }
+  if (parsed.plugins.length > NATIVE_INVENTORY_MAX_ENTRIES) {
+    return issueTopLevelObservation(
+      options.runtimeInstanceId,
+      hostname,
+      observedAt,
+      "entry-limit",
+    );
+  }
+
+  const entries: NativeInventoryEntry[] = [];
+  const malformedRows: NativeInventoryMalformedRow[] = [];
+  for (const [index, row] of parsed.plugins.entries()) {
+    const normalized = await parseReleasedNativeInventoryRow(row, index);
+    if ("issues" in normalized) malformedRows.push(normalized);
+    else entries.push(normalized);
+  }
+  return issueNativeInventoryObservation({
+    schemaVersion: 1,
+    observedAt,
+    runtimeInstanceId: options.runtimeInstanceId,
+    hostname,
+    topLevelStatus: "ok",
+    entries,
+    malformedRows,
+  });
+}
+
+function issueTopLevelObservation(
+  runtimeInstanceId: string,
+  hostname: string,
+  observedAt: number,
+  topLevelStatus: Exclude<NativeInventoryTopLevelStatus, "ok">,
+): NativeInventoryObservation {
+  return issueNativeInventoryObservation({
+    schemaVersion: 1,
+    observedAt,
+    runtimeInstanceId,
+    hostname,
+    topLevelStatus,
+    entries: [],
+    malformedRows: [],
+  });
+}
+
+function assertObservationIdentity(
+  runtimeInstanceId: string,
+  observedAt: number,
+): void {
+  if (!/^[A-Za-z0-9_-]{32}$/u.test(runtimeInstanceId)) {
+    throw new TypeError("Expected an opaque runtime instance identifier");
+  }
+  if (!Number.isSafeInteger(observedAt) || observedAt < 0) {
+    throw new TypeError("Invalid native inventory observation metadata");
+  }
+}
+
+function normalizeHostname(value: string): string {
+  const hostname = value.trim();
+  if (
+    hostname.length < 1 ||
+    hostname.length > 253 ||
+    hostname.includes(":") ||
+    hostname.includes("/") ||
+    hostname.includes("@") ||
+    hostname.includes("..") ||
+    !hostname
+      .split(".")
+      .every(
+        (label) =>
+          label.length >= 1 &&
+          label.length <= 63 &&
+          /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/u.test(label),
+      )
+  ) {
+    throw new TypeError("Invalid native inventory hostname");
+  }
+  return hostname;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/inspection/src/native-inventory-row-security.test.ts
+++ b/packages/inspection/src/native-inventory-row-security.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { observeNativePluginInventoryForTest } from "./native-inventory.ts";
+import {
+  command,
+  readObservation,
+  runtimeInstanceId,
+} from "./native-inventory-test-helpers.ts";
+
+async function observeRows(plugins: readonly unknown[]) {
+  return readObservation(
+    await observeNativePluginInventoryForTest({
+      runtimeInstanceId,
+      now: () => 2_000,
+      hostname: () => "studio.local",
+      runBb: async () => command(JSON.stringify({ plugins })),
+    }),
+  );
+}
+
+describe("native inventory row security", () => {
+  test("retains matching malformed evidence without retaining unsafe roots", async () => {
+    const unsafeRoot = "/private/secret/plugin";
+    const facts = await observeRows([
+      {
+        id: "notes",
+        source: `path:${unsafeRoot}`,
+        rootDir: 42,
+        version: "1.2.3",
+        provenance: "catalog",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "running",
+      },
+      {
+        id: "memory",
+        source: "npm:bb-plugin-memory@1.0.0",
+        rootDir: "/installed/managed/memory",
+        version: "1.0.0",
+        provenance: "direct",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "disabled",
+      },
+    ]);
+
+    expect(facts.entries).toEqual([
+      {
+        id: "memory",
+        sourceKind: "npm",
+        canonicalRoot: null,
+        version: "1.0.0",
+        provenance: "direct",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "disabled",
+      },
+    ]);
+    expect(facts.malformedRows).toEqual([
+      {
+        index: 0,
+        id: "notes",
+        canonicalRoot: null,
+        issues: ["rootDir", "source-provenance"],
+      },
+    ]);
+    expect(JSON.stringify(facts)).not.toContain(unsafeRoot);
+  });
+
+  test("does not resolve a path-shaped row whose provenance is not direct", async () => {
+    const unsafeRoot = "/definitely/missing/private/plugin";
+    const facts = await observeRows([
+      {
+        id: "notes",
+        source: `path:${unsafeRoot}`,
+        rootDir: unsafeRoot,
+        version: "1.2.3",
+        provenance: "catalog",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "running",
+      },
+    ]);
+
+    expect(facts.malformedRows).toEqual([
+      {
+        index: 0,
+        id: "notes",
+        canonicalRoot: null,
+        issues: ["source-provenance"],
+      },
+    ]);
+    expect(JSON.stringify(facts)).not.toContain(unsafeRoot);
+  });
+
+  test("rejects direct source and runtime root disagreement", async () => {
+    const sourceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-native-source-"),
+    );
+    const runtimeRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-native-runtime-"),
+    );
+    try {
+      const facts = await observeRows([
+        {
+          id: "notes",
+          source: `path:${sourceRoot}`,
+          rootDir: runtimeRoot,
+          version: "1.0.0",
+          provenance: "direct",
+          isOrphanedBuiltin: false,
+          enabled: true,
+          status: "running",
+        },
+      ]);
+
+      expect(facts.entries).toEqual([]);
+      expect(facts.malformedRows).toEqual([
+        {
+          index: 0,
+          id: "notes",
+          canonicalRoot: null,
+          issues: ["source"],
+        },
+      ]);
+      expect(JSON.stringify(facts)).not.toContain(sourceRoot);
+      expect(JSON.stringify(facts)).not.toContain(runtimeRoot);
+    } finally {
+      await Promise.all([
+        fs.rm(sourceRoot, { recursive: true, force: true }),
+        fs.rm(runtimeRoot, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  test("retains only a safely canonicalized root hint for a malformed direct row", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-mate-native-malformed-root-"),
+    );
+    try {
+      const facts = await observeRows([
+        {
+          id: 42,
+          source: `path:${root}`,
+          rootDir: root,
+          version: "1.0.0",
+          provenance: "direct",
+          isOrphanedBuiltin: false,
+          enabled: true,
+          status: "running",
+        },
+      ]);
+
+      expect(facts.malformedRows).toEqual([
+        {
+          index: 0,
+          id: null,
+          canonicalRoot: await fs.realpath(root),
+          issues: ["id"],
+        },
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/inspection/src/native-inventory-row-sources.test.ts
+++ b/packages/inspection/src/native-inventory-row-sources.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+
+import { observeNativePluginInventoryForTest } from "./native-inventory.ts";
+import {
+  command,
+  readObservation,
+  runtimeInstanceId,
+} from "./native-inventory-test-helpers.ts";
+
+async function observeRows(plugins: readonly unknown[]) {
+  return readObservation(
+    await observeNativePluginInventoryForTest({
+      runtimeInstanceId,
+      now: () => 4_000,
+      hostname: () => "studio.local",
+      runBb: async () => command(JSON.stringify({ plugins })),
+    }),
+  );
+}
+
+describe("released native inventory row shapes", () => {
+  test("bounds relevant row strings by UTF-8 bytes", async () => {
+    const facts = await observeRows([
+      {
+        id: "notes",
+        source: "npm:bb-plugin-notes",
+        rootDir: "/installed/notes",
+        version: "é".repeat(128),
+        provenance: "direct",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "running",
+      },
+    ]);
+
+    expect(facts.entries).toEqual([]);
+    expect(facts.malformedRows).toEqual([
+      { index: 0, id: "notes", canonicalRoot: null, issues: ["version"] },
+    ]);
+  });
+
+  test("rejects source schemes without a released source identity", async () => {
+    const facts = await observeRows([
+      {
+        id: "notes",
+        source: "npm:",
+        rootDir: "/installed/notes",
+        version: "1.0.0",
+        provenance: "direct",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "running",
+      },
+    ]);
+
+    expect(facts.malformedRows).toEqual([
+      { index: 0, id: "notes", canonicalRoot: null, issues: ["source"] },
+    ]);
+  });
+
+  test("classifies orphan evidence on a managed source as malformed", async () => {
+    const facts = await observeRows([
+      {
+        id: "notes",
+        source: "npm:bb-plugin-notes",
+        rootDir: "/installed/notes",
+        version: "1.0.0",
+        provenance: "direct",
+        isOrphanedBuiltin: true,
+        enabled: true,
+        status: "running",
+      },
+    ]);
+
+    expect(facts.malformedRows).toEqual([
+      {
+        index: 0,
+        id: "notes",
+        canonicalRoot: null,
+        issues: ["isOrphanedBuiltin"],
+      },
+    ]);
+  });
+
+  test("normalizes managed and bundled rows without resolving installed roots", async () => {
+    const facts = await observeRows([
+      {
+        id: "npm-plugin",
+        source: "npm:bb-plugin-npm@1.0.0",
+        rootDir: "/does/not/exist/npm",
+        version: "1.0.0",
+        provenance: "direct",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "running",
+      },
+      {
+        id: "git-plugin",
+        source: "git:https://example.invalid/plugin.git@main",
+        rootDir: "/does/not/exist/git",
+        version: "2.0.0",
+        provenance: "direct",
+        isOrphanedBuiltin: false,
+        enabled: false,
+        status: "disabled",
+      },
+      {
+        id: "threads",
+        source: "builtin:threads",
+        rootDir: "/does/not/exist/builtin",
+        version: "0.36.0",
+        provenance: "builtin",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "running",
+      },
+      {
+        id: "memory",
+        source: "builtin:memory",
+        rootDir: "/does/not/exist/catalog",
+        version: "0.36.0",
+        provenance: "catalog",
+        isOrphanedBuiltin: false,
+        enabled: true,
+        status: "needs-configuration",
+      },
+    ]);
+
+    expect(facts.malformedRows).toEqual([]);
+    expect(
+      facts.entries.map(({ id, sourceKind, canonicalRoot }) => ({
+        id,
+        sourceKind,
+        canonicalRoot,
+      })),
+    ).toEqual([
+      { id: "npm-plugin", sourceKind: "npm", canonicalRoot: null },
+      { id: "git-plugin", sourceKind: "git", canonicalRoot: null },
+      { id: "threads", sourceKind: "builtin", canonicalRoot: null },
+      { id: "memory", sourceKind: "catalog", canonicalRoot: null },
+    ]);
+    expect(JSON.stringify(facts)).not.toContain("example.invalid");
+    expect(JSON.stringify(facts)).not.toContain("/does/not/exist");
+  });
+});

--- a/packages/inspection/src/native-inventory-row.ts
+++ b/packages/inspection/src/native-inventory-row.ts
@@ -1,0 +1,186 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import type {
+  NativeInventoryEntry,
+  NativeInventoryMalformedRow,
+  NativeInventoryPluginStatus,
+  NativeInventoryProvenance,
+  NativeInventoryRowIssue,
+} from "./native-inventory-types.ts";
+
+type RawNativeInventorySourceKind = "path" | "npm" | "git" | "builtin";
+
+export async function parseReleasedNativeInventoryRow(
+  value: unknown,
+  index: number,
+): Promise<NativeInventoryEntry | NativeInventoryMalformedRow> {
+  if (!isRecord(value)) return malformedRow(index, null, ["row"]);
+  const issues: NativeInventoryRowIssue[] = [];
+  const id = boundedString(value.id, 128);
+  const source = boundedString(value.source, 4_096);
+  const rootDir = boundedString(value.rootDir, 4_096);
+  const version = boundedString(value.version, 128);
+  const provenance = isProvenance(value.provenance) ? value.provenance : null;
+  const status = isPluginStatus(value.status) ? value.status : null;
+
+  if (!id) issues.push("id");
+  if (!source) issues.push("source");
+  if (!rootDir || !path.isAbsolute(rootDir)) issues.push("rootDir");
+  if (!version) issues.push("version");
+  if (!provenance) issues.push("provenance");
+  if (typeof value.isOrphanedBuiltin !== "boolean") {
+    issues.push("isOrphanedBuiltin");
+  }
+  if (typeof value.enabled !== "boolean") issues.push("enabled");
+  if (!status) issues.push("status");
+
+  const rawSourceKind = source ? sourceKind(source) : null;
+  if (source && !rawSourceKind) issues.push("source");
+  if (
+    rawSourceKind &&
+    provenance &&
+    !sourceAndProvenanceAgree(rawSourceKind, provenance)
+  ) {
+    issues.push("source-provenance");
+  }
+  if (
+    value.isOrphanedBuiltin === true &&
+    rawSourceKind !== null &&
+    rawSourceKind !== "builtin"
+  ) {
+    issues.push("isOrphanedBuiltin");
+  }
+
+  const canonicalRoot = await canonicalDirectRoot({
+    issues,
+    provenance,
+    rootDir,
+    source,
+    sourceKind: rawSourceKind,
+  });
+  if (
+    issues.length > 0 ||
+    !id ||
+    !version ||
+    !provenance ||
+    !status ||
+    !rawSourceKind
+  ) {
+    return malformedRow(index, id, issues, canonicalRoot);
+  }
+
+  return Object.freeze({
+    id,
+    sourceKind:
+      rawSourceKind === "builtin" && provenance === "catalog"
+        ? "catalog"
+        : rawSourceKind,
+    canonicalRoot,
+    version,
+    provenance,
+    isOrphanedBuiltin: value.isOrphanedBuiltin as boolean,
+    enabled: value.enabled as boolean,
+    status,
+  });
+}
+
+async function canonicalDirectRoot(input: {
+  readonly issues: NativeInventoryRowIssue[];
+  readonly provenance: NativeInventoryProvenance | null;
+  readonly rootDir: string | null;
+  readonly source: string | null;
+  readonly sourceKind: RawNativeInventorySourceKind | null;
+}): Promise<string | null> {
+  if (
+    input.sourceKind !== "path" ||
+    input.provenance !== "direct" ||
+    !input.rootDir ||
+    !path.isAbsolute(input.rootDir)
+  ) {
+    return null;
+  }
+  const declaredRoot = input.source?.slice("path:".length) ?? "";
+  if (!declaredRoot || !path.isAbsolute(declaredRoot)) {
+    input.issues.push("source");
+    return null;
+  }
+  try {
+    const [canonicalDeclaredRoot, canonicalRuntimeRoot] = await Promise.all([
+      fs.realpath(declaredRoot),
+      fs.realpath(input.rootDir),
+    ]);
+    if (canonicalDeclaredRoot === canonicalRuntimeRoot) {
+      return canonicalRuntimeRoot;
+    }
+    input.issues.push("source");
+  } catch {
+    input.issues.push("canonical-root");
+  }
+  return null;
+}
+
+function boundedString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && Buffer.byteLength(trimmed, "utf8") <= maxLength
+    ? trimmed
+    : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isProvenance(value: unknown): value is NativeInventoryProvenance {
+  return value === "builtin" || value === "direct" || value === "catalog";
+}
+
+function isPluginStatus(value: unknown): value is NativeInventoryPluginStatus {
+  return (
+    value === "running" ||
+    value === "error" ||
+    value === "incompatible" ||
+    value === "missing" ||
+    value === "disabled" ||
+    value === "degraded" ||
+    value === "needs-configuration"
+  );
+}
+
+function sourceKind(value: string): RawNativeInventorySourceKind | null {
+  if (hasSourceIdentity(value, "path:")) return "path";
+  if (hasSourceIdentity(value, "npm:")) return "npm";
+  if (hasSourceIdentity(value, "git:")) return "git";
+  if (hasSourceIdentity(value, "builtin:")) return "builtin";
+  return null;
+}
+
+function hasSourceIdentity(value: string, prefix: string): boolean {
+  return (
+    value.startsWith(prefix) && value.slice(prefix.length).trim().length > 0
+  );
+}
+
+function sourceAndProvenanceAgree(
+  kind: RawNativeInventorySourceKind,
+  provenance: NativeInventoryProvenance,
+): boolean {
+  return kind === "builtin"
+    ? provenance === "builtin" || provenance === "catalog"
+    : provenance === "direct";
+}
+
+function malformedRow(
+  index: number,
+  id: string | null,
+  issues: readonly NativeInventoryRowIssue[],
+  canonicalRoot: string | null = null,
+): NativeInventoryMalformedRow {
+  return Object.freeze({
+    index,
+    id,
+    canonicalRoot,
+    issues: Object.freeze([...new Set(issues)]),
+  });
+}

--- a/packages/inspection/src/native-inventory-test-helpers.ts
+++ b/packages/inspection/src/native-inventory-test-helpers.ts
@@ -1,0 +1,21 @@
+import type { NativeInventoryTransitionFacts } from "./native-inventory-types.ts";
+import {
+  consumeIssuedNativeInventory,
+  readNativeInventoryTransition,
+} from "./native-inventory-transition.ts";
+import type { CommandResult } from "./types.ts";
+
+export const runtimeInstanceId = "r".repeat(32);
+
+export function command(stdout: string): CommandResult {
+  return { stdout, stderr: "", exitCode: 0 };
+}
+
+export async function readObservation(
+  observation: Parameters<typeof consumeIssuedNativeInventory>[0],
+): Promise<NativeInventoryTransitionFacts> {
+  return consumeIssuedNativeInventory(
+    observation,
+    readNativeInventoryTransition,
+  );
+}

--- a/packages/inspection/src/native-inventory-transition.test.ts
+++ b/packages/inspection/src/native-inventory-transition.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  consumeIssuedNativeInventory,
+  observeNativePluginInventoryForTest,
+  readNativeInventoryTransition,
+} from "./native-inventory.ts";
+import { command, runtimeInstanceId } from "./native-inventory-test-helpers.ts";
+
+describe("native inventory transition", () => {
+  test("admits only the exact observation and active one-use transition", async () => {
+    const observation = await observeNativePluginInventoryForTest({
+      runtimeInstanceId,
+      now: () => 6_000,
+      hostname: () => "studio.local",
+      runBb: async () => command(JSON.stringify({ plugins: [] })),
+    });
+    expect(Object.isFrozen(observation)).toBe(true);
+    expect(() => JSON.stringify(observation)).toThrow(
+      "native inventory observations are server-private",
+    );
+    let retainedTransition: unknown;
+
+    await consumeIssuedNativeInventory(observation, (transition) => {
+      retainedTransition = transition;
+      const facts = readNativeInventoryTransition(transition);
+      expect(facts.observedAt).toBe(6_000);
+      expect(Object.isFrozen(facts)).toBe(true);
+      expect(Object.isFrozen(facts.entries)).toBe(true);
+      for (const forged of [
+        { ...(transition as object) },
+        Object.create(transition as object),
+        {},
+      ]) {
+        expect(() => readNativeInventoryTransition(forged)).toThrow(
+          "native inventory transition is not active",
+        );
+      }
+    });
+
+    expect(() => readNativeInventoryTransition(retainedTransition)).toThrow(
+      "native inventory transition is not active",
+    );
+    for (const forged of [{ ...observation }, Object.create(observation), {}]) {
+      await expect(
+        consumeIssuedNativeInventory(forged, () => null),
+      ).rejects.toThrow(
+        "native inventory observation was not issued by inspection",
+      );
+    }
+    await expect(
+      consumeIssuedNativeInventory(observation, () => null),
+    ).rejects.toThrow(
+      "native inventory observation was not issued by inspection",
+    );
+
+    const failedObservation = await observeNativePluginInventoryForTest({
+      runtimeInstanceId,
+      now: () => 6_001,
+      hostname: () => "studio.local",
+      runBb: async () => command(JSON.stringify({ plugins: [] })),
+    });
+    let failedTransition: unknown;
+    await expect(
+      consumeIssuedNativeInventory(failedObservation, (transition) => {
+        failedTransition = transition;
+        throw new Error("consumer failed");
+      }),
+    ).rejects.toThrow("consumer failed");
+    expect(() => readNativeInventoryTransition(failedTransition)).toThrow(
+      "native inventory transition is not active",
+    );
+    await expect(
+      consumeIssuedNativeInventory(failedObservation, () => null),
+    ).rejects.toThrow(
+      "native inventory observation was not issued by inspection",
+    );
+  });
+});

--- a/packages/inspection/src/native-inventory-transition.ts
+++ b/packages/inspection/src/native-inventory-transition.ts
@@ -1,0 +1,88 @@
+import type {
+  NativeInventoryObservation,
+  NativeInventoryTransitionFacts,
+} from "./native-inventory-types.ts";
+
+const issuedObservations = new WeakMap<
+  object,
+  NativeInventoryTransitionFacts
+>();
+const consumedObservations = new WeakSet<object>();
+const activeTransitions = new WeakMap<object, NativeInventoryTransitionFacts>();
+
+export function issueNativeInventoryObservation(
+  input: NativeInventoryTransitionFacts,
+): NativeInventoryObservation {
+  const facts = freezeFacts(input);
+  const observation = { observedAt: facts.observedAt };
+  Object.defineProperty(observation, "toJSON", {
+    enumerable: false,
+    value: () => {
+      throw new TypeError("native inventory observations are server-private");
+    },
+  });
+  Object.freeze(observation);
+  issuedObservations.set(observation, facts);
+  return observation;
+}
+
+export async function consumeIssuedNativeInventory<T>(
+  observation: unknown,
+  consumer: (transition: unknown) => T | Promise<T>,
+): Promise<T> {
+  if (typeof observation !== "object" || observation === null) {
+    throw notIssued();
+  }
+  const facts = issuedObservations.get(observation);
+  if (!facts || consumedObservations.has(observation)) throw notIssued();
+  consumedObservations.add(observation);
+  const transition = createTransition();
+  activeTransitions.set(transition, facts);
+  try {
+    return await consumer(transition);
+  } finally {
+    activeTransitions.delete(transition);
+  }
+}
+
+export function readNativeInventoryTransition(
+  transition: unknown,
+): Readonly<NativeInventoryTransitionFacts> {
+  if (typeof transition !== "object" || transition === null) {
+    throw transitionNotActive();
+  }
+  const facts = activeTransitions.get(transition);
+  if (!facts) throw transitionNotActive();
+  return facts;
+}
+
+function freezeFacts(
+  facts: NativeInventoryTransitionFacts,
+): NativeInventoryTransitionFacts {
+  return Object.freeze({
+    ...facts,
+    entries: Object.freeze([...facts.entries]),
+    malformedRows: Object.freeze([...facts.malformedRows]),
+  });
+}
+
+function createTransition(): object {
+  const transition = {};
+  Object.defineProperty(transition, "toJSON", {
+    enumerable: false,
+    value: () => {
+      throw new TypeError("native inventory transitions are server-private");
+    },
+  });
+  return Object.freeze(transition);
+}
+
+function notIssued(): TypeError {
+  return new TypeError(
+    "native inventory observation was not issued by inspection",
+  );
+}
+
+function transitionNotActive(): TypeError {
+  return new TypeError("native inventory transition is not active");
+}

--- a/packages/inspection/src/native-inventory-types.ts
+++ b/packages/inspection/src/native-inventory-types.ts
@@ -1,0 +1,76 @@
+import type { CommandRunner } from "./types.ts";
+
+export const NATIVE_INVENTORY_MAX_OUTPUT_BYTES = 1_048_576;
+export const NATIVE_INVENTORY_MAX_ENTRIES = 256;
+
+export type NativeInventoryTopLevelStatus =
+  "ok" | "command-error" | "output-limit" | "malformed" | "entry-limit";
+
+export type NativeInventorySourceKind =
+  "path" | "npm" | "git" | "builtin" | "catalog";
+
+export type NativeInventoryProvenance = "builtin" | "direct" | "catalog";
+
+export type NativeInventoryPluginStatus =
+  | "running"
+  | "error"
+  | "incompatible"
+  | "missing"
+  | "disabled"
+  | "degraded"
+  | "needs-configuration";
+
+export type NativeInventoryRowIssue =
+  | "row"
+  | "id"
+  | "source"
+  | "rootDir"
+  | "version"
+  | "provenance"
+  | "isOrphanedBuiltin"
+  | "enabled"
+  | "status"
+  | "source-provenance"
+  | "canonical-root";
+
+export interface NativeInventoryEntry {
+  readonly id: string;
+  readonly sourceKind: NativeInventorySourceKind;
+  readonly canonicalRoot: string | null;
+  readonly version: string;
+  readonly provenance: NativeInventoryProvenance;
+  readonly isOrphanedBuiltin: boolean;
+  readonly enabled: boolean;
+  readonly status: NativeInventoryPluginStatus;
+}
+
+export interface NativeInventoryMalformedRow {
+  readonly index: number;
+  readonly id: string | null;
+  readonly canonicalRoot: string | null;
+  readonly issues: readonly NativeInventoryRowIssue[];
+}
+
+export interface NativeInventoryTransitionFacts {
+  readonly schemaVersion: 1;
+  readonly observedAt: number;
+  readonly runtimeInstanceId: string;
+  readonly hostname: string;
+  readonly topLevelStatus: NativeInventoryTopLevelStatus;
+  readonly entries: readonly NativeInventoryEntry[];
+  readonly malformedRows: readonly NativeInventoryMalformedRow[];
+}
+
+export interface NativeInventoryObservation {
+  readonly observedAt: number;
+}
+
+export interface ObserveNativePluginInventoryOptions {
+  readonly runtimeInstanceId: string;
+}
+
+export interface ObserveNativePluginInventoryTestOptions extends ObserveNativePluginInventoryOptions {
+  readonly runBb?: CommandRunner;
+  readonly now?: () => number;
+  readonly hostname?: () => string;
+}

--- a/packages/inspection/src/native-inventory.ts
+++ b/packages/inspection/src/native-inventory.ts
@@ -1,0 +1,24 @@
+export {
+  observeNativePluginInventory,
+  observeNativePluginInventoryForTest,
+} from "./native-inventory-observer.ts";
+export {
+  consumeIssuedNativeInventory,
+  readNativeInventoryTransition,
+} from "./native-inventory-transition.ts";
+export {
+  NATIVE_INVENTORY_MAX_ENTRIES,
+  NATIVE_INVENTORY_MAX_OUTPUT_BYTES,
+} from "./native-inventory-types.ts";
+export type {
+  NativeInventoryEntry,
+  NativeInventoryMalformedRow,
+  NativeInventoryObservation,
+  NativeInventoryPluginStatus,
+  NativeInventoryProvenance,
+  NativeInventoryRowIssue,
+  NativeInventorySourceKind,
+  NativeInventoryTopLevelStatus,
+  NativeInventoryTransitionFacts,
+  ObserveNativePluginInventoryOptions,
+} from "./native-inventory-types.ts";

--- a/packages/runtime/src/discovery/catalog-integrity.test.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.test.ts
@@ -80,6 +80,63 @@ afterEach(async () => {
 });
 
 describe("development-target private-source integrity", () => {
+  test("rejects a reconciliation event whose private host row is missing", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-private-host-integrity-"),
+    );
+    temporaryRoots.push(parent);
+    const pluginRoot = path.join(parent, "plugin");
+    await fs.mkdir(pluginRoot);
+    await fs.writeFile(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({ name: "bb-plugin-notes", version: "1.2.3" }),
+    );
+    const dataRoot = path.join(parent, "data");
+    const id = ObjectIdSchema.parse("t".repeat(32));
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot,
+      id: () => id,
+      clock: () => 1_000,
+    });
+    await catalog.refresh({
+      principalId,
+      bbContextId,
+      candidate: await issueInspectionCandidate(
+        candidate(await fs.realpath(pluginRoot)),
+      ),
+    });
+    catalog.close();
+
+    const databasePath = path.join(dataRoot, "workbench.sqlite3");
+    const tamper = new Database(databasePath);
+    tamper
+      .query(
+        `INSERT INTO runtime_events (
+          event_type, object_id, object_kind, revision, occurred_at,
+          principal_id, bb_context_id, target_id, session_id
+        ) VALUES ('target.native-reconciled', ?, 'development-target', 1, 1000, ?, ?, ?, NULL)`,
+      )
+      .run(id, principalId, bbContextId, id);
+    tamper.close();
+
+    await expect(
+      openDevelopmentTargetCatalog({ dataRoot }),
+    ).rejects.toMatchObject({ code: "corrupt_data" });
+    const inspect = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        inspect
+          .query(
+            "SELECT COUNT(*) AS count FROM development_target_host_observations",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      inspect.close();
+    }
+  });
+
   test("rejects invalid private field encodings without repairing them", async () => {
     for (const [column, corruptValue] of [
       ["root_key", "configured-label"],

--- a/packages/runtime/src/discovery/catalog-integrity.ts
+++ b/packages/runtime/src/discovery/catalog-integrity.ts
@@ -1,7 +1,9 @@
 import type { Database } from "bun:sqlite";
 
 import { RuntimeError } from "../errors.ts";
+import { DevelopmentTargetPayloadSchema } from "./development-target.ts";
 import { parsePrivateDevelopmentTargetSource } from "./private-source.ts";
+import { parsePrivateHostObservation } from "./private-host-observation.ts";
 
 interface IntegrityRow {
   readonly invalid: number;
@@ -11,6 +13,19 @@ interface PrivateSourceRow {
   readonly canonical_root: string;
   readonly root_key: string;
   readonly root_kind: string;
+}
+
+interface PrivateHostRow {
+  readonly runtime_instance_id: string;
+  readonly hostname: string;
+  readonly bb_host_id: string | null;
+  readonly bb_host_name: string | null;
+  readonly bb_host_is_server: number | null;
+  readonly observed_at: number;
+  readonly payload_json: string;
+  readonly object_revision: number;
+  readonly reconciliation_revision: number;
+  readonly reconciliation_occurred_at: number;
 }
 
 export function createDevelopmentTargetIntegrityCheck(
@@ -38,11 +53,95 @@ export function createDevelopmentTargetIntegrityCheck(
         OR o.target_id != o.id
         OR o.session_id IS NOT NULL
       )
+    UNION ALL
+    SELECT 1 AS invalid
+    FROM development_target_host_observations h
+    LEFT JOIN runtime_objects o ON o.id = h.object_id
+    WHERE o.id IS NULL
+      OR o.kind != 'development-target'
+      OR o.principal_id != h.principal_id
+      OR o.bb_context_id != h.bb_context_id
+      OR o.target_id != o.id
+      OR o.session_id IS NOT NULL
+      OR NOT EXISTS (
+        SELECT 1
+        FROM runtime_events e
+        WHERE e.event_type = 'target.native-reconciled'
+          AND e.object_id = h.object_id
+          AND e.principal_id = h.principal_id
+          AND e.bb_context_id = h.bb_context_id
+          AND e.target_id = h.object_id
+          AND e.session_id IS NULL
+      )
+      OR h.observed_at > (
+        SELECT e.occurred_at
+        FROM runtime_events e
+        WHERE e.event_type = 'target.native-reconciled'
+          AND e.object_id = h.object_id
+          AND e.principal_id = h.principal_id
+          AND e.bb_context_id = h.bb_context_id
+          AND e.target_id = h.object_id
+          AND e.session_id IS NULL
+        ORDER BY e.sequence DESC
+        LIMIT 1
+      )
+    UNION ALL
+    SELECT 1 AS invalid
+    FROM runtime_events e
+    LEFT JOIN runtime_objects o ON o.id = e.object_id
+    LEFT JOIN development_target_host_observations h
+      ON h.object_id = e.object_id
+      AND h.principal_id = e.principal_id
+      AND h.bb_context_id = e.bb_context_id
+    WHERE e.event_type = 'target.native-reconciled'
+      AND (
+        o.id IS NULL
+        OR o.kind != 'development-target'
+        OR e.object_kind != 'development-target'
+        OR o.principal_id != e.principal_id
+        OR o.bb_context_id != e.bb_context_id
+        OR o.target_id != e.target_id
+        OR o.session_id IS NOT e.session_id
+        OR e.revision > o.revision
+        OR e.occurred_at > o.updated_at
+        OR h.object_id IS NULL
+      )
     LIMIT 1
   `);
   const selectPrivateSources = database.query<PrivateSourceRow, []>(`
     SELECT canonical_root, root_key, root_kind
     FROM development_target_sources
+  `);
+  const selectPrivateHosts = database.query<PrivateHostRow, []>(`
+    SELECT h.runtime_instance_id, h.hostname, h.bb_host_id, h.bb_host_name,
+      h.bb_host_is_server, h.observed_at, o.payload_json,
+      o.revision AS object_revision,
+      (
+        SELECT e.revision
+        FROM runtime_events e
+        WHERE e.event_type = 'target.native-reconciled'
+          AND e.object_id = h.object_id
+          AND e.principal_id = h.principal_id
+          AND e.bb_context_id = h.bb_context_id
+          AND e.target_id = h.object_id
+          AND e.session_id IS NULL
+        ORDER BY e.sequence DESC
+        LIMIT 1
+      ) AS reconciliation_revision,
+      (
+        SELECT e.occurred_at
+        FROM runtime_events e
+        WHERE e.event_type = 'target.native-reconciled'
+          AND e.object_id = h.object_id
+          AND e.principal_id = h.principal_id
+          AND e.bb_context_id = h.bb_context_id
+          AND e.target_id = h.object_id
+          AND e.session_id IS NULL
+        ORDER BY e.sequence DESC
+        LIMIT 1
+      ) AS reconciliation_occurred_at
+    FROM development_target_host_observations h
+    INNER JOIN runtime_objects o ON o.id = h.object_id
   `);
 
   return () => {
@@ -54,6 +153,43 @@ export function createDevelopmentTargetIntegrityCheck(
           rootKey: row.root_key,
           rootKind: row.root_kind,
         });
+      }
+      for (const row of selectPrivateHosts.all()) {
+        const observation = parsePrivateHostObservation({
+          runtimeInstanceId: row.runtime_instance_id,
+          hostname: row.hostname,
+          ...(row.bb_host_id === null &&
+          row.bb_host_name === null &&
+          row.bb_host_is_server === null
+            ? {}
+            : {
+                bbHost: {
+                  id: row.bb_host_id,
+                  name: row.bb_host_name,
+                  isServer:
+                    row.bb_host_is_server === 1
+                      ? true
+                      : row.bb_host_is_server === 0
+                        ? false
+                        : row.bb_host_is_server,
+                },
+              }),
+          observedAt: row.observed_at,
+        });
+        const payload = DevelopmentTargetPayloadSchema.parse(
+          JSON.parse(row.payload_json),
+        );
+        if (
+          payload.native.observedAt !== observation.observedAt ||
+          !Number.isSafeInteger(row.object_revision) ||
+          !Number.isSafeInteger(row.reconciliation_revision) ||
+          !Number.isSafeInteger(row.reconciliation_occurred_at) ||
+          row.reconciliation_revision < 1 ||
+          row.reconciliation_revision > row.object_revision ||
+          row.reconciliation_occurred_at < observation.observedAt
+        ) {
+          throw new RuntimeError("corrupt_data");
+        }
       }
     } catch (error) {
       throw new RuntimeError("corrupt_data", { cause: error });

--- a/packages/runtime/src/discovery/catalog-storage.ts
+++ b/packages/runtime/src/discovery/catalog-storage.ts
@@ -14,6 +14,10 @@ import {
   type PrivateDevelopmentTargetSource,
 } from "./private-source.ts";
 import type { TrustedDevelopmentTargetCandidate } from "./trusted-candidate.ts";
+import {
+  parsePrivateHostObservation,
+  type PrivateHostObservation,
+} from "./private-host-observation.ts";
 
 interface ObjectRow {
   readonly id: string;
@@ -32,6 +36,43 @@ interface PrivateRow {
   readonly canonical_root: string;
   readonly root_key: string;
   readonly root_kind: string;
+}
+
+interface PrivateHostRow {
+  readonly runtime_instance_id: string;
+  readonly hostname: string;
+  readonly bb_host_id: string | null;
+  readonly bb_host_name: string | null;
+  readonly bb_host_is_server: number | null;
+  readonly observed_at: number;
+}
+
+function parsePrivateHostRow(row: PrivateHostRow): PrivateHostObservation {
+  try {
+    return parsePrivateHostObservation({
+      runtimeInstanceId: row.runtime_instance_id,
+      hostname: row.hostname,
+      ...(row.bb_host_id === null &&
+      row.bb_host_name === null &&
+      row.bb_host_is_server === null
+        ? {}
+        : {
+            bbHost: {
+              id: row.bb_host_id,
+              name: row.bb_host_name,
+              isServer:
+                row.bb_host_is_server === 1
+                  ? true
+                  : row.bb_host_is_server === 0
+                    ? false
+                    : row.bb_host_is_server,
+            },
+          }),
+      observedAt: row.observed_at,
+    });
+  } catch (error) {
+    throw new RuntimeError("corrupt_data", { cause: error });
+  }
 }
 
 function parseRow(row: ObjectRow): DevelopmentTargetEnvelope {
@@ -81,6 +122,11 @@ export interface DevelopmentTargetCatalogStorage {
     bbContextId: BbContextId,
     id: ObjectId,
   ): PrivateDevelopmentTargetSource | undefined;
+  resolvePrivateHostObservation(
+    principalId: PrincipalId,
+    bbContextId: BbContextId,
+    id: ObjectId,
+  ): PrivateHostObservation | undefined;
   persistCreation(
     envelope: DevelopmentTargetEnvelope,
     candidate: TrustedDevelopmentTargetCandidate,
@@ -88,6 +134,11 @@ export interface DevelopmentTargetCatalogStorage {
   persistUpdate(
     envelope: DevelopmentTargetEnvelope,
     candidate: TrustedDevelopmentTargetCandidate,
+    expectedRevision: number,
+  ): void;
+  persistNativeReconciliation(
+    envelope: DevelopmentTargetEnvelope,
+    observation: PrivateHostObservation,
     expectedRevision: number,
   ): void;
 }
@@ -121,6 +172,12 @@ export function createDevelopmentTargetCatalogStorage(
     FROM development_target_sources
     WHERE object_id = ? AND principal_id = ? AND bb_context_id = ?
   `);
+  const selectPrivateHost = database.query<PrivateHostRow, SQLQueryBindings[]>(`
+    SELECT runtime_instance_id, hostname, bb_host_id, bb_host_name,
+      bb_host_is_server, observed_at
+    FROM development_target_host_observations
+    WHERE object_id = ? AND principal_id = ? AND bb_context_id = ?
+  `);
   const insertObject = database.query(`
     INSERT INTO runtime_objects (
       id, kind, principal_id, bb_context_id, target_id, session_id,
@@ -141,6 +198,18 @@ export function createDevelopmentTargetCatalogStorage(
   const updatePrivate = database.query(`
     UPDATE development_target_sources
     SET root_key = ?, root_kind = ?
+    WHERE object_id = ? AND principal_id = ? AND bb_context_id = ?
+  `);
+  const insertPrivateHost = database.query(`
+    INSERT INTO development_target_host_observations (
+      object_id, principal_id, bb_context_id, runtime_instance_id, hostname,
+      bb_host_id, bb_host_name, bb_host_is_server, observed_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const updatePrivateHost = database.query(`
+    UPDATE development_target_host_observations
+    SET runtime_instance_id = ?, hostname = ?, bb_host_id = ?,
+      bb_host_name = ?, bb_host_is_server = ?, observed_at = ?
     WHERE object_id = ? AND principal_id = ? AND bb_context_id = ?
   `);
 
@@ -201,6 +270,62 @@ export function createDevelopmentTargetCatalogStorage(
       eventFeed.append("object.updated", envelope);
     },
   );
+  const persistNativeReconciliation = database.transaction(
+    (
+      envelope: DevelopmentTargetEnvelope,
+      observation: PrivateHostObservation,
+      expectedRevision: number,
+    ) => {
+      const result = updateObject.run(
+        envelope.revision,
+        envelope.updatedAt,
+        canonicalJson(envelope.payload),
+        envelope.id,
+        envelope.bindings.principalId,
+        envelope.bindings.bbContextId,
+        envelope.bindings.targetId,
+        expectedRevision,
+      );
+      if (result.changes !== 1) throw new RuntimeError("conflict");
+
+      const existing = selectPrivateHost.get(
+        envelope.id,
+        envelope.bindings.principalId,
+        envelope.bindings.bbContextId,
+      );
+      const values = [
+        observation.runtimeInstanceId,
+        observation.hostname,
+        observation.bbHost?.id ?? null,
+        observation.bbHost?.name ?? null,
+        observation.bbHost === undefined
+          ? null
+          : observation.bbHost.isServer
+            ? 1
+            : 0,
+        observation.observedAt,
+      ] as const;
+      if (existing) {
+        const privateResult = updatePrivateHost.run(
+          ...values,
+          envelope.id,
+          envelope.bindings.principalId,
+          envelope.bindings.bbContextId,
+        );
+        if (privateResult.changes !== 1) {
+          throw new RuntimeError("corrupt_data");
+        }
+      } else {
+        insertPrivateHost.run(
+          envelope.id,
+          envelope.bindings.principalId,
+          envelope.bindings.bbContextId,
+          ...values,
+        );
+      }
+      eventFeed.append("target.native-reconciled", envelope);
+    },
+  );
 
   return {
     assertIntegrity,
@@ -225,7 +350,12 @@ export function createDevelopmentTargetCatalogStorage(
           })
         : undefined;
     },
+    resolvePrivateHostObservation(principalId, bbContextId, id) {
+      const row = selectPrivateHost.get(id, principalId, bbContextId);
+      return row ? parsePrivateHostRow(row) : undefined;
+    },
     persistCreation,
     persistUpdate,
+    persistNativeReconciliation,
   };
 }

--- a/packages/runtime/src/discovery/catalog.ts
+++ b/packages/runtime/src/discovery/catalog.ts
@@ -215,6 +215,9 @@ export async function openDevelopmentTargetCatalog(
           now,
         });
         const host = readPrivateHostObservation(input.inventory);
+        if (host.observedAt > now) {
+          throw new RuntimeError("invalid_request");
+        }
         if (host.observedAt !== native.observedAt) {
           throw new RuntimeError("invalid_request");
         }

--- a/packages/runtime/src/discovery/catalog.ts
+++ b/packages/runtime/src/discovery/catalog.ts
@@ -221,6 +221,14 @@ export async function openDevelopmentTargetCatalog(
         if (host.observedAt !== native.observedAt) {
           throw new RuntimeError("invalid_request");
         }
+        const existingHost = storage.resolvePrivateHostObservation(
+          input.principalId,
+          input.bbContextId,
+          input.id,
+        );
+        if (existingHost && host.observedAt <= existingHost.observedAt) {
+          throw new RuntimeError("invalid_request");
+        }
         const envelope = parseDevelopmentTargetEnvelope({
           ...existing,
           revision: existing.revision + 1,

--- a/packages/runtime/src/discovery/catalog.ts
+++ b/packages/runtime/src/discovery/catalog.ts
@@ -17,6 +17,12 @@ import {
   type DevelopmentTargetEnvelope,
 } from "./development-target.ts";
 import type { PrivateDevelopmentTargetSource } from "./private-source.ts";
+import type { PrivateHostObservation } from "./private-host-observation.ts";
+import {
+  readPrivateHostObservation,
+  type TrustedNativeInventory,
+} from "./native-inventory.ts";
+import { reconcileNativeTarget } from "./native-reconciliation.ts";
 import {
   validateTrustedDevelopmentTargetCandidate,
   type TrustedDevelopmentTargetCandidate,
@@ -37,9 +43,21 @@ export interface RefreshDevelopmentTargetInput {
   readonly expectedRevision?: number;
 }
 
+export interface ReconcileDevelopmentTargetNativeInput {
+  readonly principalId: PrincipalId;
+  readonly bbContextId: BbContextId;
+  readonly id: ObjectId;
+  readonly candidate: TrustedDevelopmentTargetCandidate;
+  readonly inventory: TrustedNativeInventory;
+  readonly expectedRevision: number;
+}
+
 export interface DevelopmentTargetCatalog {
   refresh(
     input: RefreshDevelopmentTargetInput,
+  ): Promise<DevelopmentTargetEnvelope>;
+  reconcileNative(
+    input: ReconcileDevelopmentTargetNativeInput,
   ): Promise<DevelopmentTargetEnvelope>;
   list(input: {
     readonly principalId: PrincipalId;
@@ -55,6 +73,11 @@ export interface DevelopmentTargetCatalog {
     readonly bbContextId: BbContextId;
     readonly id: ObjectId;
   }): PrivateDevelopmentTargetSource | undefined;
+  resolvePrivateHostObservation(input: {
+    readonly principalId: PrincipalId;
+    readonly bbContextId: BbContextId;
+    readonly id: ObjectId;
+  }): PrivateHostObservation | undefined;
   close(): void;
 }
 
@@ -100,11 +123,26 @@ export async function openDevelopmentTargetCatalog(
           if (existing.revision !== expectedRevision) {
             throw new RuntimeError("conflict");
           }
+          const privateHost = storage.resolvePrivateHostObservation(
+            input.principalId,
+            input.bbContextId,
+            existing.id,
+          );
+          if (
+            privateHost &&
+            existing.payload.manifest.pluginId !==
+              candidate.target.manifest.pluginId
+          ) {
+            throw new RuntimeError("invalid_request");
+          }
           const envelope = parseDevelopmentTargetEnvelope({
             ...existing,
             revision: existing.revision + 1,
             updatedAt: clock(),
-            payload: candidate.target,
+            payload: {
+              ...candidate.target,
+              ...(privateHost ? { native: existing.payload.native } : {}),
+            },
           });
           storage.persistUpdate(envelope, candidate, expectedRevision);
           return envelope;
@@ -135,6 +173,67 @@ export async function openDevelopmentTargetCatalog(
         storageError(error);
       }
     },
+    async reconcileNative(input) {
+      try {
+        storage.assertIntegrity();
+        const existing = storage.get(
+          input.principalId,
+          input.bbContextId,
+          input.id,
+        );
+        if (!existing) throw new RuntimeError("not_found");
+        if (existing.revision !== input.expectedRevision) {
+          throw new RuntimeError("conflict");
+        }
+        const privateSource = storage.resolvePrivate(
+          input.principalId,
+          input.bbContextId,
+          input.id,
+        );
+        if (!privateSource) throw new RuntimeError("corrupt_data");
+
+        const candidate = await validateTrustedDevelopmentTargetCandidate(
+          input.candidate,
+        );
+        if (
+          candidate.canonicalRoot !== privateSource.canonicalRoot ||
+          candidate.target.manifest.pluginId !==
+            existing.payload.manifest.pluginId ||
+          candidate.target.manifest.packageName !==
+            existing.payload.manifest.packageName ||
+          candidate.target.manifest.version !==
+            existing.payload.manifest.version
+        ) {
+          throw new RuntimeError("invalid_request");
+        }
+
+        const now = clock();
+        const native = reconcileNativeTarget({
+          inventory: input.inventory,
+          targetPluginId: existing.payload.manifest.pluginId,
+          canonicalSourceRoot: privateSource.canonicalRoot,
+          now,
+        });
+        const host = readPrivateHostObservation(input.inventory);
+        if (host.observedAt !== native.observedAt) {
+          throw new RuntimeError("invalid_request");
+        }
+        const envelope = parseDevelopmentTargetEnvelope({
+          ...existing,
+          revision: existing.revision + 1,
+          updatedAt: now,
+          payload: { ...existing.payload, native },
+        });
+        storage.persistNativeReconciliation(
+          envelope,
+          host,
+          input.expectedRevision,
+        );
+        return envelope;
+      } catch (error) {
+        storageError(error);
+      }
+    },
     list(input) {
       try {
         storage.assertIntegrity();
@@ -155,6 +254,18 @@ export async function openDevelopmentTargetCatalog(
       try {
         storage.assertIntegrity();
         return storage.resolvePrivate(
+          input.principalId,
+          input.bbContextId,
+          input.id,
+        );
+      } catch (error) {
+        storageError(error);
+      }
+    },
+    resolvePrivateHostObservation(input) {
+      try {
+        storage.assertIntegrity();
+        return storage.resolvePrivateHostObservation(
           input.principalId,
           input.bbContextId,
           input.id,

--- a/packages/runtime/src/discovery/native-inventory.test.ts
+++ b/packages/runtime/src/discovery/native-inventory.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+
+import { RuntimeError } from "../errors.ts";
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import {
+  createInspectionNativeInventoryBridge,
+  readPrivateHostObservation,
+  type NativeInventoryTransitionFacts,
+} from "./native-inventory.ts";
+
+const RUNTIME_INSTANCE_ID = OpaqueIdSchema.parse("r".repeat(32));
+
+function facts(): NativeInventoryTransitionFacts {
+  return {
+    schemaVersion: 1,
+    observedAt: 1_000,
+    runtimeInstanceId: RUNTIME_INSTANCE_ID,
+    hostname: "devbox.local",
+    topLevelStatus: "ok",
+    entries: [],
+    malformedRows: [],
+  };
+}
+
+function createInspectionHarness() {
+  const issued = new WeakMap<object, NativeInventoryTransitionFacts>();
+  const consumed = new WeakSet<object>();
+  const active = new WeakMap<object, NativeInventoryTransitionFacts>();
+  const bridge = createInspectionNativeInventoryBridge({
+    async consumeIssuedNativeInventory(candidate, consumer) {
+      if (typeof candidate !== "object" || candidate === null) {
+        throw new RuntimeError("invalid_request");
+      }
+      const value = issued.get(candidate);
+      if (!value || consumed.has(candidate)) {
+        throw new RuntimeError("invalid_request");
+      }
+      consumed.add(candidate);
+      const transition = Object.freeze({ transition: true });
+      active.set(transition, value);
+      try {
+        return await consumer(transition);
+      } finally {
+        active.delete(transition);
+      }
+    },
+    readNativeInventoryTransition(transition) {
+      if (typeof transition !== "object" || transition === null) {
+        throw new RuntimeError("invalid_request");
+      }
+      const value = active.get(transition);
+      if (!value) throw new RuntimeError("invalid_request");
+      return value;
+    },
+  });
+
+  return {
+    bridge,
+    issue(value: NativeInventoryTransitionFacts) {
+      const candidate = Object.freeze({ inventory: true });
+      issued.set(candidate, Object.freeze(value));
+      return candidate;
+    },
+  };
+}
+
+describe("trusted native inventory", () => {
+  test("issues a capability only through an active one-use inspection transition", async () => {
+    const harness = createInspectionHarness();
+    const observation = harness.issue(facts());
+
+    const capability = await harness.bridge.issue(observation);
+
+    expect(Object.isFrozen(capability)).toBe(true);
+    expect(() => JSON.stringify(capability)).toThrow(
+      "native inventory capabilities are server-private",
+    );
+    await expect(harness.bridge.issue(observation)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+    await expect(harness.bridge.issue(facts())).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+  });
+
+  test("retains only bounded private host evidence on the exact capability", async () => {
+    const harness = createInspectionHarness();
+    const observation = harness.issue(facts());
+
+    const capability = await harness.bridge.issue(observation);
+
+    expect(readPrivateHostObservation(capability)).toEqual({
+      runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      hostname: "devbox.local",
+      observedAt: 1_000,
+    });
+    for (const clone of [
+      { ...capability },
+      Object.create(capability) as unknown,
+      Object.fromEntries(Object.entries(capability)),
+    ]) {
+      expect(() => readPrivateHostObservation(clone)).toThrow(
+        "Invalid native inventory capability",
+      );
+    }
+  });
+
+  test("strictly admits only the normalized bounded inventory allowlist", async () => {
+    const harness = createInspectionHarness();
+    const normalizedEntry = {
+      id: "notes",
+      sourceKind: "path" as const,
+      canonicalRoot: "/workspace/plugins/notes",
+      version: "1.2.3",
+      provenance: "direct" as const,
+      isOrphanedBuiltin: false,
+      enabled: true,
+      status: "running" as const,
+    };
+    const valid = harness.issue({
+      ...facts(),
+      entries: [normalizedEntry],
+    });
+
+    await expect(harness.bridge.issue(valid)).resolves.toBeObject();
+
+    for (const invalid of [
+      { ...facts(), command: "bb plugin list --json" },
+      {
+        ...facts(),
+        entries: [
+          {
+            id: "notes",
+            sourceKind: "npm",
+            canonicalRoot: "/managed/root",
+            version: "1.2.3",
+            provenance: "catalog",
+            isOrphanedBuiltin: false,
+            enabled: true,
+            status: "running",
+          },
+        ],
+      },
+      {
+        ...facts(),
+        entries: [
+          {
+            id: "notes",
+            sourceKind: "npm",
+            canonicalRoot: null,
+            version: "é".repeat(128),
+            provenance: "direct",
+            isOrphanedBuiltin: false,
+            enabled: true,
+            status: "running",
+          },
+        ],
+      },
+      {
+        ...facts(),
+        malformedRows: [
+          {
+            index: 0,
+            id: "notes",
+            canonicalRoot: "/workspace/plugins/notes",
+            issues: ["source"],
+          },
+        ],
+      },
+      {
+        ...facts(),
+        entries: Array.from({ length: 129 }, () => normalizedEntry),
+        malformedRows: Array.from({ length: 128 }, (_, index) => ({
+          index,
+          id: null,
+          canonicalRoot: null,
+          issues: ["row" as const],
+        })),
+      },
+    ]) {
+      await expect(
+        harness.bridge.issue(
+          harness.issue(invalid as NativeInventoryTransitionFacts),
+        ),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+    }
+  });
+
+  test("withholds a pending capability when inspection transition completion fails", async () => {
+    let captured: unknown;
+    const transition = Object.freeze({ transition: true });
+    const bridge = createInspectionNativeInventoryBridge({
+      async consumeIssuedNativeInventory(_observation, consumer) {
+        captured = await consumer(transition);
+        throw new Error("post-attestation failed");
+      },
+      readNativeInventoryTransition(candidate) {
+        if (candidate !== transition) throw new Error("inactive");
+        return facts();
+      },
+    });
+
+    await expect(bridge.issue(Object.freeze({}))).rejects.toMatchObject({
+      code: "invalid_request",
+    });
+    expect(() => readPrivateHostObservation(captured)).toThrow(
+      "Invalid native inventory capability",
+    );
+  });
+});

--- a/packages/runtime/src/discovery/native-inventory.ts
+++ b/packages/runtime/src/discovery/native-inventory.ts
@@ -1,0 +1,332 @@
+import * as path from "node:path";
+
+import { z } from "zod";
+
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
+import type { PrivateHostObservation } from "./private-host-observation.ts";
+
+const boundedText = (maximum: number) =>
+  z
+    .string()
+    .trim()
+    .min(1)
+    .refine(
+      (value) => Buffer.byteLength(value, "utf8") <= maximum,
+      `Expected at most ${maximum} UTF-8 bytes`,
+    );
+
+const NativeInventoryStatusSchema = z.enum([
+  "running",
+  "error",
+  "incompatible",
+  "missing",
+  "disabled",
+  "degraded",
+  "needs-configuration",
+]);
+
+const NativeInventorySourceKindSchema = z.enum([
+  "path",
+  "npm",
+  "git",
+  "builtin",
+  "catalog",
+]);
+
+const NativeInventoryProvenanceSchema = z.enum([
+  "builtin",
+  "direct",
+  "catalog",
+]);
+
+const CanonicalInventoryRootSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      Buffer.byteLength(value, "utf8") <= 4_096 &&
+      path.isAbsolute(value) &&
+      path.resolve(value) === value,
+    "Expected a canonical absolute path",
+  );
+
+const NativeInventoryEntrySchema = z
+  .strictObject({
+    id: boundedText(128),
+    sourceKind: NativeInventorySourceKindSchema,
+    canonicalRoot: CanonicalInventoryRootSchema.nullable(),
+    version: boundedText(128),
+    provenance: NativeInventoryProvenanceSchema,
+    isOrphanedBuiltin: z.boolean(),
+    enabled: z.boolean(),
+    status: NativeInventoryStatusSchema,
+  })
+  .superRefine((entry, context) => {
+    const expectedProvenance =
+      entry.sourceKind === "path" ||
+      entry.sourceKind === "npm" ||
+      entry.sourceKind === "git"
+        ? "direct"
+        : entry.sourceKind === "builtin"
+          ? "builtin"
+          : "catalog";
+    if (
+      (entry.sourceKind === "path") !== (entry.canonicalRoot !== null) ||
+      entry.provenance !== expectedProvenance ||
+      (entry.isOrphanedBuiltin &&
+        entry.sourceKind !== "builtin" &&
+        entry.sourceKind !== "catalog")
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Contradictory native inventory entry",
+      });
+    }
+  });
+
+const NativeInventoryMalformedIssueSchema = z.enum([
+  "row",
+  "id",
+  "source",
+  "rootDir",
+  "version",
+  "provenance",
+  "isOrphanedBuiltin",
+  "enabled",
+  "status",
+  "source-provenance",
+  "canonical-root",
+]);
+
+const NativeInventoryMalformedRowSchema = z
+  .strictObject({
+    index: z.number().int().nonnegative().max(255),
+    id: boundedText(128).nullable(),
+    canonicalRoot: CanonicalInventoryRootSchema.nullable(),
+    issues: z
+      .array(NativeInventoryMalformedIssueSchema)
+      .min(1)
+      .max(11)
+      .refine((issues) => new Set(issues).size === issues.length),
+  })
+  .superRefine((row, context) => {
+    if (
+      row.canonicalRoot !== null &&
+      row.issues.some((issue) =>
+        [
+          "row",
+          "source",
+          "rootDir",
+          "provenance",
+          "source-provenance",
+          "canonical-root",
+        ].includes(issue),
+      )
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Unsafe malformed inventory root hint",
+      });
+    }
+  });
+
+const NativeInventoryTransitionFactsSchema = z
+  .strictObject({
+    schemaVersion: z.literal(1),
+    observedAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+    runtimeInstanceId: OpaqueIdSchema,
+    hostname: boundedText(253).refine(isSafeHostname),
+    topLevelStatus: z.enum([
+      "ok",
+      "command-error",
+      "output-limit",
+      "malformed",
+      "entry-limit",
+    ]),
+    entries: z.array(NativeInventoryEntrySchema).max(256),
+    malformedRows: z
+      .array(NativeInventoryMalformedRowSchema)
+      .max(256)
+      .refine(
+        (rows) => new Set(rows.map((row) => row.index)).size === rows.length,
+        "Malformed row indices must be unique",
+      ),
+  })
+  .superRefine((facts, context) => {
+    if (facts.entries.length + facts.malformedRows.length > 256) {
+      context.addIssue({
+        code: "custom",
+        message: "Native inventory row limit exceeded",
+      });
+    }
+  });
+
+export type NativeInventoryTransitionFacts = z.input<
+  typeof NativeInventoryTransitionFactsSchema
+>;
+
+type ParsedNativeInventoryTransitionFacts = z.output<
+  typeof NativeInventoryTransitionFactsSchema
+>;
+
+type FrozenNativeInventoryTransitionFacts = Omit<
+  ParsedNativeInventoryTransitionFacts,
+  "entries" | "malformedRows"
+> & {
+  readonly entries: readonly Readonly<NativeInventoryEntry>[];
+  readonly malformedRows: readonly Readonly<
+    Omit<NativeInventoryMalformedRow, "issues"> & {
+      readonly issues: readonly NativeInventoryMalformedRow["issues"][number][];
+    }
+  >[];
+};
+
+export type NativeInventoryEntry = z.output<typeof NativeInventoryEntrySchema>;
+export type NativeInventoryMalformedRow = z.output<
+  typeof NativeInventoryMalformedRowSchema
+>;
+
+const trustedInventories = new WeakMap<
+  object,
+  FrozenNativeInventoryTransitionFacts
+>();
+
+declare const trustedNativeInventoryBrand: unique symbol;
+
+export interface TrustedNativeInventory {
+  readonly [trustedNativeInventoryBrand]: true;
+}
+
+export interface InspectionNativeInventoryBridge {
+  issue(observation: unknown): Promise<TrustedNativeInventory>;
+}
+
+export function createInspectionNativeInventoryBridge(options: {
+  readonly consumeIssuedNativeInventory: (
+    observation: unknown,
+    consumer: (transition: unknown) => unknown | Promise<unknown>,
+  ) => unknown | Promise<unknown>;
+  readonly readNativeInventoryTransition: (transition: unknown) => unknown;
+}): InspectionNativeInventoryBridge {
+  if (
+    typeof options.consumeIssuedNativeInventory !== "function" ||
+    typeof options.readNativeInventoryTransition !== "function"
+  ) {
+    throw new TypeError("Inspection transition functions must be provided");
+  }
+
+  return Object.freeze({
+    async issue(observation: unknown) {
+      try {
+        let consumed = false;
+        let pendingCapability: TrustedNativeInventory | undefined;
+        let pendingFacts: FrozenNativeInventoryTransitionFacts | undefined;
+        const capability = await options.consumeIssuedNativeInventory(
+          observation,
+          (transition) => {
+            if (consumed) throw new RuntimeError("invalid_request");
+            consumed = true;
+            const facts = NativeInventoryTransitionFactsSchema.parse(
+              options.readNativeInventoryTransition(transition),
+            );
+            const issued = createTrustedNativeInventory();
+            pendingCapability = issued;
+            pendingFacts = freezeInventoryFacts(facts);
+            return issued;
+          },
+        );
+        if (
+          !consumed ||
+          typeof capability !== "object" ||
+          capability === null ||
+          capability !== pendingCapability ||
+          !pendingFacts
+        ) {
+          throw new RuntimeError("invalid_request");
+        }
+        trustedInventories.set(capability, pendingFacts);
+        return capability as TrustedNativeInventory;
+      } catch (error) {
+        if (error instanceof RuntimeError) throw error;
+        throw new RuntimeError("invalid_request", { cause: error });
+      }
+    },
+  });
+}
+
+export function readPrivateHostObservation(
+  inventory: unknown,
+): Readonly<PrivateHostObservation> {
+  if (
+    typeof inventory !== "object" ||
+    inventory === null ||
+    !trustedInventories.has(inventory)
+  ) {
+    throw new TypeError("Invalid native inventory capability");
+  }
+  const facts = trustedInventories.get(inventory)!;
+  return Object.freeze({
+    runtimeInstanceId: facts.runtimeInstanceId,
+    hostname: facts.hostname,
+    observedAt: facts.observedAt,
+  });
+}
+
+export function readTrustedNativeInventory(
+  inventory: unknown,
+): Readonly<FrozenNativeInventoryTransitionFacts> {
+  if (
+    typeof inventory !== "object" ||
+    inventory === null ||
+    !trustedInventories.has(inventory)
+  ) {
+    throw new TypeError("Invalid native inventory capability");
+  }
+  return trustedInventories.get(inventory)!;
+}
+
+function freezeInventoryFacts(
+  facts: ParsedNativeInventoryTransitionFacts,
+): FrozenNativeInventoryTransitionFacts {
+  return Object.freeze({
+    ...facts,
+    entries: Object.freeze(
+      facts.entries.map((entry) => Object.freeze({ ...entry })),
+    ),
+    malformedRows: Object.freeze(
+      facts.malformedRows.map((row) =>
+        Object.freeze({ ...row, issues: Object.freeze([...row.issues]) }),
+      ),
+    ),
+  });
+}
+
+function createTrustedNativeInventory(): TrustedNativeInventory {
+  const inventory = {};
+  Object.defineProperty(inventory, "toJSON", {
+    enumerable: false,
+    value: () => {
+      throw new TypeError("native inventory capabilities are server-private");
+    },
+  });
+  return Object.freeze(inventory) as TrustedNativeInventory;
+}
+
+function isSafeHostname(value: string): boolean {
+  if (
+    value.includes(":") ||
+    value.includes("/") ||
+    value.includes("@") ||
+    value.includes("..")
+  ) {
+    return false;
+  }
+  const labels = value.split(".");
+  return labels.every(
+    (label) =>
+      label.length > 0 &&
+      label.length <= 63 &&
+      /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/u.test(label),
+  );
+}

--- a/packages/runtime/src/discovery/native-reconciliation.test.ts
+++ b/packages/runtime/src/discovery/native-reconciliation.test.ts
@@ -1,0 +1,517 @@
+import { describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
+import {
+  consumeIssuedNativeInventory,
+  observeNativePluginInventoryForTest,
+  readNativeInventoryTransition,
+} from "../../../inspection/src/native-inventory.ts";
+import {
+  createInspectionNativeInventoryBridge,
+  type NativeInventoryEntry,
+  type NativeInventoryTransitionFacts,
+  type TrustedNativeInventory,
+} from "./native-inventory.ts";
+import { reconcileNativeTarget } from "./native-reconciliation.ts";
+
+const RUNTIME_INSTANCE_ID = OpaqueIdSchema.parse("r".repeat(32));
+const TARGET_ROOT = "/workspace/plugins/notes";
+
+function entry(
+  overrides: Partial<NativeInventoryEntry> = {},
+): NativeInventoryEntry {
+  return {
+    id: "notes",
+    sourceKind: "path",
+    canonicalRoot: TARGET_ROOT,
+    version: "1.2.3",
+    provenance: "direct",
+    isOrphanedBuiltin: false,
+    enabled: true,
+    status: "running",
+    ...overrides,
+  };
+}
+
+async function inventory(
+  overrides: Partial<NativeInventoryTransitionFacts> = {},
+): Promise<TrustedNativeInventory> {
+  const issued = Object.freeze({ inventory: true });
+  const transition = Object.freeze({ transition: true });
+  let consumed = false;
+  let active = false;
+  const facts: NativeInventoryTransitionFacts = {
+    schemaVersion: 1,
+    observedAt: 1_000,
+    runtimeInstanceId: RUNTIME_INSTANCE_ID,
+    hostname: "devbox.local",
+    topLevelStatus: "ok",
+    entries: [],
+    malformedRows: [],
+    ...overrides,
+  };
+  const bridge = createInspectionNativeInventoryBridge({
+    async consumeIssuedNativeInventory(candidate, consumer) {
+      if (candidate !== issued || consumed) {
+        throw new RuntimeError("invalid_request");
+      }
+      consumed = true;
+      active = true;
+      try {
+        return await consumer(transition);
+      } finally {
+        active = false;
+      }
+    },
+    readNativeInventoryTransition(candidate) {
+      if (candidate !== transition || !active) {
+        throw new RuntimeError("invalid_request");
+      }
+      return facts;
+    },
+  });
+  return bridge.issue(issued);
+}
+
+describe("native target reconciliation", () => {
+  test("classifies the same plugin ID at the exact canonical direct path", async () => {
+    const result = reconcileNativeTarget({
+      inventory: await inventory({ entries: [entry()] }),
+      targetPluginId: "notes",
+      canonicalSourceRoot: TARGET_ROOT,
+      now: 1_001,
+    });
+
+    expect(result).toEqual({
+      status: "exact-path",
+      pluginId: "notes",
+      observedAt: 1_000,
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  test("classifies the same plugin ID at another direct path", async () => {
+    const result = reconcileNativeTarget({
+      inventory: await inventory({
+        entries: [entry({ canonicalRoot: "/workspace/other/notes" })],
+      }),
+      targetPluginId: "notes",
+      canonicalSourceRoot: TARGET_ROOT,
+      now: 1_001,
+    });
+
+    expect(result).toEqual({
+      status: "other-path",
+      pluginId: "notes",
+      observedAt: 1_000,
+    });
+  });
+
+  test("classifies npm and Git installations with the same ID as managed", async () => {
+    for (const sourceKind of ["npm", "git"] as const) {
+      const result = reconcileNativeTarget({
+        inventory: await inventory({
+          entries: [
+            entry({
+              sourceKind,
+              canonicalRoot: null,
+              provenance: "direct",
+            }),
+          ],
+        }),
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_001,
+      });
+
+      expect(result).toEqual({
+        status: "managed",
+        pluginId: "notes",
+        observedAt: 1_000,
+      });
+    }
+  });
+
+  test("interoperates with the real inspection observer for released npm provenance", async () => {
+    const calls: string[][] = [];
+    const observation = await observeNativePluginInventoryForTest({
+      runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      now: () => 1_000,
+      hostname: () => "devbox.local",
+      runBb: async (args) => {
+        calls.push([...args]);
+        return {
+          stdout: JSON.stringify({
+            plugins: [
+              {
+                id: "notes",
+                source: "npm:bb-plugin-notes@1.2.3",
+                rootDir: "/managed/plugins/notes",
+                version: "1.2.3",
+                provenance: "direct",
+                isOrphanedBuiltin: false,
+                enabled: true,
+                status: "running",
+              },
+            ],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      },
+    });
+    const bridge = createInspectionNativeInventoryBridge({
+      consumeIssuedNativeInventory,
+      readNativeInventoryTransition,
+    });
+
+    const result = reconcileNativeTarget({
+      inventory: await bridge.issue(observation),
+      targetPluginId: "notes",
+      canonicalSourceRoot: TARGET_ROOT,
+      now: 1_001,
+    });
+
+    expect(calls).toEqual([["plugin", "list", "--json"]]);
+    expect(result).toEqual({
+      status: "managed",
+      pluginId: "notes",
+      observedAt: 1_000,
+    });
+  });
+
+  test("uses the real observer's safe malformed-root hint to protect a matching target", async () => {
+    const root = await fs.mkdtemp(
+      path.join(await fs.realpath(os.tmpdir()), "bb-mate-native-runtime-"),
+    );
+    try {
+      const observation = await observeNativePluginInventoryForTest({
+        runtimeInstanceId: RUNTIME_INSTANCE_ID,
+        now: () => 1_000,
+        hostname: () => "devbox.local",
+        runBb: async () => ({
+          stdout: JSON.stringify({
+            plugins: [
+              {
+                id: " ",
+                source: `path:${root}`,
+                rootDir: root,
+                version: "1.2.3",
+                provenance: "direct",
+                isOrphanedBuiltin: false,
+                enabled: true,
+                status: "running",
+              },
+            ],
+          }),
+          stderr: "",
+          exitCode: 0,
+        }),
+      });
+      const bridge = createInspectionNativeInventoryBridge({
+        consumeIssuedNativeInventory,
+        readNativeInventoryTransition,
+      });
+
+      expect(
+        reconcileNativeTarget({
+          inventory: await bridge.issue(observation),
+          targetPluginId: "notes",
+          canonicalSourceRoot: await fs.realpath(root),
+          now: 1_001,
+        }),
+      ).toEqual({ status: "malformed", observedAt: 1_000 });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("classifies builtin, bundled catalog, and orphaned builtin identities as conflicts", async () => {
+    const conflicts: NativeInventoryEntry[] = [
+      entry({
+        sourceKind: "builtin",
+        canonicalRoot: null,
+        provenance: "builtin",
+      }),
+      entry({
+        sourceKind: "catalog",
+        canonicalRoot: null,
+        provenance: "catalog",
+      }),
+      entry({
+        sourceKind: "catalog",
+        canonicalRoot: null,
+        provenance: "catalog",
+        isOrphanedBuiltin: true,
+      }),
+    ];
+
+    for (const installed of conflicts) {
+      expect(
+        reconcileNativeTarget({
+          inventory: await inventory({ entries: [installed] }),
+          targetPluginId: "notes",
+          canonicalSourceRoot: TARGET_ROOT,
+          now: 1_001,
+        }),
+      ).toEqual({
+        status: "builtin-conflict",
+        pluginId: "notes",
+        observedAt: 1_000,
+      });
+    }
+  });
+
+  test("reports absent when inventory has no matching ID or canonical root", async () => {
+    const result = reconcileNativeTarget({
+      inventory: await inventory({
+        entries: [
+          entry({
+            id: "calendar",
+            canonicalRoot: "/workspace/plugins/calendar",
+          }),
+        ],
+      }),
+      targetPluginId: "notes",
+      canonicalSourceRoot: TARGET_ROOT,
+      now: 1_001,
+    });
+
+    expect(result).toEqual({ status: "absent", observedAt: 1_000 });
+  });
+
+  test("keeps observations fresh through 30 seconds and marks only older snapshots stale", async () => {
+    const trusted = await inventory({
+      observedAt: 1_000,
+      entries: [entry()],
+    });
+
+    expect(
+      reconcileNativeTarget({
+        inventory: trusted,
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 31_000,
+      }),
+    ).toMatchObject({ status: "exact-path" });
+    expect(
+      reconcileNativeTarget({
+        inventory: trusted,
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 31_001,
+      }),
+    ).toEqual({ status: "stale", observedAt: 1_000 });
+  });
+
+  test("classifies a future observation timestamp as malformed", async () => {
+    expect(
+      reconcileNativeTarget({
+        inventory: await inventory({
+          observedAt: 1_001,
+          entries: [entry()],
+        }),
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_000,
+      }),
+    ).toEqual({ status: "malformed", observedAt: 1_001 });
+  });
+
+  test("gives malformed top-level inventory evidence highest precedence", async () => {
+    for (const topLevelStatus of [
+      "command-error",
+      "output-limit",
+      "malformed",
+      "entry-limit",
+    ] as const) {
+      expect(
+        reconcileNativeTarget({
+          inventory: await inventory({
+            topLevelStatus,
+            entries: [entry()],
+          }),
+          targetPluginId: "notes",
+          canonicalSourceRoot: TARGET_ROOT,
+          now: 1_001,
+        }),
+      ).toEqual({ status: "malformed", observedAt: 1_000 });
+    }
+  });
+
+  test("matching malformed rows win while malformed unrelated siblings do not hide a safe match", async () => {
+    const malformedRow = {
+      index: 1,
+      id: "notes",
+      canonicalRoot: null,
+      issues: ["source-provenance" as const],
+    };
+    expect(
+      reconcileNativeTarget({
+        inventory: await inventory({
+          entries: [entry()],
+          malformedRows: [malformedRow],
+        }),
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_001,
+      }),
+    ).toEqual({ status: "malformed", observedAt: 1_000 });
+
+    expect(
+      reconcileNativeTarget({
+        inventory: await inventory({
+          entries: [entry()],
+          malformedRows: [{ ...malformedRow, id: "calendar" }],
+        }),
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_001,
+      }),
+    ).toMatchObject({ status: "exact-path", pluginId: "notes" });
+
+    expect(
+      reconcileNativeTarget({
+        inventory: await inventory({
+          entries: [entry()],
+          malformedRows: [
+            {
+              ...malformedRow,
+              id: null,
+              canonicalRoot: TARGET_ROOT,
+              issues: ["id"],
+            },
+          ],
+        }),
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_001,
+      }),
+    ).toEqual({ status: "malformed", observedAt: 1_000 });
+  });
+
+  test("classifies duplicate matching plugin IDs or canonical roots before path states", async () => {
+    const duplicateSets: NativeInventoryEntry[][] = [
+      [entry(), entry({ canonicalRoot: "/workspace/other/notes" })],
+      [entry(), entry({ id: "calendar" })],
+    ];
+
+    for (const entries of duplicateSets) {
+      expect(
+        reconcileNativeTarget({
+          inventory: await inventory({ entries }),
+          targetPluginId: "notes",
+          canonicalSourceRoot: TARGET_ROOT,
+          now: 1_001,
+        }),
+      ).toEqual({ status: "duplicate", observedAt: 1_000 });
+    }
+  });
+
+  test("gives duplicate evidence precedence over future and stale timestamps", async () => {
+    const duplicates = [
+      entry(),
+      entry({ canonicalRoot: "/workspace/other/notes" }),
+    ];
+    for (const [observedAt, now] of [
+      [2_000, 1_000],
+      [1_000, 31_001],
+    ] as const) {
+      expect(
+        reconcileNativeTarget({
+          inventory: await inventory({ observedAt, entries: duplicates }),
+          targetPluginId: "notes",
+          canonicalSourceRoot: TARGET_ROOT,
+          now,
+        }),
+      ).toEqual({ status: "duplicate", observedAt });
+    }
+  });
+
+  test("classifies one direct root claiming a different plugin ID as malformed", async () => {
+    expect(
+      reconcileNativeTarget({
+        inventory: await inventory({ entries: [entry({ id: "calendar" })] }),
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_001,
+      }),
+    ).toEqual({ status: "malformed", observedAt: 1_000 });
+  });
+
+  test("rejects raw, cloned, and prototype-derived inventory claims", async () => {
+    const trusted = await inventory({ entries: [entry()] });
+    for (const forged of [
+      { ...trusted },
+      Object.create(trusted) as unknown,
+      {
+        schemaVersion: 1,
+        observedAt: 1_000,
+        entries: [entry()],
+      },
+    ]) {
+      expect(() =>
+        reconcileNativeTarget({
+          inventory: forged as TrustedNativeInventory,
+          targetPluginId: "notes",
+          canonicalSourceRoot: TARGET_ROOT,
+          now: 1_001,
+        }),
+      ).toThrow("Invalid request");
+    }
+  });
+
+  test("returns only the strict public native payload", async () => {
+    const result = reconcileNativeTarget({
+      inventory: await inventory({ entries: [entry()] }),
+      targetPluginId: "notes",
+      canonicalSourceRoot: TARGET_ROOT,
+      now: 1_001,
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(Object.keys(result).sort()).toEqual([
+      "observedAt",
+      "pluginId",
+      "status",
+    ]);
+    for (const privateValue of [
+      TARGET_ROOT,
+      "devbox.local",
+      RUNTIME_INSTANCE_ID,
+      "1.2.3",
+      "running",
+    ]) {
+      expect(serialized).not.toContain(privateValue);
+    }
+  });
+
+  test("rejects invalid target identity, private root, and clock inputs", async () => {
+    const trusted = await inventory();
+    for (const input of [
+      {
+        targetPluginId: "../notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: 1_001,
+      },
+      {
+        targetPluginId: "notes",
+        canonicalSourceRoot: "plugins/notes",
+        now: 1_001,
+      },
+      {
+        targetPluginId: "notes",
+        canonicalSourceRoot: TARGET_ROOT,
+        now: Number.MAX_SAFE_INTEGER + 1,
+      },
+    ]) {
+      expect(() =>
+        reconcileNativeTarget({ inventory: trusted, ...input }),
+      ).toThrow("Invalid request");
+    }
+  });
+});

--- a/packages/runtime/src/discovery/native-reconciliation.ts
+++ b/packages/runtime/src/discovery/native-reconciliation.ts
@@ -1,0 +1,167 @@
+import { z } from "zod";
+
+import { RuntimeError } from "../errors.ts";
+import {
+  DevelopmentTargetPayloadSchema,
+  type DevelopmentTargetPayload,
+} from "./development-target.ts";
+import {
+  readTrustedNativeInventory,
+  type TrustedNativeInventory,
+} from "./native-inventory.ts";
+import { isCanonicalSourcePathFormat } from "./source-path-policy.ts";
+
+const ReconciliationInputSchema = z.strictObject({
+  targetPluginId: z
+    .string()
+    .min(1)
+    .max(64)
+    .regex(/^[a-z0-9][a-z0-9-]*$/u),
+  canonicalSourceRoot: z.string().refine(isCanonicalSourcePathFormat),
+  now: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+});
+
+export interface ReconcileNativeTargetInput {
+  readonly inventory: TrustedNativeInventory;
+  readonly targetPluginId: string;
+  readonly canonicalSourceRoot: string;
+  readonly now: number;
+}
+
+export type NativeReconciliationResult = Readonly<
+  DevelopmentTargetPayload["native"]
+>;
+
+export function reconcileNativeTarget(
+  input: ReconcileNativeTargetInput,
+): NativeReconciliationResult {
+  try {
+    const parsed = ReconciliationInputSchema.parse({
+      targetPluginId: input.targetPluginId,
+      canonicalSourceRoot: input.canonicalSourceRoot,
+      now: input.now,
+    });
+    const inventory = readTrustedNativeInventory(input.inventory);
+    if (inventory.topLevelStatus !== "ok") {
+      return Object.freeze(
+        DevelopmentTargetPayloadSchema.shape.native.parse({
+          status: "malformed",
+          observedAt: inventory.observedAt,
+        }),
+      );
+    }
+    if (
+      inventory.malformedRows.some(
+        (row) =>
+          row.id === parsed.targetPluginId ||
+          row.canonicalRoot === parsed.canonicalSourceRoot,
+      )
+    ) {
+      return Object.freeze(
+        DevelopmentTargetPayloadSchema.shape.native.parse({
+          status: "malformed",
+          observedAt: inventory.observedAt,
+        }),
+      );
+    }
+    const matchingEntries = inventory.entries.filter(
+      (entry) =>
+        entry.id === parsed.targetPluginId ||
+        (entry.sourceKind === "path" &&
+          entry.canonicalRoot === parsed.canonicalSourceRoot),
+    );
+    if (matchingEntries.length > 1) {
+      return Object.freeze(
+        DevelopmentTargetPayloadSchema.shape.native.parse({
+          status: "duplicate",
+          observedAt: inventory.observedAt,
+        }),
+      );
+    }
+    if (
+      matchingEntries.length === 1 &&
+      matchingEntries[0]!.sourceKind === "path" &&
+      matchingEntries[0]!.canonicalRoot === parsed.canonicalSourceRoot &&
+      matchingEntries[0]!.id !== parsed.targetPluginId
+    ) {
+      return Object.freeze(
+        DevelopmentTargetPayloadSchema.shape.native.parse({
+          status: "malformed",
+          observedAt: inventory.observedAt,
+        }),
+      );
+    }
+    if (inventory.observedAt > parsed.now) {
+      return Object.freeze(
+        DevelopmentTargetPayloadSchema.shape.native.parse({
+          status: "malformed",
+          observedAt: inventory.observedAt,
+        }),
+      );
+    }
+    if (parsed.now - inventory.observedAt > 30_000) {
+      return Object.freeze(
+        DevelopmentTargetPayloadSchema.shape.native.parse({
+          status: "stale",
+          observedAt: inventory.observedAt,
+        }),
+      );
+    }
+    const exact = inventory.entries.find(
+      (entry) =>
+        entry.id === parsed.targetPluginId &&
+        entry.sourceKind === "path" &&
+        entry.canonicalRoot === parsed.canonicalSourceRoot,
+    );
+    const otherPath = inventory.entries.find(
+      (entry) =>
+        entry.id === parsed.targetPluginId && entry.sourceKind === "path",
+    );
+    const managed = inventory.entries.find(
+      (entry) =>
+        entry.id === parsed.targetPluginId &&
+        (entry.sourceKind === "npm" || entry.sourceKind === "git"),
+    );
+    const builtinConflict = inventory.entries.find(
+      (entry) =>
+        entry.id === parsed.targetPluginId &&
+        (entry.sourceKind === "builtin" ||
+          entry.sourceKind === "catalog" ||
+          entry.isOrphanedBuiltin),
+    );
+    const native = exact
+      ? {
+          status: "exact-path" as const,
+          pluginId: exact.id,
+          observedAt: inventory.observedAt,
+        }
+      : otherPath
+        ? {
+            status: "other-path" as const,
+            pluginId: otherPath.id,
+            observedAt: inventory.observedAt,
+          }
+        : managed
+          ? {
+              status: "managed" as const,
+              pluginId: managed.id,
+              observedAt: inventory.observedAt,
+            }
+          : builtinConflict
+            ? {
+                status: "builtin-conflict" as const,
+                pluginId: builtinConflict.id,
+                observedAt: inventory.observedAt,
+              }
+            : {
+                status: "absent" as const,
+                observedAt: inventory.observedAt,
+              };
+    return Object.freeze(
+      DevelopmentTargetPayloadSchema.shape.native.parse(native),
+    );
+  } catch (error) {
+    if (error instanceof RuntimeError) throw error;
+    throw new RuntimeError("invalid_request", { cause: error });
+  }
+}

--- a/packages/runtime/src/discovery/private-host-observation.test.ts
+++ b/packages/runtime/src/discovery/private-host-observation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
+import { parsePrivateHostObservation } from "./private-host-observation.ts";
+
+const runtimeInstanceId = OpaqueIdSchema.parse("i".repeat(32));
+
+function validObservation() {
+  return {
+    runtimeInstanceId,
+    hostname: "mate.local",
+    bbHost: {
+      id: "desktop-host",
+      name: "Development Mac",
+      isServer: true,
+    },
+    observedAt: 1_000,
+  };
+}
+
+describe("private host observations", () => {
+  test("accepts only the bounded local host evidence needed for reconciliation", () => {
+    expect(parsePrivateHostObservation(validObservation())).toEqual(
+      validObservation(),
+    );
+    expect(
+      parsePrivateHostObservation({
+        runtimeInstanceId,
+        hostname: "localhost",
+        observedAt: 1_000,
+      }),
+    ).toEqual({ runtimeInstanceId, hostname: "localhost", observedAt: 1_000 });
+  });
+
+  test.each([
+    ["URL", { hostname: "https://mate.local" }],
+    ["port", { hostname: "mate.local:8080" }],
+    ["credentials", { hostname: "user@mate.local" }],
+    [
+      "host metadata URL",
+      {
+        bbHost: { ...validObservation().bbHost, name: "https://host.invalid" },
+      },
+    ],
+    [
+      "host metadata port",
+      { bbHost: { ...validObservation().bbHost, id: "host:8080" } },
+    ],
+    [
+      "host metadata credentials",
+      { bbHost: { ...validObservation().bbHost, name: "user@host" } },
+    ],
+    ["unbounded hostname", { hostname: "a".repeat(254) }],
+    [
+      "unbounded host id",
+      { bbHost: { ...validObservation().bbHost, id: "i".repeat(129) } },
+    ],
+    [
+      "unbounded host name",
+      { bbHost: { ...validObservation().bbHost, name: "n".repeat(129) } },
+    ],
+    ["reachability", { reachable: true }],
+    ["same-host verdict", { sameHost: true }],
+    ["same-instance verdict", { sameInstance: true }],
+    ["browser availability", { browserAvailable: true }],
+    ["topology", { topology: "local" }],
+    ["proxy", { proxyUrl: "https://proxy.invalid" }],
+    ["tunnel", { tunnel: true }],
+    ["sharing", { shareUrl: "https://share.invalid" }],
+  ])("rejects %s fields", (_label, override) => {
+    expect(() =>
+      parsePrivateHostObservation({ ...validObservation(), ...override }),
+    ).toThrow(RuntimeError);
+  });
+});

--- a/packages/runtime/src/discovery/private-host-observation.ts
+++ b/packages/runtime/src/discovery/private-host-observation.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { OpaqueIdSchema, type OpaqueId } from "../contracts/ids.ts";
+import { RuntimeError } from "../errors.ts";
+
+const boundedHostText = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine(
+    (value) =>
+      !/[\u0000-\u001f\u007f]/u.test(value) &&
+      !value.includes(":") &&
+      !value.includes("/") &&
+      !value.includes("@"),
+    "Host metadata must not contain URLs or credentials",
+  );
+
+const HostnameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(253)
+  .refine((value) => {
+    if (
+      value.includes(":") ||
+      value.includes("/") ||
+      value.includes("@") ||
+      value.includes("..")
+    ) {
+      return false;
+    }
+    return value
+      .split(".")
+      .every(
+        (label) =>
+          label.length >= 1 &&
+          label.length <= 63 &&
+          /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/u.test(label),
+      );
+  }, "Expected a hostname without a URL, port, or credentials");
+
+const PrivateHostObservationSchema = z.strictObject({
+  runtimeInstanceId: OpaqueIdSchema,
+  hostname: HostnameSchema,
+  bbHost: z
+    .strictObject({
+      id: boundedHostText,
+      name: boundedHostText,
+      isServer: z.boolean(),
+    })
+    .optional(),
+  observedAt: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+});
+
+export interface PrivateHostObservation {
+  readonly runtimeInstanceId: OpaqueId;
+  readonly hostname: string;
+  readonly bbHost?: {
+    readonly id: string;
+    readonly name: string;
+    readonly isServer: boolean;
+  };
+  readonly observedAt: number;
+}
+
+export function parsePrivateHostObservation(
+  input: unknown,
+): PrivateHostObservation {
+  try {
+    return PrivateHostObservationSchema.parse(input);
+  } catch (error) {
+    throw new RuntimeError("invalid_request", { cause: error });
+  }
+}

--- a/packages/runtime/src/discovery/schema.ts
+++ b/packages/runtime/src/discovery/schema.ts
@@ -34,6 +34,71 @@ const SOURCE_SCHEMA_ENTRIES: readonly ExpectedSchemaEntry[] = [
 ];
 const SOURCE_SCHEMA = `${SOURCES_TABLE};\n${SOURCES_INDEX};`;
 
+const HOST_OBSERVATIONS_TABLE = `CREATE TABLE development_target_host_observations (
+    object_id TEXT PRIMARY KEY,
+    principal_id TEXT NOT NULL,
+    bb_context_id TEXT NOT NULL,
+    runtime_instance_id TEXT NOT NULL CHECK (length(runtime_instance_id) = 32),
+    hostname TEXT NOT NULL CHECK (
+      length(hostname) BETWEEN 1 AND 253
+      AND instr(hostname, ':') = 0
+      AND instr(hostname, '/') = 0
+      AND instr(hostname, '@') = 0
+    ),
+    bb_host_id TEXT CHECK (
+      bb_host_id IS NULL OR (
+        length(bb_host_id) BETWEEN 1 AND 128
+        AND instr(bb_host_id, ':') = 0
+        AND instr(bb_host_id, '/') = 0
+        AND instr(bb_host_id, '@') = 0
+      )
+    ),
+    bb_host_name TEXT CHECK (
+      bb_host_name IS NULL OR (
+        length(bb_host_name) BETWEEN 1 AND 128
+        AND instr(bb_host_name, ':') = 0
+        AND instr(bb_host_name, '/') = 0
+        AND instr(bb_host_name, '@') = 0
+      )
+    ),
+    bb_host_is_server INTEGER CHECK (bb_host_is_server IS NULL OR bb_host_is_server IN (0, 1)),
+    observed_at INTEGER NOT NULL CHECK (observed_at >= 0),
+    FOREIGN KEY (object_id) REFERENCES runtime_objects(id) ON DELETE RESTRICT,
+    CHECK (
+      (bb_host_id IS NULL AND bb_host_name IS NULL AND bb_host_is_server IS NULL)
+      OR
+      (bb_host_id IS NOT NULL AND bb_host_name IS NOT NULL AND bb_host_is_server IS NOT NULL)
+    )
+  ) STRICT`;
+
+const HOST_OBSERVATIONS_INDEX = `CREATE INDEX development_target_host_observations_context
+    ON development_target_host_observations (principal_id, bb_context_id, object_id)`;
+
+const HOST_OBSERVATIONS_NO_DELETE = `CREATE TRIGGER development_target_host_observations_no_delete
+    BEFORE DELETE ON development_target_host_observations
+    BEGIN
+      SELECT RAISE(ABORT, 'development target host observations are append-only');
+    END`;
+
+const HOST_OBSERVATION_SCHEMA_ENTRIES: readonly ExpectedSchemaEntry[] = [
+  {
+    type: "table",
+    name: "development_target_host_observations",
+    sql: HOST_OBSERVATIONS_TABLE,
+  },
+  {
+    type: "index",
+    name: "development_target_host_observations_context",
+    sql: HOST_OBSERVATIONS_INDEX,
+  },
+  {
+    type: "trigger",
+    name: "development_target_host_observations_no_delete",
+    sql: HOST_OBSERVATIONS_NO_DELETE,
+  },
+];
+const HOST_OBSERVATION_SCHEMA = `${HOST_OBSERVATIONS_TABLE};\n${HOST_OBSERVATIONS_INDEX};\n${HOST_OBSERVATIONS_NO_DELETE};`;
+
 export const DEVELOPMENT_TARGET_MIGRATIONS: readonly RuntimeMigration[] = [
   {
     version: 3,
@@ -46,6 +111,22 @@ export const DEVELOPMENT_TARGET_MIGRATIONS: readonly RuntimeMigration[] = [
         database,
         "development_target_sources",
         SOURCE_SCHEMA_ENTRIES,
+      );
+    },
+  },
+  {
+    version: 4,
+    checksum: createHash("sha256")
+      .update(HOST_OBSERVATION_SCHEMA)
+      .digest("hex"),
+    apply(database) {
+      database.exec(HOST_OBSERVATION_SCHEMA);
+    },
+    verify(database) {
+      verifyOwnedSchema(
+        database,
+        "development_target_host_observations",
+        HOST_OBSERVATION_SCHEMA_ENTRIES,
       );
     },
   },

--- a/packages/runtime/src/events/feed.ts
+++ b/packages/runtime/src/events/feed.ts
@@ -13,7 +13,8 @@ const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 100;
 const CURSOR_PATTERN = /^v1_([0-9a-z]+)$/u;
 
-export type ObjectEventType = "object.created" | "object.updated";
+export type ObjectEventType =
+  "object.created" | "object.updated" | "target.native-reconciled";
 
 export interface ObjectEvent {
   readonly cursor: string;
@@ -49,7 +50,8 @@ function parseEventRow(row: EventRow): ObjectEvent {
     !Number.isSafeInteger(row.sequence) ||
     row.sequence < 1 ||
     (row.event_type !== "object.created" &&
-      row.event_type !== "object.updated") ||
+      row.event_type !== "object.updated" &&
+      row.event_type !== "target.native-reconciled") ||
     !Number.isSafeInteger(row.revision) ||
     row.revision < 1 ||
     !Number.isSafeInteger(row.occurred_at) ||

--- a/packages/runtime/src/persistence/development-target-schema.test.ts
+++ b/packages/runtime/src/persistence/development-target-schema.test.ts
@@ -17,6 +17,49 @@ afterEach(async () => {
 });
 
 describe("development-target source schema attestation", () => {
+  test("creates a strict private host-observation table with no topology fields", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-target-host-schema-"),
+    );
+    temporaryRoots.push(parent);
+    const dataRoot = path.join(parent, "data");
+    (await openDevelopmentTargetCatalog({ dataRoot })).close();
+
+    const database = new Database(path.join(dataRoot, "workbench.sqlite3"), {
+      readonly: true,
+    });
+    try {
+      expect(
+        database
+          .query<{ name: string }, []>(
+            "SELECT name FROM pragma_table_info('development_target_host_observations') ORDER BY cid",
+          )
+          .all()
+          .map(({ name }) => name),
+      ).toEqual([
+        "object_id",
+        "principal_id",
+        "bb_context_id",
+        "runtime_instance_id",
+        "hostname",
+        "bb_host_id",
+        "bb_host_name",
+        "bb_host_is_server",
+        "observed_at",
+      ]);
+      expect(
+        database
+          .query<{ sql: string }, []>(
+            "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'development_target_host_observations'",
+          )
+          .get()!.sql,
+      ).toContain("STRICT");
+    } finally {
+      database.close();
+    }
+  });
+
   test("rejects a missing private-source index without recreating it", async () => {
     const temporaryRoot = await fs.realpath(os.tmpdir());
     const parent = await fs.mkdtemp(
@@ -41,6 +84,38 @@ describe("development-target source schema attestation", () => {
         inspect
           .query(
             "SELECT name FROM sqlite_schema WHERE name = 'development_target_sources_context'",
+          )
+          .get(),
+      ).toBeNull();
+    } finally {
+      inspect.close();
+    }
+  });
+
+  test("rejects a missing private-host no-delete trigger without recreating it", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-target-host-attestation-"),
+    );
+    temporaryRoots.push(parent);
+    const dataRoot = path.join(parent, "data");
+    (await openDevelopmentTargetCatalog({ dataRoot })).close();
+
+    const databasePath = path.join(dataRoot, "workbench.sqlite3");
+    const tamper = new Database(databasePath);
+    tamper.exec("DROP TRIGGER development_target_host_observations_no_delete");
+    tamper.close();
+
+    await expect(
+      openDevelopmentTargetCatalog({ dataRoot }),
+    ).rejects.toMatchObject({ code: "corrupt_data" });
+
+    const inspect = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        inspect
+          .query(
+            "SELECT name FROM sqlite_schema WHERE name = 'development_target_host_observations_no_delete'",
           )
           .get(),
       ).toBeNull();

--- a/packages/runtime/src/service/development-target-reconciliation-fixture.ts
+++ b/packages/runtime/src/service/development-target-reconciliation-fixture.ts
@@ -1,0 +1,178 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { createRequestContext } from "../auth/context.ts";
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+  TargetIdSchema,
+} from "../contracts/ids.ts";
+import { createInspectionNativeInventoryBridge } from "../discovery/native-inventory.ts";
+import { inspectDevelopmentSourceIdentity } from "../discovery/source-identity.ts";
+import {
+  createInspectionDevelopmentTargetCandidateBridge,
+  type InspectionSourceCandidateFacts,
+} from "../discovery/trusted-candidate.ts";
+import { RuntimeError } from "../errors.ts";
+
+const temporaryRoots: string[] = [];
+export const objectId = ObjectIdSchema.parse("t".repeat(32));
+export const targetId = TargetIdSchema.parse("t".repeat(32));
+export const principalId = PrincipalIdSchema.parse("p".repeat(32));
+export const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+
+async function issueInspectionCandidate(value: InspectionSourceCandidateFacts) {
+  const source = Object.freeze({ ...value });
+  const transition = Object.freeze({ transition: true });
+  const identity = await inspectDevelopmentSourceIdentity(value.canonicalRoot);
+  let active = false;
+  return createInspectionDevelopmentTargetCandidateBridge({
+    clock: () => 1_000,
+    async consumeIssuedSourceCandidate(candidate, consumer) {
+      if (candidate !== source) throw new RuntimeError("invalid_request");
+      active = true;
+      try {
+        return await consumer(transition);
+      } finally {
+        active = false;
+      }
+    },
+    readSourceCandidateTransition(candidate) {
+      if (candidate !== transition || !active) {
+        throw new RuntimeError("invalid_request");
+      }
+      return {
+        ...value,
+        directoryIdentity: {
+          canonicalRoot: identity.canonicalRoot,
+          device: identity.device,
+          inode: identity.inode,
+        },
+        manifestIdentity: identity.manifest,
+      };
+    },
+  }).issue(source);
+}
+
+export async function issueNativeInventory(
+  canonicalRoot: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const observation = Object.freeze({ observation: true });
+  const transition = Object.freeze({ transition: true });
+  let active = false;
+  return createInspectionNativeInventoryBridge({
+    async consumeIssuedNativeInventory(input, consumer) {
+      if (input !== observation) throw new RuntimeError("invalid_request");
+      active = true;
+      try {
+        return await consumer(transition);
+      } finally {
+        active = false;
+      }
+    },
+    readNativeInventoryTransition(input) {
+      if (input !== transition || !active) {
+        throw new RuntimeError("invalid_request");
+      }
+      return {
+        schemaVersion: 1,
+        observedAt: 1_500,
+        runtimeInstanceId: OpaqueIdSchema.parse("i".repeat(32)),
+        hostname: "mate.local",
+        topLevelStatus: "ok",
+        entries: [
+          {
+            id: "notes",
+            sourceKind: "path",
+            canonicalRoot,
+            version: "1.2.3",
+            provenance: "direct",
+            isOrphanedBuiltin: false,
+            enabled: true,
+            status: "running",
+          },
+        ],
+        malformedRows: [],
+        ...overrides,
+      };
+    },
+  }).issue(observation);
+}
+
+export async function makeFixture() {
+  const temporaryRoot = await fs.realpath(os.tmpdir());
+  const parent = await fs.mkdtemp(
+    path.join(temporaryRoot, "bb-mate-development-target-"),
+  );
+  temporaryRoots.push(parent);
+  const pluginRoot = path.join(parent, "plugin");
+  await fs.mkdir(pluginRoot);
+  await fs.writeFile(
+    path.join(pluginRoot, "package.json"),
+    JSON.stringify({ name: "bb-plugin-notes", version: "1.2.3" }),
+  );
+  return {
+    dataRoot: path.join(parent, "data"),
+    pluginRoot: await fs.realpath(pluginRoot),
+  };
+}
+
+export function context() {
+  return createRequestContext({
+    id: principalId,
+    kind: "supervisor",
+    scopes: ["targets:read", "targets:write"],
+    revoked: false,
+    bbContextId,
+  });
+}
+
+function candidateInput(canonicalRoot: string) {
+  return {
+    rootKey: OpaqueIdSchema.parse("r".repeat(32)),
+    rootKind: "current-project" as const,
+    canonicalRoot,
+    target: {
+      displayName: "Notes",
+      displayPath: "plugins/notes",
+      sourceKind: "workspace-discovered" as const,
+      manifest: {
+        pluginId: "notes",
+        packageName: "bb-plugin-notes",
+        version: "1.2.3",
+        hasServer: true,
+        hasApp: true,
+      },
+      native: { status: "absent" as const, observedAt: 1_000 },
+      capabilities: { fixture: true, harness: false, live: false },
+    },
+  };
+}
+
+export async function candidate(canonicalRoot: string) {
+  const input = candidateInput(canonicalRoot);
+  return issueInspectionCandidate({
+    rootKey: input.rootKey,
+    rootKind: input.rootKind,
+    canonicalRoot: input.canonicalRoot,
+    displayName: input.target.displayName,
+    displayPath: input.target.displayPath,
+    packageName: input.target.manifest.packageName,
+    version: input.target.manifest.version,
+    pluginId: input.target.manifest.pluginId,
+    hasServer: input.target.manifest.hasServer,
+    hasApp: input.target.manifest.hasApp,
+  });
+}
+
+export async function cleanupDevelopmentTargetReconciliationFixtures() {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+}

--- a/packages/runtime/src/service/development-target-reconciliation-persistence.test.ts
+++ b/packages/runtime/src/service/development-target-reconciliation-persistence.test.ts
@@ -67,6 +67,95 @@ describe("DevelopmentTargetService native reconciliation persistence", () => {
     }
   });
 
+  test("rejects equal and older observations without regressing persisted state", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 3_000,
+    });
+    const service = createDevelopmentTargetService(catalog);
+    const created = await service.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    const accepted = await service.reconcileFromTrustedInventory(context(), {
+      targetId: created.id,
+      sourceCandidate: await candidate(fixture.pluginRoot),
+      inventory: await issueNativeInventory(fixture.pluginRoot, {
+        observedAt: 2_500,
+        runtimeInstanceId: OpaqueIdSchema.parse("j".repeat(32)),
+        hostname: "newer.local",
+      }),
+      expectedRevision: 1,
+    });
+    const acceptedHost = {
+      runtimeInstanceId: OpaqueIdSchema.parse("j".repeat(32)),
+      hostname: "newer.local",
+      observedAt: 2_500,
+    };
+    const database = new Database(
+      path.join(fixture.dataRoot, "workbench.sqlite3"),
+    );
+    const events = database
+      .query("SELECT * FROM runtime_events ORDER BY sequence")
+      .all();
+
+    try {
+      for (const observedAt of [2_500, 1_500]) {
+        await expect(
+          service.reconcileFromTrustedInventory(context(), {
+            targetId: created.id,
+            sourceCandidate: await candidate(fixture.pluginRoot),
+            inventory: await issueNativeInventory(fixture.pluginRoot, {
+              observedAt,
+              runtimeInstanceId: OpaqueIdSchema.parse("k".repeat(32)),
+              hostname: "replayed.local",
+            }),
+            expectedRevision: 2,
+          }),
+        ).rejects.toMatchObject({ code: "invalid_request" });
+        expect(service.getTarget(context(), created.id)).toEqual(accepted);
+        expect(
+          catalog.resolvePrivateHostObservation({
+            principalId,
+            bbContextId,
+            id: objectId,
+          }),
+        ).toEqual(acceptedHost);
+        expect(
+          database
+            .query("SELECT * FROM runtime_events ORDER BY sequence")
+            .all(),
+        ).toEqual(events);
+      }
+    } finally {
+      database.close();
+      catalog.close();
+    }
+
+    const reopened = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+    });
+    try {
+      expect(
+        createDevelopmentTargetService(reopened).getTarget(
+          context(),
+          created.id,
+        ),
+      ).toEqual(accepted);
+      expect(
+        reopened.resolvePrivateHostObservation({
+          principalId,
+          bbContextId,
+          id: objectId,
+        }),
+      ).toEqual(acceptedHost);
+    } finally {
+      reopened.close();
+    }
+  });
+
   test("rolls back the public target, private host row, and redacted event on either private or event failure", async () => {
     const fixture = await makeFixture();
     const catalog = await openDevelopmentTargetCatalog({

--- a/packages/runtime/src/service/development-target-reconciliation-persistence.test.ts
+++ b/packages/runtime/src/service/development-target-reconciliation-persistence.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as path from "node:path";
+
+import { ObjectIdSchema, OpaqueIdSchema } from "../contracts/ids.ts";
+import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
+import {
+  bbContextId,
+  candidate,
+  cleanupDevelopmentTargetReconciliationFixtures,
+  context,
+  issueNativeInventory,
+  makeFixture,
+  objectId,
+  principalId,
+} from "./development-target-reconciliation-fixture.ts";
+import { createDevelopmentTargetService } from "./development-target-service.ts";
+
+afterEach(cleanupDevelopmentTargetReconciliationFixtures);
+
+describe("DevelopmentTargetService native reconciliation persistence", () => {
+  test("rolls back the public target, private host row, and redacted event on either private or event failure", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    const service = createDevelopmentTargetService(catalog);
+    const created = await service.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    const database = new Database(
+      path.join(fixture.dataRoot, "workbench.sqlite3"),
+    );
+    const reconcile = async () =>
+      service.reconcileFromTrustedInventory(context(), {
+        targetId: created.id,
+        sourceCandidate: await candidate(fixture.pluginRoot),
+        inventory: await issueNativeInventory(fixture.pluginRoot),
+        expectedRevision: 1,
+      });
+    try {
+      database.exec(`
+        CREATE TRIGGER test_fail_private_host
+        BEFORE INSERT ON development_target_host_observations
+        BEGIN
+          SELECT RAISE(ABORT, 'injected private host failure');
+        END
+      `);
+      await expect(reconcile()).rejects.toMatchObject({ code: "internal" });
+      database.exec("DROP TRIGGER test_fail_private_host");
+      expect(service.getTarget(context(), created.id)).toEqual(created);
+      expect(
+        database
+          .query(
+            "SELECT COUNT(*) AS count FROM development_target_host_observations",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        database
+          .query("SELECT event_type FROM runtime_events ORDER BY sequence")
+          .all(),
+      ).toEqual([{ event_type: "object.created" }]);
+
+      database.exec(`
+        CREATE TRIGGER test_fail_native_event
+        BEFORE INSERT ON runtime_events
+        WHEN NEW.event_type = 'target.native-reconciled'
+        BEGIN
+          SELECT RAISE(ABORT, 'injected native event failure');
+        END
+      `);
+      await expect(reconcile()).rejects.toMatchObject({ code: "internal" });
+      database.exec("DROP TRIGGER test_fail_native_event");
+      expect(service.getTarget(context(), created.id)).toEqual(created);
+      expect(
+        database
+          .query(
+            "SELECT COUNT(*) AS count FROM development_target_host_observations",
+          )
+          .get(),
+      ).toEqual({ count: 0 });
+      expect(
+        database
+          .query("SELECT event_type FROM runtime_events ORDER BY sequence")
+          .all(),
+      ).toEqual([{ event_type: "object.created" }]);
+    } finally {
+      database.close();
+      catalog.close();
+    }
+  });
+
+  test("reopens and reconciles again without changing the server-issued target id", async () => {
+    const fixture = await makeFixture();
+    let now = 2_000;
+    const first = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => now,
+    });
+    const firstService = createDevelopmentTargetService(first);
+    const created = await firstService.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    const reconciled = await firstService.reconcileFromTrustedInventory(
+      context(),
+      {
+        targetId: created.id,
+        sourceCandidate: await candidate(fixture.pluginRoot),
+        inventory: await issueNativeInventory(fixture.pluginRoot),
+        expectedRevision: 1,
+      },
+    );
+    first.close();
+
+    now = 3_000;
+    const reopened = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => ObjectIdSchema.parse("u".repeat(32)),
+      clock: () => now,
+    });
+    try {
+      const service = createDevelopmentTargetService(reopened);
+      expect(service.getTarget(context(), created.id)).toEqual(reconciled);
+      const refreshed = await service.reconcileFromTrustedInventory(context(), {
+        targetId: created.id,
+        sourceCandidate: await candidate(fixture.pluginRoot),
+        inventory: await issueNativeInventory(fixture.pluginRoot, {
+          observedAt: 2_500,
+          runtimeInstanceId: OpaqueIdSchema.parse("j".repeat(32)),
+          hostname: "second.local",
+        }),
+        expectedRevision: 2,
+      });
+      expect(refreshed).toMatchObject({
+        id: created.id,
+        revision: 3,
+        updatedAt: 3_000,
+        native: { status: "exact-path", observedAt: 2_500 },
+      });
+      expect(
+        reopened.resolvePrivateHostObservation({
+          principalId,
+          bbContextId,
+          id: objectId,
+        }),
+      ).toEqual({
+        runtimeInstanceId: OpaqueIdSchema.parse("j".repeat(32)),
+        hostname: "second.local",
+        observedAt: 2_500,
+      });
+    } finally {
+      reopened.close();
+    }
+  });
+
+  test("preserves the attested native observation across a later source refresh", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      const created = await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      const reconciled = await service.reconcileFromTrustedInventory(
+        context(),
+        {
+          targetId: created.id,
+          sourceCandidate: await candidate(fixture.pluginRoot),
+          inventory: await issueNativeInventory(fixture.pluginRoot),
+          expectedRevision: 1,
+        },
+      );
+      const refreshed = await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+        { expectedRevision: 2 },
+      );
+      expect(refreshed).toMatchObject({
+        id: created.id,
+        revision: 3,
+        native: reconciled.native,
+      });
+      expect(service.getTarget(context(), created.id)).toEqual(refreshed);
+      expect(
+        catalog.resolvePrivateHostObservation({
+          principalId,
+          bbContextId,
+          id: objectId,
+        })?.observedAt,
+      ).toBe(refreshed.native.observedAt);
+    } finally {
+      catalog.close();
+    }
+  });
+
+  test("fails closed without repairing corrupt private host evidence", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    const service = createDevelopmentTargetService(catalog);
+    const created = await service.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    await service.reconcileFromTrustedInventory(context(), {
+      targetId: created.id,
+      sourceCandidate: await candidate(fixture.pluginRoot),
+      inventory: await issueNativeInventory(fixture.pluginRoot),
+      expectedRevision: 1,
+    });
+    catalog.close();
+
+    const databasePath = path.join(fixture.dataRoot, "workbench.sqlite3");
+    const tamper = new Database(databasePath);
+    tamper.exec("PRAGMA ignore_check_constraints = ON");
+    tamper
+      .query("UPDATE development_target_host_observations SET hostname = ?")
+      .run("https://mate.local:8080");
+    tamper.close();
+
+    await expect(
+      openDevelopmentTargetCatalog({ dataRoot: fixture.dataRoot }),
+    ).rejects.toMatchObject({ code: "corrupt_data" });
+    const inspect = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        inspect
+          .query<{ hostname: string }, []>(
+            "SELECT hostname FROM development_target_host_observations",
+          )
+          .get(),
+      ).toEqual({ hostname: "https://mate.local:8080" });
+    } finally {
+      inspect.close();
+    }
+  });
+
+  test("rejects a valid-looking private timestamp that diverges from the canonical public native observation", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    const service = createDevelopmentTargetService(catalog);
+    const created = await service.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+    await service.reconcileFromTrustedInventory(context(), {
+      targetId: created.id,
+      sourceCandidate: await candidate(fixture.pluginRoot),
+      inventory: await issueNativeInventory(fixture.pluginRoot),
+      expectedRevision: 1,
+    });
+    catalog.close();
+
+    const databasePath = path.join(fixture.dataRoot, "workbench.sqlite3");
+    const tamper = new Database(databasePath);
+    tamper.exec(
+      "UPDATE development_target_host_observations SET observed_at = 1400",
+    );
+    tamper.close();
+
+    await expect(
+      openDevelopmentTargetCatalog({ dataRoot: fixture.dataRoot }),
+    ).rejects.toMatchObject({ code: "corrupt_data" });
+    const inspect = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        inspect
+          .query<{ observed_at: number }, []>(
+            "SELECT observed_at FROM development_target_host_observations",
+          )
+          .get(),
+      ).toEqual({ observed_at: 1_400 });
+      expect(
+        inspect
+          .query<{ payload_json: string }, []>(
+            "SELECT payload_json FROM runtime_objects",
+          )
+          .get()!.payload_json,
+      ).toContain('"observedAt":1500');
+    } finally {
+      inspect.close();
+    }
+  });
+});

--- a/packages/runtime/src/service/development-target-reconciliation-persistence.test.ts
+++ b/packages/runtime/src/service/development-target-reconciliation-persistence.test.ts
@@ -19,6 +19,54 @@ import { createDevelopmentTargetService } from "./development-target-service.ts"
 afterEach(cleanupDevelopmentTargetReconciliationFixtures);
 
 describe("DevelopmentTargetService native reconciliation persistence", () => {
+  test("rejects a future-dated observation without corrupting persisted state", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    const service = createDevelopmentTargetService(catalog);
+    const created = await service.refreshFromTrustedCandidate(
+      context(),
+      await candidate(fixture.pluginRoot),
+    );
+
+    await expect(
+      service.reconcileFromTrustedInventory(context(), {
+        targetId: created.id,
+        sourceCandidate: await candidate(fixture.pluginRoot),
+        inventory: await issueNativeInventory(fixture.pluginRoot, {
+          observedAt: 2_001,
+        }),
+        expectedRevision: 1,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+    expect(service.getTarget(context(), created.id)).toEqual(created);
+    expect(
+      catalog.resolvePrivateHostObservation({
+        principalId,
+        bbContextId,
+        id: objectId,
+      }),
+    ).toBeUndefined();
+    catalog.close();
+
+    const reopened = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+    });
+    try {
+      expect(
+        createDevelopmentTargetService(reopened).getTarget(
+          context(),
+          created.id,
+        ),
+      ).toEqual(created);
+    } finally {
+      reopened.close();
+    }
+  });
+
   test("rolls back the public target, private host row, and redacted event on either private or event failure", async () => {
     const fixture = await makeFixture();
     const catalog = await openDevelopmentTargetCatalog({

--- a/packages/runtime/src/service/development-target-reconciliation-service.test.ts
+++ b/packages/runtime/src/service/development-target-reconciliation-service.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { createRequestContext } from "../auth/context.ts";
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+} from "../contracts/ids.ts";
+import { openDevelopmentTargetCatalog } from "../discovery/catalog.ts";
+import { RuntimeError } from "../errors.ts";
+import { createEventFeed } from "../events/feed.ts";
+import {
+  bbContextId,
+  candidate,
+  cleanupDevelopmentTargetReconciliationFixtures,
+  context,
+  issueNativeInventory,
+  makeFixture,
+  objectId,
+  principalId,
+  targetId,
+} from "./development-target-reconciliation-fixture.ts";
+import { createDevelopmentTargetService } from "./development-target-service.ts";
+
+afterEach(cleanupDevelopmentTargetReconciliationFixtures);
+
+describe("DevelopmentTargetService native reconciliation authorization", () => {
+  test("atomically reconciles a catalog target and keeps native host evidence private", async () => {
+    const fixture = await makeFixture();
+    let now = 1_000;
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => now,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      const created = await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      now = 2_000;
+      const reconciled = await service.reconcileFromTrustedInventory(
+        context(),
+        {
+          targetId: created.id,
+          sourceCandidate: await candidate(fixture.pluginRoot),
+          inventory: await issueNativeInventory(fixture.pluginRoot),
+          expectedRevision: 1,
+        },
+      );
+
+      expect(reconciled).toMatchObject({
+        id: created.id,
+        revision: 2,
+        updatedAt: 2_000,
+        native: {
+          status: "exact-path",
+          pluginId: "notes",
+          observedAt: 1_500,
+        },
+      });
+      expect(
+        catalog.resolvePrivateHostObservation({
+          principalId,
+          bbContextId,
+          id: objectId,
+        }),
+      ).toEqual({
+        runtimeInstanceId: OpaqueIdSchema.parse("i".repeat(32)),
+        hostname: "mate.local",
+        observedAt: 1_500,
+      });
+      const serialized = JSON.stringify(reconciled);
+      expect(serialized).not.toContain(fixture.pluginRoot);
+      expect(serialized).not.toContain("mate.local");
+      expect(serialized).not.toContain("i".repeat(32));
+
+      const database = new Database(
+        path.join(fixture.dataRoot, "workbench.sqlite3"),
+      );
+      try {
+        const event = database
+          .query("SELECT * FROM runtime_events ORDER BY sequence DESC LIMIT 1")
+          .get()!;
+        expect(event).toMatchObject({
+          event_type: "target.native-reconciled",
+          object_id: objectId,
+          revision: 2,
+          occurred_at: 2_000,
+        });
+        expect(JSON.stringify(event)).not.toContain(fixture.pluginRoot);
+        expect(JSON.stringify(event)).not.toContain("mate.local");
+        expect(JSON.stringify(event)).not.toContain("i".repeat(32));
+        const page = createEventFeed(database).pull({
+          bindings: {
+            principalId,
+            bbContextId,
+            targetId,
+          },
+        });
+        expect(page.events.at(-1)).toEqual({
+          cursor: expect.stringMatching(/^v1_[0-9a-z]+$/u),
+          type: "target.native-reconciled",
+          objectId,
+          objectKind: "development-target",
+          revision: 2,
+          occurredAt: 2_000,
+        });
+        expect(JSON.stringify(page)).not.toContain(fixture.pluginRoot);
+        expect(JSON.stringify(page)).not.toContain("mate.local");
+        expect(JSON.stringify(page)).not.toContain("i".repeat(32));
+      } finally {
+        database.close();
+      }
+    } finally {
+      catalog.close();
+    }
+  });
+
+  test("default-denies reconciliation across scopes, bindings, and target identities", async () => {
+    const fixture = await makeFixture();
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      const created = await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      const reconcile = async (requestContext: ReturnType<typeof context>) =>
+        service.reconcileFromTrustedInventory(requestContext, {
+          targetId: created.id,
+          sourceCandidate: await candidate(fixture.pluginRoot),
+          inventory: await issueNativeInventory(fixture.pluginRoot),
+          expectedRevision: 1,
+        });
+
+      const unscoped = createRequestContext({
+        id: principalId,
+        kind: "mcp-client",
+        scopes: ["targets:read"],
+        revoked: false,
+        bbContextId,
+      });
+      await expect(reconcile(unscoped)).rejects.toMatchObject({
+        code: "forbidden",
+      });
+      const targetBound = createRequestContext({
+        id: principalId,
+        kind: "plugin-adapter",
+        scopes: ["targets:write"],
+        revoked: false,
+        bbContextId,
+        targetId,
+      });
+      await expect(reconcile(targetBound)).rejects.toMatchObject({
+        code: "forbidden",
+      });
+
+      for (const foreign of [
+        createRequestContext({
+          id: PrincipalIdSchema.parse("q".repeat(32)),
+          kind: "supervisor",
+          scopes: ["targets:write"],
+          revoked: false,
+          bbContextId,
+        }),
+        createRequestContext({
+          id: principalId,
+          kind: "supervisor",
+          scopes: ["targets:write"],
+          revoked: false,
+          bbContextId: BbContextIdSchema.parse("c".repeat(32)),
+        }),
+      ]) {
+        await expect(
+          service.reconcileFromTrustedInventory(foreign, {
+            targetId: created.id,
+            sourceCandidate: await candidate(fixture.pluginRoot),
+            inventory: await issueNativeInventory(fixture.pluginRoot),
+            expectedRevision: 1,
+          }),
+        ).rejects.toMatchObject({ code: "not_found" });
+      }
+      await expect(
+        service.reconcileFromTrustedInventory(context(), {
+          targetId: ObjectIdSchema.parse("u".repeat(32)),
+          sourceCandidate: await candidate(fixture.pluginRoot),
+          inventory: await issueNativeInventory(fixture.pluginRoot),
+          expectedRevision: 1,
+        }),
+      ).rejects.toMatchObject({ code: "not_found" });
+      expect(service.getTarget(context(), created.id)).toEqual(created);
+    } finally {
+      catalog.close();
+    }
+  });
+
+  test("requires the current same-root source capability, exact inventory capability, and revision", async () => {
+    const fixture = await makeFixture();
+    const otherRoot = path.join(
+      path.dirname(fixture.pluginRoot),
+      "other-plugin",
+    );
+    await fs.mkdir(otherRoot);
+    await fs.writeFile(
+      path.join(otherRoot, "package.json"),
+      JSON.stringify({ name: "bb-plugin-notes", version: "1.2.3" }),
+    );
+    const canonicalOtherRoot = await fs.realpath(otherRoot);
+    const catalog = await openDevelopmentTargetCatalog({
+      dataRoot: fixture.dataRoot,
+      id: () => objectId,
+      clock: () => 2_000,
+    });
+    try {
+      const service = createDevelopmentTargetService(catalog);
+      const created = await service.refreshFromTrustedCandidate(
+        context(),
+        await candidate(fixture.pluginRoot),
+      );
+      const validSource = await candidate(fixture.pluginRoot);
+      const validInventory = await issueNativeInventory(fixture.pluginRoot);
+
+      await expect(
+        service.reconcileFromTrustedInventory(context(), {
+          targetId: created.id,
+          sourceCandidate: validSource,
+          inventory: validInventory,
+          expectedRevision: 2,
+        }),
+      ).rejects.toEqual(new RuntimeError("conflict"));
+      await expect(
+        service.reconcileFromTrustedInventory(context(), {
+          targetId: created.id,
+          sourceCandidate: await candidate(canonicalOtherRoot),
+          inventory: validInventory,
+          expectedRevision: 1,
+        }),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+      await expect(
+        service.reconcileFromTrustedInventory(context(), null as never),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+      for (const [sourceCandidate, inventory] of [
+        [{ ...validSource }, validInventory],
+        [validSource, { ...validInventory }],
+        [Object.create(validSource), validInventory],
+        [validSource, Object.create(validInventory)],
+      ] as const) {
+        await expect(
+          service.reconcileFromTrustedInventory(context(), {
+            targetId: created.id,
+            sourceCandidate: sourceCandidate as never,
+            inventory: inventory as never,
+            expectedRevision: 1,
+          }),
+        ).rejects.toMatchObject({ code: "invalid_request" });
+      }
+      await expect(
+        service.reconcileFromTrustedInventory(context(), {
+          targetId: created.id,
+          sourceCandidate: validSource,
+          inventory: validInventory,
+          expectedRevision: 1,
+          canonicalRoot: fixture.pluginRoot,
+        } as never),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+      expect(service.getTarget(context(), created.id)).toEqual(created);
+      expect(
+        catalog.resolvePrivateHostObservation({
+          principalId,
+          bbContextId,
+          id: objectId,
+        }),
+      ).toBeUndefined();
+    } finally {
+      catalog.close();
+    }
+  });
+});

--- a/packages/runtime/src/service/development-target-service.ts
+++ b/packages/runtime/src/service/development-target-service.ts
@@ -4,6 +4,7 @@ import { ObjectIdSchema, type ObjectId } from "../contracts/ids.ts";
 import type { Scope } from "../auth/principals.ts";
 import type { DevelopmentTargetCatalog } from "../discovery/catalog.ts";
 import { projectDevelopmentTarget } from "../discovery/development-target.ts";
+import type { TrustedNativeInventory } from "../discovery/native-inventory.ts";
 import { type TrustedDevelopmentTargetCandidate } from "../discovery/trusted-candidate.ts";
 import { RuntimeError } from "../errors.ts";
 
@@ -19,6 +20,34 @@ function authorizeUnboundTargetContext(
     throw new RuntimeError("forbidden");
   }
   return authorized.principal;
+}
+
+const RECONCILIATION_INPUT_KEYS = [
+  "expectedRevision",
+  "inventory",
+  "sourceCandidate",
+  "targetId",
+] as const;
+
+function assertExactReconciliationInput(
+  input: unknown,
+): asserts input is object {
+  if (typeof input !== "object" || input === null) {
+    throw new RuntimeError("invalid_request");
+  }
+  const keys = Reflect.ownKeys(input);
+  if (
+    keys.length !== RECONCILIATION_INPUT_KEYS.length ||
+    keys.some(
+      (key) =>
+        typeof key !== "string" ||
+        !RECONCILIATION_INPUT_KEYS.includes(
+          key as (typeof RECONCILIATION_INPUT_KEYS)[number],
+        ),
+    )
+  ) {
+    throw new RuntimeError("invalid_request");
+  }
 }
 
 export function createDevelopmentTargetService(
@@ -46,6 +75,40 @@ export function createDevelopmentTargetService(
           ...(options.expectedRevision === undefined
             ? {}
             : { expectedRevision: options.expectedRevision }),
+        }),
+      );
+    },
+    async reconcileFromTrustedInventory(
+      context: RequestContext,
+      input: {
+        readonly targetId: unknown;
+        readonly sourceCandidate: TrustedDevelopmentTargetCandidate;
+        readonly inventory: TrustedNativeInventory;
+        readonly expectedRevision: number;
+      },
+    ) {
+      const principal = authorizeUnboundTargetContext(context, "targets:write");
+      assertExactReconciliationInput(input);
+      let targetId: ObjectId;
+      try {
+        targetId = ObjectIdSchema.parse(input.targetId);
+      } catch (error) {
+        throw new RuntimeError("invalid_request", { cause: error });
+      }
+      if (
+        !Number.isSafeInteger(input.expectedRevision) ||
+        input.expectedRevision < 1
+      ) {
+        throw new RuntimeError("invalid_request");
+      }
+      return projectDevelopmentTarget(
+        await catalog.reconcileNative({
+          principalId: principal.id,
+          bbContextId: principal.bbContextId,
+          id: targetId,
+          candidate: input.sourceCandidate,
+          inventory: input.inventory,
+          expectedRevision: input.expectedRevision,
         }),
       );
     },

--- a/scripts/native-target-reconciliation.integration.test.ts
+++ b/scripts/native-target-reconciliation.integration.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { discoverSourceCandidates } from "../packages/inspection/src/discover-source-candidates.ts";
+import {
+  consumeIssuedNativeInventory,
+  observeNativePluginInventoryForTest,
+  readNativeInventoryTransition,
+} from "../packages/inspection/src/native-inventory.ts";
+import {
+  consumeIssuedSourceCandidate,
+  readSourceCandidateTransition,
+} from "../packages/inspection/src/source-candidate-transition.ts";
+import { admitTrustedRoots } from "../packages/inspection/src/trusted-roots.ts";
+import { createRequestContext } from "../packages/runtime/src/auth/context.ts";
+import {
+  BbContextIdSchema,
+  ObjectIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+} from "../packages/runtime/src/contracts/ids.ts";
+import { openDevelopmentTargetCatalog } from "../packages/runtime/src/discovery/catalog.ts";
+import { createInspectionNativeInventoryBridge } from "../packages/runtime/src/discovery/native-inventory.ts";
+import { createInspectionDevelopmentTargetCandidateBridge } from "../packages/runtime/src/discovery/trusted-candidate.ts";
+import { createDevelopmentTargetService } from "../packages/runtime/src/service/development-target-service.ts";
+
+const ROOT_KEY = OpaqueIdSchema.parse("r".repeat(32));
+const PRINCIPAL_ID = PrincipalIdSchema.parse("p".repeat(32));
+const BB_CONTEXT_ID = BbContextIdSchema.parse("b".repeat(32));
+const TARGET_ID = ObjectIdSchema.parse("t".repeat(32));
+const RUNTIME_INSTANCE_ID = OpaqueIdSchema.parse("i".repeat(32));
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("native development-target reconciliation", () => {
+  test("reconciles released managed inventory into one source target and reopens it", async () => {
+    const temporaryRoot = await fs.realpath(os.tmpdir());
+    const parent = await fs.mkdtemp(
+      path.join(temporaryRoot, "bb-mate-native-target-"),
+    );
+    temporaryRoots.push(parent);
+    const workspaceRoot = path.join(parent, "workspace");
+    const pluginRoot = path.join(workspaceRoot, "plugins", "example");
+    const executionSentinel = path.join(parent, "target-executed");
+    await fs.mkdir(path.join(pluginRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-example",
+        version: "1.2.3",
+        scripts: { preinstall: `touch ${JSON.stringify(executionSentinel)}` },
+        bb: {
+          name: "Example plugin",
+          description: "A passive native-reconciliation fixture.",
+          branding: { icon: "extension" },
+          server: "dist/server.js",
+        },
+      }),
+    );
+    await fs.writeFile(
+      path.join(pluginRoot, "dist", "server.js"),
+      `await Bun.write(${JSON.stringify(executionSentinel)}, "executed");`,
+    );
+
+    const admission = await admitTrustedRoots([
+      {
+        rootKey: ROOT_KEY,
+        kind: "current-project",
+        path: workspaceRoot,
+        displayName: "workspace",
+      },
+    ]);
+    expect(admission.diagnostics).toEqual([]);
+    const discover = async () => {
+      const result = await discoverSourceCandidates(admission.roots);
+      expect(result.diagnostics).toEqual([]);
+      expect(result.candidates).toHaveLength(1);
+      return result.candidates[0]!;
+    };
+
+    const sourceBridge = createInspectionDevelopmentTargetCandidateBridge({
+      consumeIssuedSourceCandidate,
+      readSourceCandidateTransition,
+      clock: () => 1_000,
+    });
+    const nativeBridge = createInspectionNativeInventoryBridge({
+      consumeIssuedNativeInventory,
+      readNativeInventoryTransition,
+    });
+    const nativeCommands: string[][] = [];
+    const observation = await observeNativePluginInventoryForTest({
+      runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      now: () => 2_000,
+      hostname: () => "devbox.local",
+      runBb: async (args) => {
+        nativeCommands.push([...args]);
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            plugins: [
+              {
+                id: "example",
+                source: "npm:bb-plugin-example@1.2.3",
+                rootDir: "/managed/bb-plugin-example",
+                version: "1.2.3",
+                provenance: "direct",
+                isOrphanedBuiltin: false,
+                enabled: true,
+                status: "running",
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      },
+    });
+    const inventory = await nativeBridge.issue(observation);
+    const context = createRequestContext({
+      id: PRINCIPAL_ID,
+      kind: "plugin-adapter",
+      scopes: ["targets:read", "targets:write"],
+      revoked: false,
+      bbContextId: BB_CONTEXT_ID,
+    });
+    const dataRoot = path.join(parent, "runtime-data");
+    let clock = 1_000;
+    let catalog = await openDevelopmentTargetCatalog({
+      dataRoot,
+      id: () => TARGET_ID,
+      clock: () => clock,
+    });
+    let service = createDevelopmentTargetService(catalog);
+
+    expect(service.listTargets(context)).toEqual([]);
+    const created = await service.refreshFromTrustedCandidate(
+      context,
+      await sourceBridge.issue(await discover()),
+    );
+    clock = 2_000;
+    const reconciled = await service.reconcileFromTrustedInventory(context, {
+      targetId: created.id,
+      sourceCandidate: await sourceBridge.issue(await discover()),
+      inventory,
+      expectedRevision: created.revision,
+    });
+
+    expect(nativeCommands).toEqual([["plugin", "list", "--json"]]);
+    expect(reconciled.id).toBe(created.id);
+    expect(reconciled.revision).toBe(2);
+    expect(reconciled.native).toEqual({
+      status: "managed",
+      pluginId: "example",
+      observedAt: 2_000,
+    });
+    expect(service.listTargets(context)).toEqual([reconciled]);
+    expect(JSON.stringify(reconciled)).not.toContain(parent);
+    expect(JSON.stringify(reconciled)).not.toContain("devbox.local");
+    expect(
+      catalog.resolvePrivateHostObservation({
+        principalId: PRINCIPAL_ID,
+        bbContextId: BB_CONTEXT_ID,
+        id: TARGET_ID,
+      }),
+    ).toEqual({
+      runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      hostname: "devbox.local",
+      observedAt: 2_000,
+    });
+    catalog.close();
+
+    catalog = await openDevelopmentTargetCatalog({ dataRoot });
+    service = createDevelopmentTargetService(catalog);
+    expect(service.listTargets(context)).toEqual([reconciled]);
+    expect(service.getTarget(context, TARGET_ID)).toEqual(reconciled);
+    catalog.close();
+    expect(
+      await fs
+        .stat(executionSentinel)
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context

Delivers merge-first slice 57B1 of #57 after the merged secure source catalog in PR #72. Native inventory remains downstream evidence for an existing source target and never seeds candidates.

## What changed

- observe exactly `bb plugin list --json` through a bounded no-shell runner
- normalize only released bb 0.36 fields with 1 MiB output, 256-row, and UTF-8 field bounds
- canonicalize only direct path roots; never inspect managed or builtin roots
- bridge inspection to runtime through exact one-use identity capabilities
- reconcile malformed, duplicate, future/stale, exact path, other path, npm/Git managed, builtin/catalog conflict, and absent states
- require target-unbound `targets:write`, a scoped target ID, a fresh same-root source capability, a trusted inventory capability, and an optimistic revision
- reject future-dated observations before mutation and require strictly newer per-target observations
- atomically persist the public native result, bounded private host observation, and redacted `target.native-reconciled` event
- fail closed on missing, corrupt, public/private-divergent, older, or replayed host evidence

## Verification

- `bun run format:check`
- `bun run check`
- `bun run test` — 470 tests: inspection 136, runtime 169, CLI 42, Workbench 53, Linear plugin 21, scripts 49
- `bun run build`
- package clean room — 41 files, 13 stories, SHA-256 `e4e726bb0209adb43673942f9a33cc7243f5c82064eddea1231ff8bb82c73e6d`
- coordinator walking skeleton proves source discovery → stable target → released-shape inventory → atomic reconciliation → reopen without target execution or candidate seeding
- replay regressions prove equal/older observations leave public state, private host state, events, and reopened data unchanged
- implementation head passed two independent 5/5 reviews with zero findings and green hosted CI; the final docs-only exact head is being re-pinned before ready/merge

## Boundary

No browser adapter, topology verdict, bootstrap credential, lifecycle mutation, target execution, Connect, normal-profile mutation, MCP, publication, release, signing, or upstream submission.

Part of #57.