### PR TITLE
feat: add supervised bb-mate runtime protocol

### DIFF
--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -500,8 +500,8 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
 check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
 run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
 run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
-  passed 527 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
-  plugin 21, and scripts 54. Repeated aggregate runs exposed a test-teardown
+  passed 528 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
+  plugin 21, and scripts 55. Repeated aggregate runs exposed a test-teardown
   race that recursively removed a symlink holder and its external temporary
   target concurrently. Teardown now removes temporary roots sequentially in
   reverse creation order; 100 focused reruns (600 tests), the full scripts
@@ -665,12 +665,15 @@ test && bun run build && bun run compatibility:latest` passed; package clean
 - The first hosted standalone job at both the implementation and docs heads
   emitted a valid orphan-lane descriptor and then hit an immediate loopback
   connection refusal; same-head reruns and every local moved-binary proof passed.
-  The clean-room readiness probe now retries only connection-refused failures
-  for a bounded two-second window after descriptor validation, still requires
-  exact HTTP 200, and fails immediately on HTTP or unrelated network errors.
-  Focused tests cover retry-to-ready, non-200, unrelated failure, and deadline
-  exhaustion. The harness-only change raises the aggregate to 527 tests while
-  leaving the exact package and standalone hashes recorded above unchanged.
+  The clean-room readiness probe initially retried only connection-refused
+  failures for two seconds after descriptor validation. One of two duplicate
+  hosted runs still exceeded that arbitrary allowance while the other passed.
+  The final bounded window is ten seconds, matching the existing descriptor
+  deadline; it still requires exact HTTP 200 and fails immediately on HTTP or
+  unrelated network errors. Focused tests cover readiness after 2.5 seconds,
+  non-200, unrelated failure, and deadline exhaustion. The harness-only change
+  raises the aggregate to 528 tests while leaving the exact package and
+  standalone hashes recorded above unchanged.
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -498,15 +498,15 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
 check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
 run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
 run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
-  passed 518 tests: inspection 136, runtime 175, CLI 68, Workbench 66, Linear
+  passed 525 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
   plugin 21, and scripts 52. One initial aggregate run hit the existing
   five-second standalone symlink-ancestor test timeout; the focused 6/6 retry
   and complete aggregate rerun passed. The legacy package clean room contained
   41 files and 13 stories with SHA-256
-  `7376eb25f413e2d2cec1c4f1b208549a0839b319aef31c2ac8b12c2b609ca718`.
+  `c2480bdd519e1d5bfe22691d8ccb9da64b5516162a8d9c9210e57ecc11711a9f`.
   The twice-built moved standalone was deterministic, Mach-O arm64, mode 0755,
   64,783,586 bytes, 35 assets, 13 stories, and SHA-256
-  `cadf0105d4a9e71142cfc053e9cb0ef6ae25b6cbaf9856e8d5329e93613013f8`.
+  `df2218e931e2c048ed0c2896a4448313169af324eca9595cc72717364a1ca16f`.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
   room produced 41 files, 13 stories, SHA-256
@@ -638,8 +638,17 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   keep-alive, flushes the secured generic 400, and then destroys the unread
   request. Slow encoded-dot GET, fragment HEAD, absolute-form POST, and 33-way
   concurrent incomplete-request regressions all close within the bounded window
-  with zero runtime-handler calls. The replacement aggregate passed 518 tests;
+  with zero runtime-handler calls. The replacement aggregate passed 525 tests;
   package and moved-standalone proofs produced the hashes recorded above.
+- The next targeted pass found the same unread-body lifetime gap after canonical
+  requests reached early Host, Origin, authentication, encoding, declared-size,
+  or capacity responses. The Node listener now treats request completion as the
+  systemic ownership boundary: before sending any handler response for an
+  incomplete message it overrides connection headers to close, preserves the
+  handler status/body/security policy, flushes the response, and destroys the
+  unread request. Focused slow-body tests cover 400/401/403/413/415/503, 33-way
+  concurrent rejection, the 32-request capacity boundary, handler header
+  override, and successful keep-alive reuse after a completely consumed body.
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -8,9 +8,10 @@ Status: Active
 The execution goal is active. Compatibility baseline #52, spec/goal PR #53,
 released-capability Gate 0 PR #68, and standalone-runtime PR #69 are merged.
 The narrowed runtime domain/security foundation #55 is merged through PR #71
-and reconciled. Source-first development-target discovery #57 is the active
-milestone. Slices 57A and 57B1 are merged and reconciled. Slice 57B2, the
-catalog-backed opaque-target Workbench adapter, is now active.
+and reconciled. Source-first development-target discovery #57 is merged,
+reconciled, and closed. Host-shell #62 is the active milestone. Slice 62A's
+supervised runtime implementation and review are complete in PR #76; merge and
+reconciliation remain before the packaged plugin slice 62B begins.
 
 ## Readiness
 
@@ -21,15 +22,16 @@ evidence and is reconciled. The transport-neutral runtime foundation #55 has
 passed focused/aggregate verification, two independent exact-head reviews, and
 hosted CI, then merged and reconciled. Source-catalog slice 57A is also merged
 and reconciled. Slice 57B1 passed its full local, review, hosted, merge, and
-GitButler reconciliation gates. Slice 57B2 is active; browser
-bootstrap/topology remains isolated in #70.
+GitButler reconciliation gates. Slice 57B2 is merged and reconciled. Slice 62A
+has passed local, hosted, and implementation-head review gates; its final
+docs-only exact-head review, ready transition, merge, and reconciliation remain.
+Browser bootstrap/topology remains isolated in #70.
 
 ## Baseline
 
 - Repository: `/Users/mg/Developer/bb/bb-mate`
-- Active branch: `feat/workbench/opaque-target-adapter`; issue #57; draft PR
-  #75.
-- Current merge base: `73e6865e2a135dfd02dc2429ebc3debaa179d79d`.
+- Active branch: `feat/plugin-workbench/host-shell`; issue #62; draft PR #76.
+- Current merge base: `6ed0c33ddbe8b971eadb36d170fc705dbf9550b3`.
 - Compatibility PR #52 merged from exact head
   `1b047598b52f49ed8e6e0f7dd88387ff02c10445` to baseline merge commit
   `fa02c6d0d7c4ffb2f8855029def1589ed7ce7824`; issue #51 is closed.
@@ -621,8 +623,8 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   fragment aliases cannot reach either runtime route. THS-003 is fixed by
   awaiting child stdio `close`, not only process `exit`, before output-purity and
   secret-nonleak assertions. Focused regressions reproduce each prior gap and
-  pass after remediation. PR #76 remains draft while the replacement exact-head
-  hosted checks and independent reviews are pending.
+  pass after remediation. At that point PR #76 remained draft while replacement
+  exact-head hosted checks and independent reviews were pending.
 - Targeted host-shell round 2 then found THS-004: raw GET/HEAD body framing was
   omitted while constructing the Fetch request, so an incomplete chunked health
   request could receive 200 before its body ended and escape the runtime body and
@@ -649,6 +651,15 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   unread request. Focused slow-body tests cover 400/401/403/413/415/503, 33-way
   concurrent rejection, the 32-request capacity boundary, handler header
   override, and successful keep-alive reuse after a completely consumed body.
+- Exact implementation head `2897369eaad4fedfc202b1a08fd23bac14f5f88f`
+  passed the 525-test aggregate, exact package and standalone proofs, hosted
+  verify/visual/standalone rerun, GitGuardian, zero-thread, and clean GitButler
+  gates. Standing round five awarded 5/5 with zero P0-P3. Targeted round five
+  found only THS-005: this ledger's current-state header still described merged
+  57B2 as active and hosted readiness as pending. Those current-state fields are
+  now corrected; executable and build-input bytes are unchanged. Slice 62A is
+  implementation-and-review complete, while final docs-only review, ready,
+  merge, and reconciliation remain.
 
 ## Prompt / Goal Alignment
 
@@ -669,7 +680,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
 source-catalog slices 57A, 57B1, and 57B2 are merged and reconciled; #57 is
 closed. Host-shell #62 is active with an explicit merge-first split: 62A's
-implementation and local verification are complete in draft PR #76, with
-exact-head review and hosted readiness pending; 62B then packages and
-supervises that exact runtime from `bb-plugin-mate`. All
+implementation and review are complete in draft PR #76, with final docs-only
+review, ready transition, merge, and reconciliation pending; 62B then packages
+and supervises that exact runtime from `bb-plugin-mate`. All
 release/upstream/Connect/normal-profile stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -581,6 +581,16 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   and unrelated #73 remained preserved. Superseded Workbench rounds 1-3 were
   scratch-archived only after all findings and fixed dispositions were recorded
   here.
+- PR #75 was made ready only after exact final head
+  `cc4c7e383dd0dac6b665f14b0075b9aaa288ebb0` passed terminal hosted checks,
+  zero-thread verification, packet doctor, and final standing plus targeted
+  5/5 reviews. GitHub async request
+  `2cc9e6c7-3d21-41ba-8ad9-cb643da8dd6b` merged it as
+  `6ed0c33ddbe8b971eadb36d170fc705dbf9550b3`. `but pull` removed the
+  integrated 57B2 branch and reconciled the workspace; #57 closed complete and
+  #21 now records source-first development-target discovery as merged. The
+  unrelated #73 lane remains isolated in its pre-existing force-push-required
+  state.
 
 ## Prompt / Goal Alignment
 
@@ -599,8 +609,8 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 ## Final State
 
 Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
-source-catalog slices 57A and 57B1 are merged and reconciled. Slice 57B2
-implementation, local and hosted verification, and dual 5/5 review are complete
-on draft PR #75; the final docs-only exact-head review, ready/merge, issue
-closure, and reconciliation remain. All release/upstream/Connect/normal-profile
-stop boundaries remain intact.
+source-catalog slices 57A, 57B1, and 57B2 are merged and reconciled; #57 is
+closed. Host-shell #62 is active with an explicit merge-first split: 62A adds
+the supervised runtime protocol, then 62B packages and supervises that exact
+runtime from `bb-plugin-mate`. All release/upstream/Connect/normal-profile stop
+boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -24,7 +24,7 @@ hosted CI, then merged and reconciled. Source-catalog slice 57A is also merged
 and reconciled. Slice 57B1 passed its full local, review, hosted, merge, and
 GitButler reconciliation gates. Slice 57B2 is merged and reconciled. Slice 62A
 has passed local, hosted, and implementation-head review gates; its final
-docs-only exact-head review, ready transition, merge, and reconciliation remain.
+exact-head review, ready transition, merge, and reconciliation remain.
 Browser bootstrap/topology remains isolated in #70.
 
 ## Baseline
@@ -500,10 +500,12 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
 check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
 run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
 run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
-  passed 525 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
-  plugin 21, and scripts 52. One initial aggregate run hit the existing
-  five-second standalone symlink-ancestor test timeout; the focused 6/6 retry
-  and complete aggregate rerun passed. The legacy package clean room contained
+  passed 527 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
+  plugin 21, and scripts 54. Repeated aggregate runs exposed a test-teardown
+  race that recursively removed a symlink holder and its external temporary
+  target concurrently. Teardown now removes temporary roots sequentially in
+  reverse creation order; 100 focused reruns (600 tests), the full scripts
+  suite, and the complete aggregate passed. The legacy package clean room contained
   41 files and 13 stories with SHA-256
   `c2480bdd519e1d5bfe22691d8ccb9da64b5516162a8d9c9210e57ecc11711a9f`.
   The twice-built moved standalone was deterministic, Mach-O arm64, mode 0755,
@@ -658,8 +660,17 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   found only THS-005: this ledger's current-state header still described merged
   57B2 as active and hosted readiness as pending. Those current-state fields are
   now corrected; executable and build-input bytes are unchanged. Slice 62A is
-  implementation-and-review complete, while final docs-only review, ready,
+  implementation-and-review complete, while final exact-head review, ready,
   merge, and reconciliation remain.
+- The first hosted standalone job at both the implementation and docs heads
+  emitted a valid orphan-lane descriptor and then hit an immediate loopback
+  connection refusal; same-head reruns and every local moved-binary proof passed.
+  The clean-room readiness probe now retries only connection-refused failures
+  for a bounded two-second window after descriptor validation, still requires
+  exact HTTP 200, and fails immediately on HTTP or unrelated network errors.
+  Focused tests cover retry-to-ready, non-200, unrelated failure, and deadline
+  exhaustion. The harness-only change raises the aggregate to 527 tests while
+  leaving the exact package and standalone hashes recorded above unchanged.
 
 ## Prompt / Goal Alignment
 
@@ -680,7 +691,7 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
 source-catalog slices 57A, 57B1, and 57B2 are merged and reconciled; #57 is
 closed. Host-shell #62 is active with an explicit merge-first split: 62A's
-implementation and review are complete in draft PR #76, with final docs-only
+implementation and review are complete in draft PR #76, with final exact-head
 review, ready transition, merge, and reconciliation pending; 62B then packages
 and supervises that exact runtime from `bb-plugin-mate`. All
 release/upstream/Connect/normal-profile stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -498,15 +498,15 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
 check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
 run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
 run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
-  passed 515 tests: inspection 136, runtime 175, CLI 65, Workbench 66, Linear
+  passed 518 tests: inspection 136, runtime 175, CLI 68, Workbench 66, Linear
   plugin 21, and scripts 52. One initial aggregate run hit the existing
   five-second standalone symlink-ancestor test timeout; the focused 6/6 retry
   and complete aggregate rerun passed. The legacy package clean room contained
   41 files and 13 stories with SHA-256
-  `c0a077788d0b2870baf91a0c0aa218d1836fa37c140c2ff0455d632622c340a0`.
+  `7376eb25f413e2d2cec1c4f1b208549a0839b319aef31c2ac8b12c2b609ca718`.
   The twice-built moved standalone was deterministic, Mach-O arm64, mode 0755,
   64,783,586 bytes, 35 assets, 13 stories, and SHA-256
-  `25401cda38e0c46e8b052d026b6734d812f80309935fb3d29c85dd641f6444ee`.
+  `cadf0105d4a9e71142cfc053e9cb0ef6ae25b6cbaf9856e8d5329e93613013f8`.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
   room produced 41 files, 13 stories, SHA-256
@@ -631,6 +631,15 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   closes the connection, and destroys the unread request after the response.
   Slow chunked GET/HEAD, Content-Length zero plus trailing bytes, nonzero length,
   duplicate length, canonical bodyless reads, and streamed POST regressions pass.
+- Exact-head round 3 showed that THS-004 still applied to noncanonical targets:
+  target validation returned the secured 400 before the framing cleanup path,
+  leaving an incomplete keep-alive socket open outside request accounting. Every
+  listener-level pre-dispatch rejection now uses one close path that disables
+  keep-alive, flushes the secured generic 400, and then destroys the unread
+  request. Slow encoded-dot GET, fragment HEAD, absolute-form POST, and 33-way
+  concurrent incomplete-request regressions all close within the bounded window
+  with zero runtime-handler calls. The replacement aggregate passed 518 tests;
+  package and moved-standalone proofs produced the hashes recorded above.
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -494,16 +494,19 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
   passed. The unchanged package clean room remained 41 files/13 stories at
   SHA-256
   `e4e726bb0209adb43673942f9a33cc7243f5c82064eddea1231ff8bb82c73e6d`.
-- Host-shell slice 62A local implementation gate passed `bun run
-format:check`, `bun run check`, `bun run test`, `bun run build`, `bun run
-compatibility:latest`, `bun run package:inspect`, `bun run standalone:inspect`,
-  and `bun run standalone:test`. The aggregate lane passed 506 tests: inspection
-  136, runtime 175, CLI 57, Workbench 66, Linear plugin 21, and scripts 51. The
-  legacy package clean room remained at 41 files and 13 stories with SHA-256
-  `0b8c30cb9a6c68c3e17fd0066ab21b6fef0a26be3d3a1acfa53475948653a1fe`.
+- Host-shell slice 62A remediation gate passed `bun run format:check`, `bun run
+check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
+run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
+run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
+  passed 510 tests: inspection 136, runtime 175, CLI 60, Workbench 66, Linear
+  plugin 21, and scripts 52. One initial aggregate run hit the existing
+  five-second standalone symlink-ancestor test timeout; the focused 6/6 retry
+  and complete aggregate rerun passed. The legacy package clean room contained
+  41 files and 13 stories with SHA-256
+  `f4fe45151ce055fbf305a54c5dddbe179c6d54a727de42e63325cc13ebb2cb72`.
   The twice-built moved standalone was deterministic, Mach-O arm64, mode 0755,
   64,783,586 bytes, 35 assets, 13 stories, and SHA-256
-  `15fd53ad017c990a9f3e50b27dd320408d47849fbd895371131ad3ab4159c36e`.
+  `f2ec32ddac59a7dedf036b0220c86ef2bebdeb090ed44811cf7494c3130e0897`.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
   room produced 41 files, 13 stories, SHA-256
@@ -609,8 +612,17 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   Parent disappearance, extra frame bytes, EOF, SIGINT, and SIGTERM converge on
   one awaited listener stop. The moved empty-PATH executable proves EOF,
   parent-loss-with-FD-open, and signal cleanup without a checkout asset or normal
-  profile. PR #76 remains draft while exact-head hosted checks and independent
-  standing/targeted reviews are pending.
+  profile.
+- Targeted host-shell round 1 found three release blockers after the initial
+  implementation review. THS-001 is fixed by including bundled Zod in generated
+  third-party notices and asserting its MIT license in the package clean room.
+  THS-002 is fixed by inspecting raw origin-form request targets before WHATWG
+  normalization, so encoded-dot, absolute, scheme-relative, backslash, and
+  fragment aliases cannot reach either runtime route. THS-003 is fixed by
+  awaiting child stdio `close`, not only process `exit`, before output-purity and
+  secret-nonleak assertions. Focused regressions reproduce each prior gap and
+  pass after remediation. PR #76 remains draft while the replacement exact-head
+  hosted checks and independent reviews are pending.
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -498,15 +498,15 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
 check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
 run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
 run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
-  passed 510 tests: inspection 136, runtime 175, CLI 60, Workbench 66, Linear
+  passed 515 tests: inspection 136, runtime 175, CLI 65, Workbench 66, Linear
   plugin 21, and scripts 52. One initial aggregate run hit the existing
   five-second standalone symlink-ancestor test timeout; the focused 6/6 retry
   and complete aggregate rerun passed. The legacy package clean room contained
   41 files and 13 stories with SHA-256
-  `f4fe45151ce055fbf305a54c5dddbe179c6d54a727de42e63325cc13ebb2cb72`.
+  `c0a077788d0b2870baf91a0c0aa218d1836fa37c140c2ff0455d632622c340a0`.
   The twice-built moved standalone was deterministic, Mach-O arm64, mode 0755,
   64,783,586 bytes, 35 assets, 13 stories, and SHA-256
-  `f2ec32ddac59a7dedf036b0220c86ef2bebdeb090ed44811cf7494c3130e0897`.
+  `25401cda38e0c46e8b052d026b6734d812f80309935fb3d29c85dd641f6444ee`.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
   room produced 41 files, 13 stories, SHA-256
@@ -623,6 +623,14 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   secret-nonleak assertions. Focused regressions reproduce each prior gap and
   pass after remediation. PR #76 remains draft while the replacement exact-head
   hosted checks and independent reviews are pending.
+- Targeted host-shell round 2 then found THS-004: raw GET/HEAD body framing was
+  omitted while constructing the Fetch request, so an incomplete chunked health
+  request could receive 200 before its body ended and escape the runtime body and
+  concurrency accounting. The raw listener now rejects any Content-Length or
+  Transfer-Encoding on GET/HEAD before dispatch, returns the secured generic 400,
+  closes the connection, and destroys the unread request after the response.
+  Slow chunked GET/HEAD, Content-Length zero plus trailing bytes, nonzero length,
+  duplicate length, canonical bodyless reads, and streamed POST regressions pass.
 
 ## Prompt / Goal Alignment
 

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -494,6 +494,16 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
   passed. The unchanged package clean room remained 41 files/13 stories at
   SHA-256
   `e4e726bb0209adb43673942f9a33cc7243f5c82064eddea1231ff8bb82c73e6d`.
+- Host-shell slice 62A local implementation gate passed `bun run
+format:check`, `bun run check`, `bun run test`, `bun run build`, `bun run
+compatibility:latest`, `bun run package:inspect`, `bun run standalone:inspect`,
+  and `bun run standalone:test`. The aggregate lane passed 506 tests: inspection
+  136, runtime 175, CLI 57, Workbench 66, Linear plugin 21, and scripts 51. The
+  legacy package clean room remained at 41 files and 13 stories with SHA-256
+  `0b8c30cb9a6c68c3e17fd0066ab21b6fef0a26be3d3a1acfa53475948653a1fe`.
+  The twice-built moved standalone was deterministic, Mach-O arm64, mode 0755,
+  64,783,586 bytes, 35 assets, 13 stories, and SHA-256
+  `15fd53ad017c990a9f3e50b27dd320408d47849fbd895371131ad3ab4159c36e`.
 - PR #52 final local gate: `bun run format:check && bun run check && bun run
 test && bun run build && bun run compatibility:latest` passed; package clean
   room produced 41 files, 13 stories, SHA-256
@@ -591,6 +601,16 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   #21 now records source-first development-target discovery as merged. The
   unrelated #73 lane remains isolated in its pre-existing force-push-required
   state.
+- Slice 62A now supplies the prerequisite protocol that #62 previously lacked.
+  The strict inherited FD carries one bounded credential frame and remains the
+  primary liveness signal; port-zero `serve` binds only numerical loopback,
+  emits one bounded descriptor line, and exposes only constant health plus an
+  authenticated capability document with exact runtime/API/instance identity.
+  Parent disappearance, extra frame bytes, EOF, SIGINT, and SIGTERM converge on
+  one awaited listener stop. The moved empty-PATH executable proves EOF,
+  parent-loss-with-FD-open, and signal cleanup without a checkout asset or normal
+  profile. PR #76 remains draft while exact-head hosted checks and independent
+  standing/targeted reviews are pending.
 
 ## Prompt / Goal Alignment
 
@@ -610,7 +630,8 @@ ports. The normal profile was inspected read-only for unique-plugin absence.
 
 Execution active. Gate 0, standalone-runtime #56, runtime foundation #55, and
 source-catalog slices 57A, 57B1, and 57B2 are merged and reconciled; #57 is
-closed. Host-shell #62 is active with an explicit merge-first split: 62A adds
-the supervised runtime protocol, then 62B packages and supervises that exact
-runtime from `bb-plugin-mate`. All release/upstream/Connect/normal-profile stop
-boundaries remain intact.
+closed. Host-shell #62 is active with an explicit merge-first split: 62A's
+implementation and local verification are complete in draft PR #76, with
+exact-head review and hosted readiness pending; 62B then packages and
+supervises that exact runtime from `bb-plugin-mate`. All
+release/upstream/Connect/normal-profile stop boundaries remain intact.

--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -500,8 +500,8 @@ standalone:inspect`. The remediation aggregate test lane passed 483 tests:
 check`, `bun run test`, `bun run build`, `bun run compatibility:latest`, `bun
 run package:inspect`, `bun run package:test`, `bun run standalone:build`, `bun
 run standalone:inspect`, and `bun run standalone:test`. The aggregate lane
-  passed 528 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
-  plugin 21, and scripts 55. Repeated aggregate runs exposed a test-teardown
+  passed 531 tests: inspection 136, runtime 175, CLI 75, Workbench 66, Linear
+  plugin 21, and scripts 58. Repeated aggregate runs exposed a test-teardown
   race that recursively removed a symlink holder and its external temporary
   target concurrently. Teardown now removes temporary roots sequentially in
   reverse creation order; 100 focused reruns (600 tests), the full scripts
@@ -668,12 +668,18 @@ test && bun run build && bun run compatibility:latest` passed; package clean
   The clean-room readiness probe initially retried only connection-refused
   failures for two seconds after descriptor validation. One of two duplicate
   hosted runs still exceeded that arbitrary allowance while the other passed.
-  The final bounded window is ten seconds, matching the existing descriptor
-  deadline; it still requires exact HTTP 200 and fails immediately on HTTP or
-  unrelated network errors. Focused tests cover readiness after 2.5 seconds,
-  non-200, unrelated failure, and deadline exhaustion. The harness-only change
-  raises the aggregate to 528 tests while leaving the exact package and
-  standalone hashes recorded above unchanged.
+  A later duplicate hosted run exhausted even the ten-second allowance after a
+  valid orphan descriptor while its twin passed. Because descriptors follow the
+  Node listener's `listening` event, that was not ordinary startup delay. The
+  final proof uses a fresh non-pooled loopback connection for each health and
+  cleanup probe, races readiness against child close with bounded redacted exit
+  diagnostics, and replaces the timed sleep parent with an owner-held indefinite
+  sentinel asserted alive before the deliberate parent-loss transition. It still
+  requires exact HTTP 200 and fails immediately on HTTP or unrelated network
+  errors. Focused tests cover fresh connections, canceled-socket cleanup,
+  readiness after 2.5 seconds, runtime exit, non-200, unrelated failure, and
+  deadline exhaustion. The harness-only changes raise the aggregate to 531 tests
+  while leaving the exact package and standalone hashes recorded above unchanged.
 
 ## Prompt / Goal Alignment
 

--- a/.agents/plans/2026-08-10-development-target-discovery.md
+++ b/.agents/plans/2026-08-10-development-target-discovery.md
@@ -1,7 +1,7 @@
 # Source-first development-target discovery
 
 Date: 2026-08-10
-Status: Slices 57A and 57B1 merged; slice 57B2 implementation and review complete, merge pending
+Status: Complete
 Issue: #57
 Parent: #21
 Depends on: #55 (merged through PR #71)
@@ -111,7 +111,7 @@ decision; #70 owns that gate.
 6. [x] Run aggregate gates and two 5/5 lanes, then merge and reconcile 57B1.
 7. [x] Adapt one-authorized-target inspection and Workbench selection to
        opaque target IDs; reverse the prior external-symlink acceptance test.
-8. [ ] Run visual/accessibility and aggregate gates, two 5/5 reviews, hosted
+8. [x] Run visual/accessibility and aggregate gates, two 5/5 reviews, hosted
        CI, merge 57B2, close #57, and reconcile GitButler.
 
 ## Verification

--- a/.agents/plans/2026-08-10-plugin-workbench-host-shell.md
+++ b/.agents/plans/2026-08-10-plugin-workbench-host-shell.md
@@ -1,7 +1,7 @@
 # Plugin Workbench host shell and supervised runtime
 
 Date: 2026-08-10
-Status: Slice 62A implementation complete; exact-head review pending
+Status: Slice 62A implementation and review complete; merge pending
 Issue: #62
 Parent: #21
 Depends on: #54, #55, #56, and #57 (all merged)

--- a/.agents/plans/2026-08-10-plugin-workbench-host-shell.md
+++ b/.agents/plans/2026-08-10-plugin-workbench-host-shell.md
@@ -1,7 +1,7 @@
 # Plugin Workbench host shell and supervised runtime
 
 Date: 2026-08-10
-Status: Active — slice 62A implementation pending
+Status: Slice 62A implementation complete; exact-head review pending
 Issue: #62
 Parent: #21
 Depends on: #54, #55, #56, and #57 (all merged)
@@ -31,10 +31,11 @@ Issue #62 closes only after both slices merge and reconcile.
 
 ## 62A protocol contract
 
-- `bb-mate serve --host 127.0.0.1 --port 0 --json --parent-pid <pid>
---supervisor-fd 3` is the only supervised entrypoint. It bypasses passive
-  target inspection and rejects non-numerical loopback, missing JSON mode,
-  invalid FDs, and unexpected positional targets.
+- `bb-mate serve --port 0 --json --parent-pid <pid> --supervisor-fd 3` is the
+  only supervised entrypoint. The host is fixed internally to numerical
+  `127.0.0.1`; supervised mode exposes no caller-selected host option. It
+  bypasses passive target inspection and rejects host overrides, missing JSON
+  mode, invalid FDs, and unexpected positional targets.
 - FD 3 carries one strict, bounded JSON line with schema/runtime/API
   expectations, a 32-byte base64url credential, principal ID, and bb-context
   ID. The writer keeps that same pipe open; extra bytes are a protocol error and
@@ -89,15 +90,15 @@ Issue #62 closes only after both slices merge and reconcile.
 
 ## TDD execution
 
-1. [ ] Add strict supervisor-frame and launch-descriptor contracts with bounds,
+1. [x] Add strict supervisor-frame and launch-descriptor contracts with bounds,
        unknown-field rejection, secret redaction, and version/capability
        equality tests.
-2. [ ] Add `serve` argument handling and ensure it bypasses inspection, binds
+2. [x] Add `serve` argument handling and ensure it bypasses inspection, binds
        only numerical loopback/port zero, prints one descriptor line, and keeps
        logs on stderr.
-3. [ ] Add bearer authentication, FD liveness, parent/signal shutdown, bounded
+3. [x] Add bearer authentication, FD liveness, parent/signal shutdown, bounded
        request handling, and idempotent listener cleanup tests.
-4. [ ] Extend the moved empty-PATH standalone clean room to prove the private
+4. [x] Extend the moved empty-PATH standalone clean room to prove the private
        channel, descriptor/capability handshake, EOF/orphan cleanup, no checkout
        assets, and no leaked secret.
 5. [ ] Run focused, aggregate, package, standalone, hosted, and two independent

--- a/.agents/plans/2026-08-10-plugin-workbench-host-shell.md
+++ b/.agents/plans/2026-08-10-plugin-workbench-host-shell.md
@@ -1,0 +1,146 @@
+# Plugin Workbench host shell and supervised runtime
+
+Date: 2026-08-10
+Status: Active — slice 62A implementation pending
+Issue: #62
+Parent: #21
+Depends on: #54, #55, #56, and #57 (all merged)
+
+## Outcome
+
+Ship a real `bb-plugin-mate` package whose released `navPanel` lazily
+supervises the exact packaged macOS-arm64 `bb-mate` runtime. The plugin stays a
+thin public-contract adapter; the runtime owns its protocol and canonical
+state. Missing, tampered, incompatible, or unsupported artifacts remain
+actionable unavailable states and spawn nothing.
+
+## Delivery shape
+
+Deliver #62 as two merge-first slices:
+
+1. **62A — supervised runtime protocol.** Add a standalone-safe `serve`
+   command, one private inherited supervisor/liveness channel, a bounded public
+   launch descriptor, authenticated capability handshake, and deterministic
+   shutdown/orphan proof.
+2. **62B — installed Plugin Workbench host.** Add `plugins/mate`, exact runtime
+   package/stamp verification, installed-root resolution, lazy serialized
+   supervision, released `navPanel`, skill, and isolated bb 0.36 lifecycle
+   proof.
+
+Issue #62 closes only after both slices merge and reconcile.
+
+## 62A protocol contract
+
+- `bb-mate serve --host 127.0.0.1 --port 0 --json --parent-pid <pid>
+--supervisor-fd 3` is the only supervised entrypoint. It bypasses passive
+  target inspection and rejects non-numerical loopback, missing JSON mode,
+  invalid FDs, and unexpected positional targets.
+- FD 3 carries one strict, bounded JSON line with schema/runtime/API
+  expectations, a 32-byte base64url credential, principal ID, and bb-context
+  ID. The writer keeps that same pipe open; extra bytes are a protocol error and
+  EOF is the primary parent-death signal. No secret enters argv, environment,
+  URLs, files, descriptor, stdout, stderr, or logs.
+- Parent PID monitoring is secondary to liveness EOF. Signal, EOF, parent
+  disappearance, startup failure, and normal shutdown converge on one
+  idempotent graceful-stop path.
+- Bind exact numerical `127.0.0.1`; port zero selects the listener port. Emit
+  exactly one UTF-8 JSON descriptor line on stdout, bounded to 8 KiB, with exact
+  schema/runtime/API versions, child PID, opaque runtime-instance ID, exact
+  loopback base URL, and the finite capability document. Human diagnostics use
+  bounded redacted stderr only.
+- `GET /healthz` remains constant and unauthenticated. `GET
+/v1/capabilities` requires the supervisor bearer and returns metadata and
+  capabilities exactly matching the descriptor. Host/Origin/body/concurrency
+  rules remain those of the runtime foundation. No target, browser bootstrap,
+  MCP, object mutation, static UI, SSE, or WebSocket route is added.
+- Compile with ambient dotenv/bunfig disabled. Managed launch clears
+  `BUN_BE_BUN` and `BUN_OPTIONS`; direct invocation cannot claim protection
+  from a parent that sets `BUN_BE_BUN` before app code.
+
+## 62B host/package contract
+
+- `plugins/mate` is `bb-plugin-mate` with `engines.bb >=0.36` and
+  `engines.bbPluginSdk ^0.4.1`, released `navPanel`, backend
+  `background.service`/`onDispose`, and a project-scoped skill. Harness remains
+  unavailable while the public SDK package is E404.
+- Build stages only `runtime/darwin-arm64/{bb-mate,manifest.json}` from the
+  exact deterministic standalone output. The npm allowlist is exact and package
+  inspection proves stamped frontend/backend artifacts, skill/docs, executable
+  mode 0755, Mach-O arm64, size, version, API, SHA-256, and absence of source,
+  node_modules, symlinks, traversal, or extra entries.
+- The backend embeds the expected runtime SHA/size/arch/version/API. It resolves
+  only the literal runtime path relative to built `import.meta.url`, verifies
+  containment and identity immediately before spawn, and never consults cwd,
+  PATH, HOME, inventory, Bun, bunx, or a global `bb-mate`.
+- One lazy supervisor state machine serializes `ensure`/reuse/stop. Plugin load
+  alone starts no process or listener. Concurrent nav/RPC demand shares one
+  start. `background.service` owns capped crash restart; deterministic artifact
+  failures become `NeedsConfigurationError`, not a custom restart loop.
+- Spawn one process group with a minimized environment and inherited private
+  channel. Enforce descriptor byte/time/schema/version/PID/base-URL/capability
+  limits, then perform the authenticated capability handshake. Abort,
+  `onDispose`, reload, disable, remove, server shutdown, crash, and orphan paths
+  terminate the owned group and listener within a bounded grace/force window.
+- Frontend/RPC projections contain only finite status enums, public target
+  projections, versions, and non-secret opaque context facts. They contain no
+  paths, PID, hostname, command, environment, secret, bearer, base URL, browser
+  URL, Connect fact, or topology conclusion. Browser launch stays visibly
+  unavailable until #70.
+
+## TDD execution
+
+1. [ ] Add strict supervisor-frame and launch-descriptor contracts with bounds,
+       unknown-field rejection, secret redaction, and version/capability
+       equality tests.
+2. [ ] Add `serve` argument handling and ensure it bypasses inspection, binds
+       only numerical loopback/port zero, prints one descriptor line, and keeps
+       logs on stderr.
+3. [ ] Add bearer authentication, FD liveness, parent/signal shutdown, bounded
+       request handling, and idempotent listener cleanup tests.
+4. [ ] Extend the moved empty-PATH standalone clean room to prove the private
+       channel, descriptor/capability handshake, EOF/orphan cleanup, no checkout
+       assets, and no leaked secret.
+5. [ ] Run focused, aggregate, package, standalone, hosted, and two independent
+       5/5 review lanes; merge and reconcile 62A.
+6. [ ] Scaffold `plugins/mate` only from released 0.36 artifacts; add the exact
+       package stamp/allowlist/resolver and adversarial pack/extract tests.
+7. [ ] Add the lazy supervisor, status RPC, released nav panel, and skill with
+       race/crash/dispose/unavailable tests and no browser-launch claim.
+8. [ ] Prove the extracted package in a disposable bb 0.36 profile: install,
+       idle-before-demand, one child, reload, disable, enable/redemand, crash,
+       remove, graceful shutdown, forced parent loss, no orphan/listener, and
+       no normal-profile mutation.
+9. [ ] Run full local/hosted gates and two 5/5 review lanes; merge 62B, close
+       #62, reconcile GitButler, and update #21.
+
+## Verification
+
+- Focused CLI/runtime/protocol/supervisor/package/frontend tests while
+  iterating.
+- `bun run format:check && bun run check && bun run test && bun run build`
+- `bun run visual:test` for 62B UI changes.
+- `bun run compatibility:latest`
+- `bun run package:inspect && bun run package:test`
+- `bun run standalone:inspect && bun run standalone:test`
+- Native `bb plugin types --check`, `bb plugin build`, exact tar inspection, and
+  disposable-profile path install from an extracted package.
+- Exact-head hosted checks, zero review threads, 5/5 standing and targeted
+  reports, immutable merge SHA, and clean GitButler reconciliation per slice.
+
+## Stop conditions
+
+Stop before PATH/Bun/bunx fallback, chmod/postinstall repair, unsupported
+platform claims, browser credentials or secret-bearing URLs, automatic host
+browser control, target execution, native target lifecycle mutation, Connect,
+MCP, publication/release/signing, upstream submission, or normal-profile
+mutation. Stop 62B launch work if 62A is not merged or if packaged hash, mode,
+architecture, installed-root containment, descriptor handshake, or cleanup
+proof fails.
+
+## Done
+
+Both slices are merged to `main`; #62 and #21 are current; exact local, hosted,
+package, standalone, and isolated lifecycle gates pass; two independent review
+lanes score 5/5 with zero P0-P3 per slice; GitButler is clean/reconciled; and
+the goal retrospective records exact proof without crossing release or browser
+bootstrap boundaries.

--- a/apps/cli/THIRD_PARTY_NOTICES.md
+++ b/apps/cli/THIRD_PARTY_NOTICES.md
@@ -25,10 +25,12 @@ checked before any public distribution decision.
 | tailwind-merge                     | MIT        | <https://github.com/dcastil/tailwind-merge>     |
 | tw-animate-css                     | MIT        | <https://github.com/Wombosvideo/tw-animate-css> |
 | xmlchars                           | MIT        | <https://github.com/lddubeau/xmlchars>          |
+| Zod                                | MIT        | <https://github.com/colinhacks/zod>             |
 
 The generated payload includes Base UI's runtime dependency closure, Ladle,
 classnames, Prism React Renderer and PrismJS, PropTypes and React Is, React and
 scheduler, the Focus Lock/React Remove Scroll family, Reach UI dialog, tslib,
 and the inspection parser dependency closure. This inventory and those notices
-cover third-party components only. BB Mate itself is distributed under the MIT
-License included as `LICENSE` in the package.
+cover third-party components, including the runtime protocol's bundled Zod
+schema implementation, only. BB Mate itself is distributed under the MIT License
+included as `LICENSE` in the package.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -46,7 +46,8 @@
     "test": "bun test src"
   },
   "dependencies": {
-    "@bb-mate/inspection": "workspace:*"
+    "@bb-mate/inspection": "workspace:*",
+    "@bb-mate/runtime": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "^1.3.4",

--- a/apps/cli/src/args.test.ts
+++ b/apps/cli/src/args.test.ts
@@ -33,4 +33,72 @@ describe("bb-mate arguments", () => {
       "--json is only available with inspect.",
     );
   });
+
+  test("parses the supervised serve contract without a target path", () => {
+    expect(
+      parseCliArgs([
+        "serve",
+        "--port",
+        "0",
+        "--json",
+        "--parent-pid",
+        "4321",
+        "--supervisor-fd",
+        "3",
+      ]),
+    ).toEqual({
+      command: "serve",
+      host: "127.0.0.1",
+      port: 0,
+      json: true,
+      help: false,
+      parentPid: 4321,
+      supervisorFd: 3,
+    });
+  });
+
+  test("fails closed when the supervised serve contract is incomplete", () => {
+    const base = [
+      "serve",
+      "--port",
+      "0",
+      "--json",
+      "--parent-pid",
+      "4321",
+      "--supervisor-fd",
+      "3",
+    ];
+
+    expect(() => parseCliArgs(base.slice(0, -2))).toThrow(
+      "Supervised serve requires --supervisor-fd >= 3.",
+    );
+    expect(() => parseCliArgs([...base, "plugins/notes"])).toThrow(
+      "serve does not accept a plugin path.",
+    );
+    expect(() =>
+      parseCliArgs(base.map((value) => (value === "4321" ? "0" : value))),
+    ).toThrow("Supervised serve requires a positive --parent-pid.");
+    expect(() =>
+      parseCliArgs(base.map((value) => (value === "3" ? "2" : value))),
+    ).toThrow("Supervised serve requires --supervisor-fd >= 3.");
+    expect(() =>
+      parseCliArgs(base.map((value) => (value === "0" ? "1" : value))),
+    ).toThrow("--port must be 0 for supervised serve.");
+    expect(() => parseCliArgs([...base, "--host", "127.0.0.1"])).toThrow(
+      "Supervised serve does not accept --host.",
+    );
+    expect(() =>
+      parseCliArgs(base.filter((value, index) => index !== 1 && index !== 2)),
+    ).toThrow("Supervised serve requires explicit --port 0.");
+  });
+
+  test("allows supervised help without opening the supervisor channel", () => {
+    expect(parseCliArgs(["serve", "--help"])).toEqual({
+      command: "serve",
+      host: "127.0.0.1",
+      port: 0,
+      json: false,
+      help: true,
+    });
+  });
 });

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from "node:util";
 
-export type CliCommand = "dev" | "inspect" | "check" | "live";
+export type CliCommand = "dev" | "inspect" | "check" | "live" | "serve";
 
 export interface CliArguments {
   command: CliCommand;
@@ -9,9 +9,17 @@ export interface CliArguments {
   port: number;
   json: boolean;
   help: boolean;
+  parentPid?: number;
+  supervisorFd?: number;
 }
 
-const commands = new Set<CliCommand>(["dev", "inspect", "check", "live"]);
+const commands = new Set<CliCommand>([
+  "dev",
+  "inspect",
+  "check",
+  "live",
+  "serve",
+]);
 
 export function parseCliArgs(argv: readonly string[]): CliArguments {
   const values = [...argv];
@@ -29,6 +37,8 @@ export function parseCliArgs(argv: readonly string[]): CliArguments {
       json: { type: "boolean", default: false },
       host: { type: "string" },
       port: { type: "string" },
+      "parent-pid": { type: "string" },
+      "supervisor-fd": { type: "string" },
     },
   });
   if (parsed.positionals.length > 1) {
@@ -37,9 +47,21 @@ export function parseCliArgs(argv: readonly string[]): CliArguments {
 
   const targetPath = parsed.positionals[0];
   const host = parsed.values.host ?? "127.0.0.1";
-  const parsedPort = parsed.values.port ? Number(parsed.values.port) : 5173;
-  if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65_535) {
-    throw new Error("--port must be an integer between 1 and 65535.");
+  const parsedPort = parsed.values.port
+    ? Number(parsed.values.port)
+    : command === "serve"
+      ? 0
+      : 5173;
+  if (
+    !Number.isInteger(parsedPort) ||
+    parsedPort < (command === "serve" ? 0 : 1) ||
+    parsedPort > 65_535
+  ) {
+    throw new Error(
+      command === "serve"
+        ? "--port must be 0 for supervised serve."
+        : "--port must be an integer between 1 and 65535.",
+    );
   }
   const port = parsedPort;
   const json = parsed.values.json;
@@ -47,11 +69,51 @@ export function parseCliArgs(argv: readonly string[]): CliArguments {
   const addressOption =
     parsed.values.host !== undefined || parsed.values.port !== undefined;
 
+  const parentPid = parsed.values["parent-pid"]
+    ? Number(parsed.values["parent-pid"])
+    : undefined;
+  const supervisorFd = parsed.values["supervisor-fd"]
+    ? Number(parsed.values["supervisor-fd"])
+    : undefined;
+
+  if (command === "serve") {
+    if (help) return { command, host, port, json, help };
+    if (targetPath) throw new Error("serve does not accept a plugin path.");
+    if (parsed.values.host !== undefined) {
+      throw new Error("Supervised serve does not accept --host.");
+    }
+    if (parsed.values.port === undefined) {
+      throw new Error("Supervised serve requires explicit --port 0.");
+    }
+    if (port !== 0) throw new Error("--port must be 0 for supervised serve.");
+    if (!json) throw new Error("Supervised serve requires --json.");
+    if (!Number.isSafeInteger(parentPid) || (parentPid ?? 0) < 1) {
+      throw new Error("Supervised serve requires a positive --parent-pid.");
+    }
+    if (!Number.isSafeInteger(supervisorFd) || (supervisorFd ?? 0) < 3) {
+      throw new Error("Supervised serve requires --supervisor-fd >= 3.");
+    }
+    return {
+      command,
+      host,
+      port,
+      json,
+      help,
+      parentPid,
+      supervisorFd,
+    };
+  }
+
   if (json && command !== "inspect") {
     throw new Error("--json is only available with inspect.");
   }
   if (command !== "dev" && addressOption) {
     throw new Error("--host and --port are only available with dev.");
+  }
+  if (parentPid !== undefined || supervisorFd !== undefined) {
+    throw new Error(
+      "--parent-pid and --supervisor-fd are only available with serve.",
+    );
   }
 
   return { command, targetPath, host, port, json, help };

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -2,10 +2,14 @@
 
 import { runBbMateEntrypoint } from "./entrypoint.ts";
 
+const manifest = (await Bun.file(
+  new URL("../package.json", import.meta.url),
+).json()) as { version: string };
 const result = await runBbMateEntrypoint({
   mode: "source-or-package",
   moduleUrl: import.meta.url,
   bunExecutable: process.execPath,
+  runtimeVersion: manifest.version,
 });
 if (result.signal) process.kill(process.pid, result.signal);
 process.exit(result.exitCode ?? 1);

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -135,6 +135,7 @@ function runtime(
       resolveBb: async () => "/fake/bin/bb",
       runCaptured: captured,
       runInherited: async () => processExit,
+      runServe: async () => ({ exitCode: 1, signal: null }),
       ...overrides,
     } satisfies CliRuntime,
   };
@@ -170,6 +171,49 @@ describe("bb-mate CLI", () => {
     expect(result).toEqual({ exitCode: 0, signal: null });
     expect(nativeCall).toBe(false);
     expect(testRuntime.stdout.join("")).toContain("Usage: bb-mate [path]");
+    expect(testRuntime.stdout.join("")).toContain(
+      "bb-mate serve --port 0 --json --parent-pid <pid> --supervisor-fd <fd>",
+    );
+  });
+
+  test("routes supervised serve before plugin inspection or native bb lookup", async () => {
+    let nativeCall = false;
+    const serveCalls: unknown[] = [];
+    const testRuntime = runtime(
+      "/workspace",
+      async () => {
+        nativeCall = true;
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+      {
+        resolveBb: async () => {
+          nativeCall = true;
+          return null;
+        },
+        runServe: async (options) => {
+          serveCalls.push(options);
+          return { exitCode: 0, signal: null };
+        },
+      },
+    );
+
+    const result = await runCli(
+      [
+        "serve",
+        "--port",
+        "0",
+        "--json",
+        "--parent-pid",
+        "4321",
+        "--supervisor-fd",
+        "3",
+      ],
+      testRuntime.value,
+    );
+
+    expect(result).toEqual({ exitCode: 0, signal: null });
+    expect(serveCalls).toEqual([{ port: 0, parentPid: 4321, supervisorFd: 3 }]);
+    expect(nativeCall).toBe(false);
   });
 
   test("inspects a standalone plugin without executing its entrypoint", async () => {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -36,6 +36,11 @@ export interface CliRuntime {
     options: { cwd: string; env: NodeJS.ProcessEnv },
   ): Promise<ProcessExit>;
   runFixture?(options: { host: string; port: number }): Promise<ProcessExit>;
+  runServe(options: {
+    port: 0;
+    parentPid: number;
+    supervisorFd: number;
+  }): Promise<ProcessExit>;
 }
 
 interface InspectionContext {
@@ -51,6 +56,7 @@ const help = `Usage: bb-mate [path]
        bb-mate inspect [path] [--json]
        bb-mate check [path]
        bb-mate live [path]
+       bb-mate serve --port 0 --json --parent-pid <pid> --supervisor-fd <fd>
 
 Fixture workbench, packaged surface lab, and passive inspection stay in BB Mate.
 Native bb owns build, install, dev/reload, and live runtime.`;
@@ -197,6 +203,14 @@ export async function runCli(
   if (args.help) {
     line(runtime.stdout, help);
     return success;
+  }
+
+  if (args.command === "serve") {
+    return runtime.runServe({
+      port: 0,
+      parentPid: args.parentPid as number,
+      supervisorFd: args.supervisorFd as number,
+    });
   }
 
   const context = await inspectSelection(runtime, args.targetPath);

--- a/apps/cli/src/entrypoint.test.ts
+++ b/apps/cli/src/entrypoint.test.ts
@@ -22,6 +22,7 @@ describe("bb-mate entrypoint modes", () => {
 
     const runtime = await createBbMateCliRuntime({
       mode: "standalone",
+      runtimeVersion: "0.1.0-alpha.2",
       assets: { "/index.html": indexPath },
     });
 
@@ -29,7 +30,11 @@ describe("bb-mate entrypoint modes", () => {
     expect(runtime.bunExecutable).toBeUndefined();
     expect(runtime.workspaceRoot).toBeUndefined();
     await expect(
-      createBbMateCliRuntime({ mode: "standalone", assets: {} }),
+      createBbMateCliRuntime({
+        mode: "standalone",
+        runtimeVersion: "0.1.0-alpha.2",
+        assets: {},
+      }),
     ).rejects.toThrow("Standalone surface lab assets must include /index.html");
   });
 
@@ -44,6 +49,7 @@ describe("bb-mate entrypoint modes", () => {
       mode: "source-or-package",
       moduleUrl,
       bunExecutable: "/actual/bun",
+      runtimeVersion: "0.1.0-alpha.2",
     });
     expect(source.bunExecutable).toBe("/actual/bun");
     expect(source.runFixture).toBeUndefined();
@@ -54,6 +60,7 @@ describe("bb-mate entrypoint modes", () => {
       mode: "source-or-package",
       moduleUrl,
       bunExecutable: "/actual/bun",
+      runtimeVersion: "0.1.0-alpha.2",
     });
     expect(packaged.runFixture).toBeFunction();
     expect(packaged.bunExecutable).toBeUndefined();
@@ -67,7 +74,11 @@ describe("bb-mate entrypoint modes", () => {
     const stdout: string[] = [];
 
     const result = await runBbMateEntrypoint(
-      { mode: "standalone", assets: { "/index.html": indexPath } },
+      {
+        mode: "standalone",
+        runtimeVersion: "0.1.0-alpha.2",
+        assets: { "/index.html": indexPath },
+      },
       {
         argv: ["--help"],
         stdout: (value) => stdout.push(value),

--- a/apps/cli/src/entrypoint.ts
+++ b/apps/cli/src/entrypoint.ts
@@ -12,6 +12,7 @@ import {
   runCapturedCommand,
   runInheritedCommand,
 } from "./native.ts";
+import { runSupervisedServe } from "./serve.ts";
 import { runSurfaceLab } from "./surface-lab-server.ts";
 
 export type BbMateEntrypointOptions =
@@ -19,10 +20,12 @@ export type BbMateEntrypointOptions =
       mode: "source-or-package";
       moduleUrl: string;
       bunExecutable: string;
+      runtimeVersion: string;
     }
   | {
       mode: "standalone";
       assets: EmbeddedLabAssetMap;
+      runtimeVersion: string;
     };
 
 interface EntrypointEnvironment {
@@ -110,6 +113,10 @@ export async function createBbMateCliRuntime(
         env: nativeCommandEnv(current.env),
       }),
     runInherited: runInheritedCommand,
+    runServe: (serveOptions) =>
+      runSupervisedServe(serveOptions, {
+        runtimeVersion: options.runtimeVersion,
+      }),
   };
 }
 

--- a/apps/cli/src/runtime-http-listener.test.ts
+++ b/apps/cli/src/runtime-http-listener.test.ts
@@ -41,7 +41,131 @@ async function rawRequest(
   return Buffer.concat(chunks).toString("utf8");
 }
 
+async function openSlowRequest(port: number, request: string) {
+  const socket = connect({ host: "127.0.0.1", port });
+  const response = new Promise<string>((resolve, reject) => {
+    socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+    socket.once("error", reject);
+  });
+  const closed = new Promise<boolean>((resolve) =>
+    socket.once("close", () => resolve(true)),
+  );
+  await new Promise<void>((resolve) => socket.once("connect", resolve));
+  socket.write(request);
+  return { socket, response, closed };
+}
+
 describe("runtime HTTP listener", () => {
+  test("force-closes a slow framed invalid target without dispatch", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    const socket = connect({ host: "127.0.0.1", port: listener.port });
+    const response = new Promise<string>((resolve, reject) => {
+      socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+      socket.once("error", reject);
+    });
+    const closed = new Promise<boolean>((resolve) =>
+      socket.once("close", () => resolve(true)),
+    );
+    try {
+      await new Promise<void>((resolve) => socket.once("connect", resolve));
+      socket.write(
+        `GET /%2e%2e/healthz HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+      );
+      const firstBytes = await response;
+
+      expect(firstBytes).toStartWith("HTTP/1.1 400");
+      expect(firstBytes.toLowerCase()).toContain("cache-control: no-store");
+      expect(handlerCalls).toBe(0);
+      expect(
+        await Promise.race([closed, Bun.sleep(250).then(() => false)]),
+      ).toBe(true);
+    } finally {
+      socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("force-closes slow invalid HEAD and POST targets before dispatch", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    const attacks = await Promise.all([
+      openSlowRequest(
+        listener.port,
+        `HEAD /healthz#fragment HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+      ),
+      openSlowRequest(
+        listener.port,
+        `POST http://127.0.0.1:${listener.port}/v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+      ),
+    ]);
+    try {
+      for (const attack of attacks) {
+        const response = await attack.response;
+        expect(response).toStartWith("HTTP/1.1 400");
+        expect(response.toLowerCase()).toContain("connection: close");
+        expect(response.toLowerCase()).toContain("cache-control: no-store");
+        expect(
+          await Promise.race([attack.closed, Bun.sleep(250).then(() => false)]),
+        ).toBe(true);
+      }
+      expect(handlerCalls).toBe(0);
+    } finally {
+      for (const attack of attacks) attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("releases 33 concurrent slow invalid requests without dispatch", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    const requestLines = [
+      "GET /%2e%2e/healthz",
+      "HEAD /healthz#fragment",
+      `POST http://127.0.0.1:${listener.port}/v1/capabilities`,
+    ];
+    const attacks = await Promise.all(
+      Array.from({ length: 33 }, (_, index) =>
+        openSlowRequest(
+          listener.port,
+          `${requestLines[index % requestLines.length]} HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+        ),
+      ),
+    );
+    try {
+      const responses = await Promise.all(
+        attacks.map((attack) => attack.response),
+      );
+      expect(
+        responses.every((response) => response.startsWith("HTTP/1.1 400")),
+      ).toBe(true);
+      expect(
+        responses.every((response) =>
+          response.toLowerCase().includes("connection: close"),
+        ),
+      ).toBe(true);
+      expect(
+        await Promise.race([
+          Promise.all(attacks.map((attack) => attack.closed)).then(() => true),
+          Bun.sleep(1_000).then(() => false),
+        ]),
+      ).toBe(true);
+      expect(handlerCalls).toBe(0);
+    } finally {
+      for (const attack of attacks) attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
   test("rejects a slow chunked GET before handler dispatch", async () => {
     let handlerCalls = 0;
     const listener = await listenRuntimeHttp(async () => {

--- a/apps/cli/src/runtime-http-listener.test.ts
+++ b/apps/cli/src/runtime-http-listener.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { connect } from "node:net";
+import {
+  createOpaqueId,
+  createRequestContext,
+  createRuntimeHttpHandler,
+} from "@bb-mate/runtime";
+import { RUNTIME_CAPABILITIES } from "@bb-mate/runtime/supervision";
+import { listenRuntimeHttp } from "./runtime-http-listener.ts";
+
+async function rawRequest(
+  port: number,
+  target: string,
+  init: {
+    readonly method?: string;
+    readonly host?: string;
+    readonly headers?: Readonly<Record<string, string>>;
+  } = {},
+) {
+  const socket = connect({ host: "127.0.0.1", port });
+  const chunks: Buffer[] = [];
+  socket.on("data", (chunk) =>
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+  );
+  const closed = new Promise<void>((resolve, reject) => {
+    socket.once("close", () => resolve());
+    socket.once("error", reject);
+  });
+  const headers = Object.entries(init.headers ?? {})
+    .map(([name, value]) => `${name}: ${value}\r\n`)
+    .join("");
+  socket.once("connect", () =>
+    socket.write(
+      `${init.method ?? "GET"} ${target} HTTP/1.1\r\nHost: ${init.host ?? `127.0.0.1:${port}`}\r\n${headers}Connection: close\r\n\r\n`,
+    ),
+  );
+  await closed;
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+describe("runtime HTTP listener", () => {
+  test("rejects encoded-dot route aliases before Request normalization", async () => {
+    const token = Buffer.alloc(32, 7).toString("base64url");
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    const listener = await listenRuntimeHttp((request) => handler!(request));
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+      authenticate: async (request) =>
+        request.headers.get("authorization") === `Bearer ${token}`
+          ? createRequestContext({
+              id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              kind: "supervisor",
+              scopes: ["runtime:read"],
+              revoked: false,
+              bbContextId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            })
+          : undefined,
+    });
+
+    try {
+      const health = await rawRequest(listener.port, "/%2e%2e/healthz");
+      const capabilities = await rawRequest(
+        listener.port,
+        "/v1/%2e%2e/v1/capabilities",
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+
+      for (const response of [health, capabilities]) {
+        expect(response).toStartWith("HTTP/1.1 400");
+        expect(response.toLowerCase()).toContain("cache-control: no-store");
+        expect(response.toLowerCase()).toContain(
+          "x-content-type-options: nosniff",
+        );
+      }
+    } finally {
+      await listener.stop();
+    }
+  });
+
+  test("rejects non-origin-form targets without broadening canonical routes", async () => {
+    const listener = await listenRuntimeHttp(async () =>
+      Response.json({ reached: true }),
+    );
+    try {
+      for (const target of [
+        `http://127.0.0.1:${listener.port}/healthz`,
+        "//evil.example/healthz",
+        "/\\evil.example/healthz",
+        "/healthz#fragment",
+      ]) {
+        const response = await rawRequest(listener.port, target);
+        expect(response, target).toStartWith("HTTP/1.1 400");
+        expect(response, target).not.toContain('"reached":true');
+      }
+      const asterisk = await rawRequest(listener.port, "*", {
+        method: "OPTIONS",
+      });
+      const authority = await rawRequest(
+        listener.port,
+        `127.0.0.1:${listener.port}`,
+        { method: "CONNECT" },
+      );
+      expect(asterisk).toStartWith("HTTP/1.1 400");
+      expect(asterisk).not.toContain('"reached":true');
+      expect(authority).toBe("");
+
+      const canonical = await rawRequest(listener.port, "/healthz");
+      expect(canonical).toStartWith("HTTP/1.1 200");
+      expect(canonical).toContain('"reached":true');
+    } finally {
+      await listener.stop();
+    }
+  });
+
+  test("preserves runtime Host, Origin, auth, headers, and body policies", async () => {
+    const token = Buffer.alloc(32, 7).toString("base64url");
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    const listener = await listenRuntimeHttp((request) => handler!(request));
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+      authenticate: async (request) =>
+        request.headers.get("authorization") === `Bearer ${token}`
+          ? createRequestContext({
+              id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              kind: "supervisor",
+              scopes: ["runtime:read"],
+              revoked: false,
+              bbContextId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            })
+          : undefined,
+    });
+
+    try {
+      const health = await rawRequest(listener.port, "/healthz", {
+        headers: { Origin: `http://127.0.0.1:${listener.port}` },
+      });
+      const capabilities = await rawRequest(listener.port, "/v1/capabilities", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const hostileHost = await rawRequest(listener.port, "/healthz", {
+        host: "evil.example",
+      });
+      const hostileOrigin = await rawRequest(listener.port, "/healthz", {
+        headers: { Origin: "http://evil.example" },
+      });
+      const oversized = await rawRequest(listener.port, "/v1/capabilities", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Length": String(256 * 1024 + 1),
+        },
+      });
+
+      expect(health).toStartWith("HTTP/1.1 200");
+      expect(capabilities).toStartWith("HTTP/1.1 200");
+      expect(capabilities).toContain('"runtimeVersion":"0.1.0-alpha.2"');
+      expect(hostileHost).toStartWith("HTTP/1.1 400");
+      expect(hostileOrigin).toStartWith("HTTP/1.1 403");
+      expect(oversized).toStartWith("HTTP/1.1 413");
+      for (const response of [
+        health,
+        capabilities,
+        hostileHost,
+        hostileOrigin,
+        oversized,
+      ]) {
+        expect(response.toLowerCase()).toContain("cache-control: no-store");
+        expect(response.toLowerCase()).toContain(
+          "x-content-type-options: nosniff",
+        );
+        expect(response).not.toContain(token);
+      }
+    } finally {
+      await listener.stop();
+    }
+  });
+});

--- a/apps/cli/src/runtime-http-listener.test.ts
+++ b/apps/cli/src/runtime-http-listener.test.ts
@@ -15,6 +15,8 @@ async function rawRequest(
     readonly method?: string;
     readonly host?: string;
     readonly headers?: Readonly<Record<string, string>>;
+    readonly rawHeaderLines?: readonly string[];
+    readonly body?: string;
   } = {},
 ) {
   const socket = connect({ host: "127.0.0.1", port });
@@ -28,10 +30,11 @@ async function rawRequest(
   });
   const headers = Object.entries(init.headers ?? {})
     .map(([name, value]) => `${name}: ${value}\r\n`)
+    .concat((init.rawHeaderLines ?? []).map((line) => `${line}\r\n`))
     .join("");
   socket.once("connect", () =>
     socket.write(
-      `${init.method ?? "GET"} ${target} HTTP/1.1\r\nHost: ${init.host ?? `127.0.0.1:${port}`}\r\n${headers}Connection: close\r\n\r\n`,
+      `${init.method ?? "GET"} ${target} HTTP/1.1\r\nHost: ${init.host ?? `127.0.0.1:${port}`}\r\n${headers}Connection: close\r\n\r\n${init.body ?? ""}`,
     ),
   );
   await closed;
@@ -39,6 +42,169 @@ async function rawRequest(
 }
 
 describe("runtime HTTP listener", () => {
+  test("rejects a slow chunked GET before handler dispatch", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    const socket = connect({ host: "127.0.0.1", port: listener.port });
+    const response = new Promise<string>((resolve, reject) => {
+      socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+      socket.once("error", reject);
+    });
+    try {
+      await new Promise<void>((resolve) => socket.once("connect", resolve));
+      socket.write(
+        `GET /healthz HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n1\r\na\r\n`,
+      );
+      const firstBytes = await Promise.race([
+        response,
+        Bun.sleep(1_000).then(() => {
+          throw new Error("Listener did not reject the framed GET promptly.");
+        }),
+      ]);
+
+      expect(firstBytes).toStartWith("HTTP/1.1 400");
+      expect(firstBytes.toLowerCase()).toContain("cache-control: no-store");
+      expect(handlerCalls).toBe(0);
+    } finally {
+      socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("rejects a slow chunked HEAD before handler dispatch", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    const socket = connect({ host: "127.0.0.1", port: listener.port });
+    const response = new Promise<string>((resolve, reject) => {
+      socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+      socket.once("error", reject);
+    });
+    try {
+      await new Promise<void>((resolve) => socket.once("connect", resolve));
+      socket.write(
+        `HEAD /healthz HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n1\r\na\r\n`,
+      );
+      const firstBytes = await Promise.race([
+        response,
+        Bun.sleep(1_000).then(() => {
+          throw new Error("Listener did not reject the framed HEAD promptly.");
+        }),
+      ]);
+
+      expect(firstBytes).toStartWith("HTTP/1.1 400");
+      expect(firstBytes.toLowerCase()).toContain("cache-control: no-store");
+      expect(handlerCalls).toBe(0);
+    } finally {
+      socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("rejects Content-Length zero before trailing bytes can escape accounting", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    const socket = connect({ host: "127.0.0.1", port: listener.port });
+    const response = new Promise<string>((resolve, reject) => {
+      socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+      socket.once("error", reject);
+    });
+    try {
+      await new Promise<void>((resolve) => socket.once("connect", resolve));
+      socket.write(
+        `GET /healthz HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nContent-Length: 0\r\n\r\nG`,
+      );
+      const firstBytes = await Promise.race([
+        response,
+        Bun.sleep(1_000).then(() => {
+          throw new Error("Listener did not reject the framed GET promptly.");
+        }),
+      ]);
+
+      expect(firstBytes).toStartWith("HTTP/1.1 400");
+      expect(firstBytes.toLowerCase()).toContain("connection: close");
+      expect(firstBytes.toLowerCase()).toContain("cache-control: no-store");
+      expect(handlerCalls).toBe(0);
+    } finally {
+      socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("rejects every GET or HEAD body-framing header without dispatch", async () => {
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp(async () => {
+      handlerCalls += 1;
+      return Response.json({ reached: true });
+    });
+    try {
+      const responses = await Promise.all([
+        rawRequest(listener.port, "/healthz", {
+          headers: { "Content-Length": "1" },
+        }),
+        rawRequest(listener.port, "/healthz", {
+          method: "HEAD",
+          headers: { "Content-Length": "0" },
+        }),
+        rawRequest(listener.port, "/healthz", {
+          rawHeaderLines: ["Content-Length: 0", "Content-Length: 0"],
+        }),
+      ]);
+
+      for (const [index, response] of responses.entries()) {
+        expect(response, `framing case ${index}`).toStartWith("HTTP/1.1 400");
+        expect(response.toLowerCase(), `framing case ${index}`).toContain(
+          "cache-control: no-store",
+        );
+        expect(response.toLowerCase(), `framing case ${index}`).toContain(
+          "connection: close",
+        );
+      }
+      expect(handlerCalls).toBe(0);
+    } finally {
+      await listener.stop();
+    }
+  });
+
+  test("preserves bodyless GET and HEAD plus streamed mutation bodies", async () => {
+    const calls: Array<{ method: string; body: string }> = [];
+    const listener = await listenRuntimeHttp(async (request) => {
+      const body = request.body ? await request.text() : "";
+      calls.push({ method: request.method, body });
+      return Response.json({ method: request.method, body });
+    });
+    try {
+      const get = await rawRequest(listener.port, "/healthz");
+      const head = await rawRequest(listener.port, "/healthz", {
+        method: "HEAD",
+      });
+      const post = await rawRequest(listener.port, "/v1/capabilities", {
+        method: "POST",
+        headers: { "Content-Length": "3" },
+        body: "abc",
+      });
+
+      expect(get).toStartWith("HTTP/1.1 200");
+      expect(head).toStartWith("HTTP/1.1 200");
+      expect(post).toStartWith("HTTP/1.1 200");
+      expect(calls).toEqual([
+        { method: "GET", body: "" },
+        { method: "HEAD", body: "" },
+        { method: "POST", body: "abc" },
+      ]);
+    } finally {
+      await listener.stop();
+    }
+  });
+
   test("rejects encoded-dot route aliases before Request normalization", async () => {
     const token = Buffer.alloc(32, 7).toString("base64url");
     let handler: ((request: Request) => Promise<Response>) | undefined;

--- a/apps/cli/src/runtime-http-listener.test.ts
+++ b/apps/cli/src/runtime-http-listener.test.ts
@@ -166,6 +166,299 @@ describe("runtime HTTP listener", () => {
     }
   });
 
+  test("force-closes a slow valid-target POST after an early Host rejection", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp((request) => {
+      handlerCalls += 1;
+      return handler!(request);
+    });
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+    });
+    const attack = await openSlowRequest(
+      listener.port,
+      `POST /v1/capabilities HTTP/1.1\r\nHost: evil.example\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+    );
+    try {
+      const response = await attack.response;
+      expect(response).toStartWith("HTTP/1.1 400");
+      expect(response.toLowerCase()).toContain("cache-control: no-store");
+      expect(handlerCalls).toBe(1);
+      expect(
+        await Promise.race([attack.closed, Bun.sleep(250).then(() => false)]),
+      ).toBe(true);
+    } finally {
+      attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("force-closes slow POSTs after early Origin and auth rejection", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp((request) => {
+      handlerCalls += 1;
+      return handler!(request);
+    });
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+    });
+    const attacks = await Promise.all([
+      openSlowRequest(
+        listener.port,
+        `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nOrigin: http://evil.example\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+      ),
+      openSlowRequest(
+        listener.port,
+        `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+      ),
+    ]);
+    try {
+      const responses = await Promise.all(
+        attacks.map((attack) => attack.response),
+      );
+      expect(responses[0]).toStartWith("HTTP/1.1 403");
+      expect(responses[1]).toStartWith("HTTP/1.1 401");
+      for (const response of responses) {
+        expect(response.toLowerCase()).toContain("connection: close");
+        expect(response.toLowerCase()).toContain("cache-control: no-store");
+      }
+      expect(
+        await Promise.race([
+          Promise.all(attacks.map((attack) => attack.closed)).then(() => true),
+          Bun.sleep(250).then(() => false),
+        ]),
+      ).toBe(true);
+      expect(handlerCalls).toBe(2);
+    } finally {
+      for (const attack of attacks) attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("force-closes slow POSTs after encoding and declared-size rejection", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    const listener = await listenRuntimeHttp((request) => handler!(request));
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+    });
+    const attacks = await Promise.all([
+      openSlowRequest(
+        listener.port,
+        `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nOrigin: http://127.0.0.1:${listener.port}\r\nContent-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+      ),
+      openSlowRequest(
+        listener.port,
+        `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nOrigin: http://127.0.0.1:${listener.port}\r\nContent-Length: ${256 * 1024 + 1}\r\n\r\na`,
+      ),
+    ]);
+    try {
+      const responses = await Promise.all(
+        attacks.map((attack) => attack.response),
+      );
+      expect(responses[0]).toStartWith("HTTP/1.1 415");
+      expect(responses[1]).toStartWith("HTTP/1.1 413");
+      expect(
+        responses.every((response) =>
+          response.toLowerCase().includes("connection: close"),
+        ),
+      ).toBe(true);
+      expect(
+        await Promise.race([
+          Promise.all(attacks.map((attack) => attack.closed)).then(() => true),
+          Bun.sleep(250).then(() => false),
+        ]),
+      ).toBe(true);
+    } finally {
+      for (const attack of attacks) attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("releases 33 concurrent slow valid-target policy rejections", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp((request) => {
+      handlerCalls += 1;
+      return handler!(request);
+    });
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+    });
+    const attackHeaders = [
+      "Host: evil.example",
+      `Host: 127.0.0.1:${listener.port}\r\nOrigin: http://evil.example`,
+      `Host: 127.0.0.1:${listener.port}`,
+    ];
+    const attacks = await Promise.all(
+      Array.from({ length: 33 }, (_, index) =>
+        openSlowRequest(
+          listener.port,
+          `POST /v1/capabilities HTTP/1.1\r\n${attackHeaders[index % attackHeaders.length]}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+        ),
+      ),
+    );
+    try {
+      const responses = await Promise.all(
+        attacks.map((attack) => attack.response),
+      );
+      expect(
+        responses.every((response) =>
+          ["HTTP/1.1 400", "HTTP/1.1 403", "HTTP/1.1 401"].some((status) =>
+            response.startsWith(status),
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        responses.every((response) =>
+          response.toLowerCase().includes("connection: close"),
+        ),
+      ).toBe(true);
+      expect(
+        await Promise.race([
+          Promise.all(attacks.map((attack) => attack.closed)).then(() => true),
+          Bun.sleep(1_000).then(() => false),
+        ]),
+      ).toBe(true);
+      expect(handlerCalls).toBe(33);
+    } finally {
+      for (const attack of attacks) attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("force-closes the overloaded request while 32 bodies remain accounted", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    let handlerCalls = 0;
+    const listener = await listenRuntimeHttp((request) => {
+      handlerCalls += 1;
+      return handler!(request);
+    });
+    handler = createRuntimeHttpHandler({
+      port: listener.port,
+      identity: {
+        runtimeVersion: "0.1.0-alpha.2",
+        instanceId: createOpaqueId(() => Buffer.alloc(24, 13)),
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+    });
+    const request = `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nOrigin: http://127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`;
+    const accounted = await Promise.all(
+      Array.from({ length: 32 }, () => openSlowRequest(listener.port, request)),
+    );
+    let overloaded: Awaited<ReturnType<typeof openSlowRequest>> | undefined;
+    try {
+      const deadline = Date.now() + 1_000;
+      while (handlerCalls < 32 && Date.now() < deadline) await Bun.sleep(1);
+      expect(handlerCalls).toBe(32);
+
+      overloaded = await openSlowRequest(listener.port, request);
+      const response = await overloaded.response;
+      expect(response).toStartWith("HTTP/1.1 503");
+      expect(response.toLowerCase()).toContain("connection: close");
+      expect(
+        await Promise.race([
+          overloaded.closed,
+          Bun.sleep(250).then(() => false),
+        ]),
+      ).toBe(true);
+      expect(handlerCalls).toBe(33);
+    } finally {
+      overloaded?.socket.destroy();
+      for (const attack of accounted) attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("preserves keep-alive after a completed mutation body", async () => {
+    const bodies: string[] = [];
+    const listener = await listenRuntimeHttp(async (request) => {
+      bodies.push(request.body ? await request.text() : "");
+      return Response.json({ accepted: true });
+    });
+    const socket = connect({ host: "127.0.0.1", port: listener.port });
+    const closed = new Promise<boolean>((resolve) =>
+      socket.once("close", () => resolve(true)),
+    );
+    try {
+      await new Promise<void>((resolve) => socket.once("connect", resolve));
+      const firstResponse = new Promise<string>((resolve, reject) => {
+        socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+        socket.once("error", reject);
+      });
+      socket.write(
+        `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nContent-Length: 3\r\n\r\nabc`,
+      );
+      const firstBytes = await firstResponse;
+      expect(firstBytes).toStartWith("HTTP/1.1 200");
+      expect(firstBytes.toLowerCase()).not.toContain("connection: close");
+      expect(
+        await Promise.race([closed, Bun.sleep(50).then(() => false)]),
+      ).toBe(false);
+
+      const secondResponse = new Promise<string>((resolve, reject) => {
+        socket.once("data", (chunk) => resolve(chunk.toString("utf8")));
+        socket.once("error", reject);
+      });
+      socket.write(
+        `GET /healthz HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nConnection: close\r\n\r\n`,
+      );
+      expect(await secondResponse).toStartWith("HTTP/1.1 200");
+      expect(
+        await Promise.race([closed, Bun.sleep(250).then(() => false)]),
+      ).toBe(true);
+      expect(bodies).toEqual(["abc", ""]);
+    } finally {
+      socket.destroy();
+      await listener.stop();
+    }
+  });
+
+  test("keeps unread-body closure authoritative over handler headers", async () => {
+    const listener = await listenRuntimeHttp(async () =>
+      Response.json(
+        { rejected: true },
+        { status: 401, headers: { Connection: "keep-alive" } },
+      ),
+    );
+    const attack = await openSlowRequest(
+      listener.port,
+      `POST /v1/capabilities HTTP/1.1\r\nHost: 127.0.0.1:${listener.port}\r\nTransfer-Encoding: chunked\r\n\r\n1\r\na\r\n`,
+    );
+    try {
+      const response = await attack.response;
+      expect(response).toStartWith("HTTP/1.1 401");
+      expect(response.toLowerCase()).toContain("connection: close");
+      expect(
+        await Promise.race([attack.closed, Bun.sleep(250).then(() => false)]),
+      ).toBe(true);
+    } finally {
+      attack.socket.destroy();
+      await listener.stop();
+    }
+  });
+
   test("rejects a slow chunked GET before handler dispatch", async () => {
     let handlerCalls = 0;
     const listener = await listenRuntimeHttp(async () => {

--- a/apps/cli/src/runtime-http-listener.ts
+++ b/apps/cli/src/runtime-http-listener.ts
@@ -60,6 +60,23 @@ function requestHeaders(request: IncomingMessage): Headers {
   return headers;
 }
 
+function hasRawHeader(request: IncomingMessage, name: string): boolean {
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasReadBodyFraming(request: IncomingMessage): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  return (
+    hasRawHeader(request, "content-length") ||
+    hasRawHeader(request, "transfer-encoding")
+  );
+}
+
 function toRequest(request: IncomingMessage, url: URL): Request {
   const method = request.method ?? "GET";
   const init: RequestInit & { duplex?: "half" } = {
@@ -95,30 +112,40 @@ export async function listenRuntimeHttp(
   handle: (request: Request) => Promise<Response>,
 ): Promise<RuntimeHttpListener> {
   let port = 0;
-  const server = createServer((request, response) => {
-    const target = request.url ?? "";
-    const origin = `http://127.0.0.1:${port}`;
-    const url = canonicalOriginForm(target, origin);
-    if (!url) {
-      rejectInvalidTarget(response);
-      return;
-    }
-    void handle(toRequest(request, url))
-      .then((handled) => sendResponse(response, handled))
-      .catch(() => {
-        if (response.headersSent) {
-          response.destroy();
-          return;
-        }
-        response.statusCode = 500;
-        setSecurityHeaders(response);
-        response.end(
-          JSON.stringify({
-            error: { code: "internal", message: "Internal error" },
-          }),
-        );
-      });
-  });
+  const server = createServer(
+    { joinDuplicateHeaders: true },
+    (request, response) => {
+      const target = request.url ?? "";
+      const origin = `http://127.0.0.1:${port}`;
+      const url = canonicalOriginForm(target, origin);
+      if (!url) {
+        rejectInvalidTarget(response);
+        return;
+      }
+      if (hasReadBodyFraming(request)) {
+        response.shouldKeepAlive = false;
+        response.setHeader("Connection", "close");
+        response.once("finish", () => request.destroy());
+        rejectInvalidTarget(response);
+        return;
+      }
+      void handle(toRequest(request, url))
+        .then((handled) => sendResponse(response, handled))
+        .catch(() => {
+          if (response.headersSent) {
+            response.destroy();
+            return;
+          }
+          response.statusCode = 500;
+          setSecurityHeaders(response);
+          response.end(
+            JSON.stringify({
+              error: { code: "internal", message: "Internal error" },
+            }),
+          );
+        });
+    },
+  );
   await new Promise<void>((resolve, reject) => {
     const onError = (error: Error) => {
       server.off("listening", onListening);

--- a/apps/cli/src/runtime-http-listener.ts
+++ b/apps/cli/src/runtime-http-listener.ts
@@ -102,9 +102,15 @@ async function sendResponse(
   nodeResponse.end(body);
 }
 
-function rejectInvalidTarget(response: ServerResponse): void {
+function rejectBeforeDispatch(
+  request: IncomingMessage,
+  response: ServerResponse,
+): void {
   response.statusCode = 400;
+  response.shouldKeepAlive = false;
+  response.setHeader("Connection", "close");
   setSecurityHeaders(response);
+  response.once("finish", () => request.destroy());
   response.end(INVALID_REQUEST_BODY);
 }
 
@@ -119,14 +125,11 @@ export async function listenRuntimeHttp(
       const origin = `http://127.0.0.1:${port}`;
       const url = canonicalOriginForm(target, origin);
       if (!url) {
-        rejectInvalidTarget(response);
+        rejectBeforeDispatch(request, response);
         return;
       }
       if (hasReadBodyFraming(request)) {
-        response.shouldKeepAlive = false;
-        response.setHeader("Connection", "close");
-        response.once("finish", () => request.destroy());
-        rejectInvalidTarget(response);
+        rejectBeforeDispatch(request, response);
         return;
       }
       void handle(toRequest(request, url))

--- a/apps/cli/src/runtime-http-listener.ts
+++ b/apps/cli/src/runtime-http-listener.ts
@@ -1,0 +1,150 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { Readable } from "node:stream";
+
+export interface RuntimeHttpListener {
+  readonly port: number;
+  stop(): Promise<void>;
+}
+
+const INVALID_REQUEST_BODY = JSON.stringify({
+  error: { code: "invalid_request", message: "Invalid request" },
+});
+const SECURITY_HEADERS = {
+  "Content-Type": "application/json;charset=utf-8",
+  "Cache-Control": "no-store",
+  "Content-Security-Policy":
+    "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
+} as const;
+
+function setSecurityHeaders(response: ServerResponse): void {
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    response.setHeader(name, value);
+  }
+}
+
+function canonicalOriginForm(target: string, origin: string): URL | undefined {
+  if (
+    !target.startsWith("/") ||
+    target.startsWith("//") ||
+    target.includes("\\") ||
+    target.includes("#")
+  ) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(target, origin);
+    return parsed.origin === origin &&
+      `${parsed.pathname}${parsed.search}` === target
+      ? parsed
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function requestHeaders(request: IncomingMessage): Headers {
+  const headers = new Headers();
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    headers.append(
+      request.rawHeaders[index] ?? "",
+      request.rawHeaders[index + 1] ?? "",
+    );
+  }
+  return headers;
+}
+
+function toRequest(request: IncomingMessage, url: URL): Request {
+  const method = request.method ?? "GET";
+  const init: RequestInit & { duplex?: "half" } = {
+    method,
+    headers: requestHeaders(request),
+  };
+  if (method !== "GET" && method !== "HEAD") {
+    init.body = Readable.toWeb(request) as ReadableStream<Uint8Array>;
+    init.duplex = "half";
+  }
+  return new Request(url.toString(), init);
+}
+
+async function sendResponse(
+  nodeResponse: ServerResponse,
+  response: Response,
+): Promise<void> {
+  nodeResponse.statusCode = response.status;
+  for (const [name, value] of response.headers) {
+    nodeResponse.setHeader(name, value);
+  }
+  const body = Buffer.from(await response.arrayBuffer());
+  nodeResponse.end(body);
+}
+
+function rejectInvalidTarget(response: ServerResponse): void {
+  response.statusCode = 400;
+  setSecurityHeaders(response);
+  response.end(INVALID_REQUEST_BODY);
+}
+
+export async function listenRuntimeHttp(
+  handle: (request: Request) => Promise<Response>,
+): Promise<RuntimeHttpListener> {
+  let port = 0;
+  const server = createServer((request, response) => {
+    const target = request.url ?? "";
+    const origin = `http://127.0.0.1:${port}`;
+    const url = canonicalOriginForm(target, origin);
+    if (!url) {
+      rejectInvalidTarget(response);
+      return;
+    }
+    void handle(toRequest(request, url))
+      .then((handled) => sendResponse(response, handled))
+      .catch(() => {
+        if (response.headersSent) {
+          response.destroy();
+          return;
+        }
+        response.statusCode = 500;
+        setSecurityHeaders(response);
+        response.end(
+          JSON.stringify({
+            error: { code: "internal", message: "Internal error" },
+          }),
+        );
+      });
+  });
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(0, "127.0.0.1");
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Supervised runtime did not receive a listener port.");
+  }
+  port = address.port;
+
+  return {
+    port,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      }),
+  };
+}

--- a/apps/cli/src/runtime-http-listener.ts
+++ b/apps/cli/src/runtime-http-listener.ts
@@ -91,15 +91,27 @@ function toRequest(request: IncomingMessage, url: URL): Request {
 }
 
 async function sendResponse(
+  request: IncomingMessage,
   nodeResponse: ServerResponse,
   response: Response,
 ): Promise<void> {
+  const hasUnreadBody = !request.complete;
   nodeResponse.statusCode = response.status;
   for (const [name, value] of response.headers) {
     nodeResponse.setHeader(name, value);
   }
+  if (hasUnreadBody) closeUnreadRequest(request, nodeResponse);
   const body = Buffer.from(await response.arrayBuffer());
   nodeResponse.end(body);
+}
+
+function closeUnreadRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+): void {
+  response.shouldKeepAlive = false;
+  response.setHeader("Connection", "close");
+  response.once("finish", () => request.destroy());
 }
 
 function rejectBeforeDispatch(
@@ -107,10 +119,8 @@ function rejectBeforeDispatch(
   response: ServerResponse,
 ): void {
   response.statusCode = 400;
-  response.shouldKeepAlive = false;
-  response.setHeader("Connection", "close");
+  closeUnreadRequest(request, response);
   setSecurityHeaders(response);
-  response.once("finish", () => request.destroy());
   response.end(INVALID_REQUEST_BODY);
 }
 
@@ -133,12 +143,13 @@ export async function listenRuntimeHttp(
         return;
       }
       void handle(toRequest(request, url))
-        .then((handled) => sendResponse(response, handled))
+        .then((handled) => sendResponse(request, response, handled))
         .catch(() => {
           if (response.headersSent) {
             response.destroy();
             return;
           }
+          if (!request.complete) closeUnreadRequest(request, response);
           response.statusCode = 500;
           setSecurityHeaders(response);
           response.end(

--- a/apps/cli/src/serve.test.ts
+++ b/apps/cli/src/serve.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from "bun:test";
+import { createOpaqueId } from "@bb-mate/runtime";
+import {
+  parseSupervisorFrame,
+  RUNTIME_CAPABILITIES,
+} from "@bb-mate/runtime/supervision";
+import { runSupervisedServe, type SupervisedServePlatform } from "./serve.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const token = Buffer.alloc(32, 7).toString("base64url");
+const instanceId = createOpaqueId(() => Buffer.alloc(24, 13));
+const frame = parseSupervisorFrame(
+  JSON.stringify({
+    schemaVersion: 1,
+    expectedRuntimeVersion: "0.1.0-alpha.2",
+    expectedApiVersion: 1,
+    token,
+    principalId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    bbContextId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  }),
+);
+
+describe("supervised serve", () => {
+  test("emits one descriptor and stops exactly once when liveness closes", async () => {
+    const liveness = deferred<void>();
+    const signal = deferred<NodeJS.Signals>();
+    const parentExit = deferred<void>();
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let stopCalls = 0;
+    let fetchHandler: ((request: Request) => Promise<Response>) | undefined;
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({ frame, closed: liveness.promise }),
+      isParentAlive: () => true,
+      waitForParentExit: () => parentExit.promise,
+      waitForSignal: () => signal.promise,
+      listen: (fetch) => {
+        fetchHandler = fetch;
+        return { port: 41721, stop: () => void (stopCalls += 1) };
+      },
+      stdout: (value) => stdout.push(value),
+      stderr: (value) => stderr.push(value),
+    };
+
+    const running = runSupervisedServe(
+      { port: 0, parentPid: 4321, supervisorFd: 3 },
+      { runtimeVersion: "0.1.0-alpha.2", platform },
+    );
+    while (stdout.length === 0) await Bun.sleep(0);
+
+    expect(stdout).toHaveLength(1);
+    expect(JSON.parse(stdout[0] ?? "")).toEqual({
+      apiVersion: 1,
+      baseUrl: "http://127.0.0.1:41721",
+      capabilities: RUNTIME_CAPABILITIES,
+      instanceId,
+      pid: 9001,
+      protocol: "bb-mate-runtime",
+      runtimeVersion: "0.1.0-alpha.2",
+      schemaVersion: 1,
+    });
+    expect(fetchHandler).toBeFunction();
+    expect(stderr).toEqual([]);
+
+    liveness.resolve();
+    await expect(running).resolves.toEqual({ exitCode: 0, signal: null });
+    expect(stopCalls).toBe(1);
+  });
+
+  test("authenticates capabilities with only the inherited bearer token", async () => {
+    const liveness = deferred<void>();
+    let fetchHandler: ((request: Request) => Promise<Response>) | undefined;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({ frame, closed: liveness.promise }),
+      isParentAlive: () => true,
+      waitForParentExit: () => new Promise(() => undefined),
+      waitForSignal: () => new Promise(() => undefined),
+      listen: (fetch) => {
+        fetchHandler = fetch;
+        return { port: 41721, stop: () => undefined };
+      },
+      stdout: (value) => stdout.push(value),
+      stderr: (value) => stderr.push(value),
+    };
+    const running = runSupervisedServe(
+      { port: 0, parentPid: 4321, supervisorFd: 3 },
+      { runtimeVersion: "0.1.0-alpha.2", platform },
+    );
+    while (!fetchHandler) await Bun.sleep(0);
+
+    const request = (authorization?: string) =>
+      new Request("http://127.0.0.1:41721/v1/capabilities", {
+        headers: {
+          host: "127.0.0.1:41721",
+          ...(authorization ? { authorization } : {}),
+        },
+      });
+    const denied = [
+      await fetchHandler(request()),
+      await fetchHandler(request("Bearer wrong")),
+      await fetchHandler(request(`Bearer ${"a".repeat(64 * 1024)}`)),
+    ];
+    expect(denied.map((response) => response.status)).toEqual([401, 401, 401]);
+    for (const response of denied) {
+      expect(await response.text()).not.toContain(token);
+    }
+    const authorized = await fetchHandler(request(`Bearer ${token}`));
+    expect(authorized.status).toBe(200);
+    expect(await authorized.json()).toEqual({
+      schemaVersion: 1,
+      runtimeVersion: "0.1.0-alpha.2",
+      apiVersion: 1,
+      instanceId,
+      capabilities: RUNTIME_CAPABILITIES,
+    });
+    expect(stdout.join("")).not.toContain(token);
+    expect(stderr.join("")).not.toContain(token);
+
+    liveness.resolve();
+    await running;
+  });
+
+  test("refuses a mismatched supervisor before binding or describing a listener", async () => {
+    const incompatible = parseSupervisorFrame(
+      JSON.stringify({
+        ...frame,
+        expectedRuntimeVersion: "0.1.0-alpha.1",
+      }),
+    );
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let listened = false;
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({
+        frame: incompatible,
+        closed: new Promise(() => undefined),
+      }),
+      isParentAlive: () => true,
+      waitForParentExit: () => new Promise(() => undefined),
+      waitForSignal: () => new Promise(() => undefined),
+      listen: () => {
+        listened = true;
+        throw new Error("must not listen");
+      },
+      stdout: (value) => stdout.push(value),
+      stderr: (value) => stderr.push(value),
+    };
+
+    await expect(
+      runSupervisedServe(
+        { port: 0, parentPid: 4321, supervisorFd: 3 },
+        { runtimeVersion: "0.1.0-alpha.2", platform },
+      ),
+    ).resolves.toEqual({ exitCode: 1, signal: null });
+    expect(listened).toBe(false);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("")).toBe(
+      "Supervised runtime version is incompatible.\n",
+    );
+    expect(stderr.join("")).not.toContain(token);
+  });
+
+  test("does not read credentials when the declared parent is already gone", async () => {
+    let opened = false;
+    let listened = false;
+    const stderr: string[] = [];
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => {
+        opened = true;
+        throw new Error("must not open");
+      },
+      isParentAlive: () => false,
+      waitForParentExit: () => new Promise(() => undefined),
+      waitForSignal: () => new Promise(() => undefined),
+      listen: () => {
+        listened = true;
+        throw new Error("must not listen");
+      },
+      stdout: () => undefined,
+      stderr: (value) => stderr.push(value),
+    };
+
+    await expect(
+      runSupervisedServe(
+        { port: 0, parentPid: 4321, supervisorFd: 3 },
+        { runtimeVersion: "0.1.0-alpha.2", platform },
+      ),
+    ).resolves.toEqual({ exitCode: 1, signal: null });
+    expect(opened).toBe(false);
+    expect(listened).toBe(false);
+    expect(stderr).toEqual(["Supervised runtime parent is unavailable.\n"]);
+  });
+
+  test("returns the terminating signal after idempotent listener cleanup", async () => {
+    const signal = deferred<NodeJS.Signals>();
+    let stopCalls = 0;
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({
+        frame,
+        closed: new Promise(() => undefined),
+      }),
+      isParentAlive: () => true,
+      waitForParentExit: () => new Promise(() => undefined),
+      waitForSignal: () => signal.promise,
+      listen: () => ({
+        port: 41721,
+        stop: () => void (stopCalls += 1),
+      }),
+      stdout: () => undefined,
+      stderr: () => undefined,
+    };
+    const running = runSupervisedServe(
+      { port: 0, parentPid: 4321, supervisorFd: 3 },
+      { runtimeVersion: "0.1.0-alpha.2", platform },
+    );
+    await Bun.sleep(0);
+
+    signal.resolve("SIGTERM");
+    await expect(running).resolves.toEqual({
+      exitCode: null,
+      signal: "SIGTERM",
+    });
+    expect(stopCalls).toBe(1);
+  });
+
+  test("fails closed and stops when the supervisor process disappears", async () => {
+    const parentExit = deferred<void>();
+    const stderr: string[] = [];
+    let stopCalls = 0;
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({
+        frame,
+        closed: new Promise(() => undefined),
+      }),
+      isParentAlive: () => true,
+      waitForParentExit: () => parentExit.promise,
+      waitForSignal: () => new Promise(() => undefined),
+      listen: () => ({
+        port: 41721,
+        stop: () => void (stopCalls += 1),
+      }),
+      stdout: () => undefined,
+      stderr: (value) => stderr.push(value),
+    };
+    const running = runSupervisedServe(
+      { port: 0, parentPid: 4321, supervisorFd: 3 },
+      { runtimeVersion: "0.1.0-alpha.2", platform },
+    );
+    await Bun.sleep(0);
+
+    parentExit.resolve();
+    await expect(running).resolves.toEqual({ exitCode: 1, signal: null });
+    expect(stopCalls).toBe(1);
+    expect(stderr).toEqual(["Supervised runtime stopped unexpectedly.\n"]);
+  });
+
+  test("stops when the one-frame channel reports post-frame bytes", async () => {
+    const liveness = deferred<void>();
+    let stopCalls = 0;
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({ frame, closed: liveness.promise }),
+      isParentAlive: () => true,
+      waitForParentExit: () => new Promise(() => undefined),
+      waitForSignal: () => new Promise(() => undefined),
+      listen: () => ({
+        port: 41721,
+        stop: () => void (stopCalls += 1),
+      }),
+      stdout: () => undefined,
+      stderr: () => undefined,
+    };
+    const running = runSupervisedServe(
+      { port: 0, parentPid: 4321, supervisorFd: 3 },
+      { runtimeVersion: "0.1.0-alpha.2", platform },
+    );
+    await Bun.sleep(0);
+
+    liveness.reject(new Error("Supervisor channel accepts exactly one frame."));
+    await expect(running).resolves.toEqual({ exitCode: 1, signal: null });
+    expect(stopCalls).toBe(1);
+  });
+
+  test("stops once when shutdown sources settle together", async () => {
+    const liveness = deferred<void>();
+    const signal = deferred<NodeJS.Signals>();
+    const parentExit = deferred<void>();
+    let stopCalls = 0;
+    const platform: SupervisedServePlatform = {
+      pid: 9001,
+      createInstanceId: () => instanceId,
+      openChannel: async () => ({ frame, closed: liveness.promise }),
+      isParentAlive: () => true,
+      waitForParentExit: () => parentExit.promise,
+      waitForSignal: () => signal.promise,
+      listen: () => ({
+        port: 41721,
+        stop: async () => {
+          stopCalls += 1;
+        },
+      }),
+      stdout: () => undefined,
+      stderr: () => undefined,
+    };
+    const running = runSupervisedServe(
+      { port: 0, parentPid: 4321, supervisorFd: 3 },
+      { runtimeVersion: "0.1.0-alpha.2", platform },
+    );
+    await Bun.sleep(0);
+
+    liveness.resolve();
+    signal.resolve("SIGTERM");
+    parentExit.resolve();
+    await running;
+    expect(stopCalls).toBe(1);
+  });
+});

--- a/apps/cli/src/serve.ts
+++ b/apps/cli/src/serve.ts
@@ -19,6 +19,7 @@ import {
   readSupervisorChannel,
   type SupervisorChannel,
 } from "./supervisor-channel.ts";
+import { listenRuntimeHttp } from "./runtime-http-listener.ts";
 
 interface RuntimeServer {
   readonly port: number;
@@ -32,7 +33,9 @@ export interface SupervisedServePlatform {
   isParentAlive(pid: number): boolean;
   waitForParentExit(pid: number, signal: AbortSignal): Promise<void>;
   waitForSignal(signal: AbortSignal): Promise<NodeJS.Signals>;
-  listen(fetch: (request: Request) => Promise<Response>): RuntimeServer;
+  listen(
+    fetch: (request: Request) => Promise<Response>,
+  ): RuntimeServer | Promise<RuntimeServer>;
   stdout(value: string): void;
   stderr(value: string): void;
 }
@@ -143,14 +146,7 @@ function productionPlatform(): SupervisedServePlatform {
         process.once("SIGTERM", onTerminate);
         signal.addEventListener("abort", cleanup, { once: true });
       }),
-    listen: (fetch) => {
-      const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch });
-      if (!server.port) {
-        void server.stop(true);
-        throw new Error("Supervised runtime did not receive a listener port.");
-      }
-      return { port: server.port, stop: () => server.stop(true) };
-    },
+    listen: listenRuntimeHttp,
     stdout: (value) => process.stdout.write(value),
     stderr: (value) => process.stderr.write(value),
   };
@@ -186,7 +182,7 @@ export async function runSupervisedServe(
     const token = Buffer.from(channel.frame.token, "base64url");
     expectedToken = token;
     let handler: ((request: Request) => Promise<Response>) | undefined;
-    server = platform.listen((request) => {
+    server = await platform.listen((request) => {
       if (!handler) return Promise.resolve(new Response(null, { status: 503 }));
       return handler(request);
     });

--- a/apps/cli/src/serve.ts
+++ b/apps/cli/src/serve.ts
@@ -1,0 +1,246 @@
+import { timingSafeEqual } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  createOpaqueId,
+  createRequestContext,
+  createRuntimeHttpHandler,
+  type OpaqueId,
+} from "@bb-mate/runtime";
+import {
+  parseSupervisorFrame,
+  RUNTIME_API_VERSION,
+  RUNTIME_CAPABILITIES,
+  serializeRuntimeLaunchDescriptor,
+  SUPERVISOR_FRAME_MAX_BYTES,
+  type SupervisorFrame,
+} from "@bb-mate/runtime/supervision";
+import type { ProcessExit } from "./commands.ts";
+import {
+  readSupervisorChannel,
+  type SupervisorChannel,
+} from "./supervisor-channel.ts";
+
+interface RuntimeServer {
+  readonly port: number;
+  stop(): void | Promise<void>;
+}
+
+export interface SupervisedServePlatform {
+  readonly pid: number;
+  createInstanceId(): OpaqueId;
+  openChannel(fd: number): Promise<SupervisorChannel<SupervisorFrame>>;
+  isParentAlive(pid: number): boolean;
+  waitForParentExit(pid: number, signal: AbortSignal): Promise<void>;
+  waitForSignal(signal: AbortSignal): Promise<NodeJS.Signals>;
+  listen(fetch: (request: Request) => Promise<Response>): RuntimeServer;
+  stdout(value: string): void;
+  stderr(value: string): void;
+}
+
+export interface SupervisedServeOptions {
+  readonly port: 0;
+  readonly parentPid: number;
+  readonly supervisorFd: number;
+}
+
+function tokenMatches(request: Request, expected: Buffer): boolean {
+  const header = request.headers.get("authorization");
+  const match = header?.match(/^Bearer ([A-Za-z0-9_-]{43})$/u);
+  if (!match?.[1]) return false;
+  const received = Buffer.from(match[1], "base64url");
+  try {
+    return (
+      received.byteLength === expected.byteLength &&
+      received.toString("base64url") === match[1] &&
+      timingSafeEqual(received, expected)
+    );
+  } finally {
+    received.fill(0);
+  }
+}
+
+function authenticatedContext(
+  frame: SupervisorFrame,
+  token: Buffer,
+  request: Request,
+) {
+  if (!tokenMatches(request, token)) return undefined;
+  return createRequestContext({
+    id: frame.principalId,
+    kind: "supervisor",
+    scopes: ["runtime:read"],
+    revoked: false,
+    bbContextId: frame.bbContextId,
+  });
+}
+
+function productionPlatform(): SupervisedServePlatform {
+  return {
+    pid: process.pid,
+    createInstanceId: createOpaqueId,
+    openChannel: (fd) =>
+      readSupervisorChannel(
+        createReadStream("", { fd, autoClose: true }),
+        parseSupervisorFrame,
+        { maxBytes: SUPERVISOR_FRAME_MAX_BYTES },
+      ),
+    isParentAlive: (pid) => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (error) {
+        return (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "EPERM"
+        );
+      }
+    },
+    waitForParentExit: (pid, signal) =>
+      new Promise((resolve) => {
+        const poll = () => {
+          try {
+            process.kill(pid, 0);
+          } catch (error) {
+            if (!(
+              typeof error === "object" &&
+              error !== null &&
+              "code" in error &&
+              error.code === "EPERM"
+            )) {
+              finish();
+            }
+          }
+        };
+        const timer = setInterval(poll, 250);
+        const finish = () => {
+          clearInterval(timer);
+          signal.removeEventListener("abort", cancel);
+          resolve();
+        };
+        const cancel = () => {
+          clearInterval(timer);
+          resolve();
+        };
+        signal.addEventListener("abort", cancel, { once: true });
+        poll();
+      }),
+    waitForSignal: (signal) =>
+      new Promise((resolve) => {
+        const finish = (received: NodeJS.Signals) => {
+          cleanup();
+          resolve(received);
+        };
+        const onInterrupt = () => finish("SIGINT");
+        const onTerminate = () => finish("SIGTERM");
+        const cleanup = () => {
+          process.off("SIGINT", onInterrupt);
+          process.off("SIGTERM", onTerminate);
+          signal.removeEventListener("abort", cleanup);
+        };
+        process.once("SIGINT", onInterrupt);
+        process.once("SIGTERM", onTerminate);
+        signal.addEventListener("abort", cleanup, { once: true });
+      }),
+    listen: (fetch) => {
+      const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch });
+      if (!server.port) {
+        void server.stop(true);
+        throw new Error("Supervised runtime did not receive a listener port.");
+      }
+      return { port: server.port, stop: () => server.stop(true) };
+    },
+    stdout: (value) => process.stdout.write(value),
+    stderr: (value) => process.stderr.write(value),
+  };
+}
+
+export async function runSupervisedServe(
+  options: SupervisedServeOptions,
+  runtime: {
+    readonly runtimeVersion: string;
+    readonly platform?: SupervisedServePlatform;
+  },
+): Promise<ProcessExit> {
+  const platform = runtime.platform ?? productionPlatform();
+  if (!platform.isParentAlive(options.parentPid)) {
+    platform.stderr("Supervised runtime parent is unavailable.\n");
+    return { exitCode: 1, signal: null };
+  }
+
+  let server: RuntimeServer | undefined;
+  let expectedToken: Buffer | undefined;
+  const lifecycle = new AbortController();
+  try {
+    const channel = await platform.openChannel(options.supervisorFd);
+    if (
+      channel.frame.expectedRuntimeVersion !== runtime.runtimeVersion ||
+      channel.frame.expectedApiVersion !== RUNTIME_API_VERSION
+    ) {
+      platform.stderr("Supervised runtime version is incompatible.\n");
+      return { exitCode: 1, signal: null };
+    }
+
+    const instanceId = platform.createInstanceId();
+    const token = Buffer.from(channel.frame.token, "base64url");
+    expectedToken = token;
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    server = platform.listen((request) => {
+      if (!handler) return Promise.resolve(new Response(null, { status: 503 }));
+      return handler(request);
+    });
+    handler = createRuntimeHttpHandler({
+      port: server.port,
+      identity: {
+        runtimeVersion: runtime.runtimeVersion,
+        instanceId,
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+      authenticate: async (request) =>
+        authenticatedContext(channel.frame, token, request),
+    });
+
+    platform.stdout(
+      serializeRuntimeLaunchDescriptor({
+        schemaVersion: 1,
+        protocol: "bb-mate-runtime",
+        runtimeVersion: runtime.runtimeVersion,
+        apiVersion: RUNTIME_API_VERSION,
+        pid: platform.pid,
+        instanceId,
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        capabilities: RUNTIME_CAPABILITIES,
+      }),
+    );
+
+    const outcome = await Promise.race([
+      channel.closed.then(
+        () => ({ kind: "channel" as const }),
+        (error: unknown) => ({ kind: "failure" as const, error }),
+      ),
+      platform
+        .waitForParentExit(options.parentPid, lifecycle.signal)
+        .then(() => ({ kind: "parent" as const })),
+      platform
+        .waitForSignal(lifecycle.signal)
+        .then((signal) => ({ kind: "signal" as const, signal })),
+    ]);
+
+    if (outcome.kind === "signal") {
+      return { exitCode: null, signal: outcome.signal };
+    }
+    if (outcome.kind === "channel") {
+      return { exitCode: 0, signal: null };
+    }
+    platform.stderr("Supervised runtime stopped unexpectedly.\n");
+    return { exitCode: 1, signal: null };
+  } catch {
+    platform.stderr("Supervised runtime could not start.\n");
+    return { exitCode: 1, signal: null };
+  } finally {
+    lifecycle.abort();
+    expectedToken?.fill(0);
+    await server?.stop();
+  }
+}

--- a/apps/cli/src/supervisor-channel.test.ts
+++ b/apps/cli/src/supervisor-channel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { PassThrough } from "node:stream";
+import { readSupervisorChannel } from "./supervisor-channel.ts";
+
+describe("supervisor channel", () => {
+  test("reads one bounded frame and treats the remaining stream as liveness", async () => {
+    const stream = new PassThrough();
+    const opened = readSupervisorChannel(stream, (value) => JSON.parse(value), {
+      timeoutMs: 100,
+    });
+
+    stream.write('{"schemaVersion":1}\n');
+    const channel = await opened;
+
+    expect(channel.frame).toEqual({ schemaVersion: 1 });
+    let closed = false;
+    void channel.closed.then(() => {
+      closed = true;
+    });
+    await Bun.sleep(0);
+    expect(closed).toBe(false);
+    stream.end();
+    await expect(channel.closed).resolves.toBeUndefined();
+  });
+
+  test("rejects queued and later bytes after the single frame", async () => {
+    const queued = new PassThrough();
+    const queuedRead = readSupervisorChannel(
+      queued,
+      (value) => JSON.parse(value),
+      {
+        timeoutMs: 100,
+      },
+    );
+    queued.end('{"schemaVersion":1}\nextra');
+    await expect(queuedRead).rejects.toThrow(
+      "Supervisor channel accepts exactly one frame.",
+    );
+
+    const split = new PassThrough();
+    const splitRead = readSupervisorChannel(
+      split,
+      (value) => JSON.parse(value),
+      {
+        timeoutMs: 100,
+      },
+    );
+    split.write('{"schemaVersion":1}\n');
+    split.write("extra");
+    const splitChannel = await splitRead;
+    await expect(splitChannel.closed).rejects.toThrow(
+      "Supervisor channel accepts exactly one frame.",
+    );
+
+    const later = new PassThrough();
+    const laterRead = readSupervisorChannel(
+      later,
+      (value) => JSON.parse(value),
+      {
+        timeoutMs: 100,
+      },
+    );
+    later.write('{"schemaVersion":1}\n');
+    const channel = await laterRead;
+    later.write("extra");
+    await expect(channel.closed).rejects.toThrow(
+      "Supervisor channel accepts exactly one frame.",
+    );
+  });
+
+  test("bounds frame bytes and wait time before parsing", async () => {
+    const oversized = new PassThrough();
+    const oversizedRead = readSupervisorChannel(oversized, (value) => value, {
+      timeoutMs: 100,
+    });
+    oversized.end(`${"x".repeat(4_096)}\n`);
+    await expect(oversizedRead).rejects.toThrow(
+      "Supervisor frame exceeds 4096 bytes.",
+    );
+    expect(oversized.destroyed).toBe(true);
+
+    const silent = new PassThrough();
+    await expect(
+      readSupervisorChannel(silent, (value) => value, { timeoutMs: 1 }),
+    ).rejects.toThrow("Timed out waiting for the supervisor frame.");
+    expect(silent.destroyed).toBe(true);
+  });
+});

--- a/apps/cli/src/supervisor-channel.ts
+++ b/apps/cli/src/supervisor-channel.ts
@@ -1,0 +1,124 @@
+import type { Readable } from "node:stream";
+
+const DEFAULT_FRAME_BYTES = 4_096;
+const DEFAULT_TIMEOUT_MS = 2_000;
+
+export interface SupervisorChannel<Frame> {
+  readonly frame: Frame;
+  readonly closed: Promise<void>;
+}
+
+export async function readSupervisorChannel<Frame>(
+  stream: Readable,
+  parseFrame: (value: string) => Frame,
+  options: {
+    readonly maxBytes?: number;
+    readonly timeoutMs?: number;
+  } = {},
+): Promise<SupervisorChannel<Frame>> {
+  const maxBytes = options.maxBytes ?? DEFAULT_FRAME_BYTES;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+
+  let firstLine: Buffer;
+  try {
+    firstLine = await new Promise<Buffer>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => finish(new Error("Timed out waiting for the supervisor frame.")),
+        timeoutMs,
+      );
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        stream.off("data", onData);
+        stream.off("end", onEnd);
+        stream.off("error", finish);
+      };
+      const finish = (error: unknown, value?: Buffer) => {
+        cleanup();
+        if (error) reject(error);
+        else resolve(value as Buffer);
+      };
+      const onEnd = () =>
+        finish(new Error("Supervisor channel closed before its frame."));
+      const onData = (value: Buffer | string) => {
+        const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+        const newline = chunk.indexOf(0x0a);
+        const accepted = newline === -1 ? chunk : chunk.subarray(0, newline);
+        byteLength += accepted.byteLength + (newline === -1 ? 0 : 1);
+        chunks.push(accepted);
+        if (byteLength > maxBytes) {
+          finish(new Error("Supervisor frame exceeds 4096 bytes."));
+          return;
+        }
+        if (newline === -1) return;
+        stream.pause();
+        if (newline !== chunk.byteLength - 1) {
+          finish(new Error("Supervisor channel accepts exactly one frame."));
+          return;
+        }
+        finish(undefined, Buffer.concat(chunks, byteLength - 1));
+      };
+
+      stream.on("data", onData);
+      stream.once("end", onEnd);
+      stream.once("error", finish);
+    });
+  } catch (error) {
+    for (const chunk of chunks) chunk.fill(0);
+    stream.destroy();
+    throw error;
+  }
+
+  let frame: Frame;
+  try {
+    let decoded: string;
+    try {
+      decoded = new TextDecoder("utf-8", { fatal: true }).decode(firstLine);
+    } catch (error) {
+      throw new Error("Supervisor frame must be valid UTF-8.", {
+        cause: error,
+      });
+    }
+    frame = parseFrame(decoded);
+  } catch (error) {
+    stream.destroy();
+    throw error;
+  } finally {
+    firstLine.fill(0);
+    for (const chunk of chunks) chunk.fill(0);
+  }
+
+  if (stream.readableEnded || stream.destroyed) {
+    return { frame, closed: Promise.resolve() };
+  }
+  const closed = new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      stream.off("data", onData);
+      stream.off("end", onEnd);
+      stream.off("close", onEnd);
+      stream.off("error", onError);
+    };
+    const onData = () => {
+      cleanup();
+      reject(new Error("Supervisor channel accepts exactly one frame."));
+    };
+    const onEnd = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    stream.on("data", onData);
+    stream.once("end", onEnd);
+    stream.once("close", onEnd);
+    stream.once("error", onError);
+  });
+  stream.resume();
+
+  return { frame, closed };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
       },
       "dependencies": {
         "@bb-mate/inspection": "workspace:*",
+        "@bb-mate/runtime": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "^1.3.4",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./supervision": "./src/supervision/protocol.ts"
   },
   "scripts": {
     "build": "tsc --noEmit",

--- a/packages/runtime/src/http/handler.concurrency.test.ts
+++ b/packages/runtime/src/http/handler.concurrency.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { createRequestContext } from "../auth/context.ts";
-import { createRuntimeHttpHandler } from "./handler.ts";
+import { createRuntimeHttpHandler } from "./handler.test-support.ts";
 
 const context = createRequestContext({
   id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/packages/runtime/src/http/handler.headers.test.ts
+++ b/packages/runtime/src/http/handler.headers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createRuntimeHttpHandler } from "./handler.ts";
+import { createRuntimeHttpHandler } from "./handler.test-support.ts";
 
 const URL = "http://127.0.0.1:41721";
 const HOST = "127.0.0.1:41721";

--- a/packages/runtime/src/http/handler.policy.test.ts
+++ b/packages/runtime/src/http/handler.policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { createRequestContext } from "../auth/context.ts";
-import { createRuntimeHttpHandler } from "./handler.ts";
+import { createRuntimeHttpHandler } from "./handler.test-support.ts";
 
 const URL = "http://127.0.0.1:41721";
 const HOST = "127.0.0.1:41721";

--- a/packages/runtime/src/http/handler.routes.test.ts
+++ b/packages/runtime/src/http/handler.routes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { createRequestContext } from "../auth/context.ts";
-import { createRuntimeHttpHandler } from "./handler.ts";
+import { createRuntimeHttpHandler } from "./handler.test-support.ts";
 
 const principal = createRequestContext({
   id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/packages/runtime/src/http/handler.test-support.ts
+++ b/packages/runtime/src/http/handler.test-support.ts
@@ -1,0 +1,26 @@
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import { RUNTIME_CAPABILITIES } from "../supervision/protocol.ts";
+import {
+  createRuntimeHttpHandler as createHandler,
+  type RuntimeHttpHandler,
+  type RuntimeHttpHandlerOptions,
+} from "./handler.ts";
+
+const TEST_IDENTITY = {
+  runtimeVersion: "0.1.0",
+  instanceId: OpaqueIdSchema.parse("d".repeat(32)),
+  capabilities: RUNTIME_CAPABILITIES,
+} as const;
+
+type TestHandlerOptions = Omit<RuntimeHttpHandlerOptions, "identity"> & {
+  identity?: RuntimeHttpHandlerOptions["identity"];
+};
+
+export function createRuntimeHttpHandler(
+  options: TestHandlerOptions,
+): RuntimeHttpHandler {
+  return createHandler({
+    ...options,
+    identity: options.identity ?? TEST_IDENTITY,
+  });
+}

--- a/packages/runtime/src/http/handler.test.ts
+++ b/packages/runtime/src/http/handler.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import { createRequestContext } from "../auth/context.ts";
 import type { PrincipalKind } from "../auth/principals.ts";
-import { createRuntimeHttpHandler } from "./handler.ts";
+import { OpaqueIdSchema } from "../contracts/ids.ts";
+import { RUNTIME_CAPABILITIES } from "../supervision/protocol.ts";
+import { createRuntimeHttpHandler } from "./handler.test-support.ts";
+import { createRuntimeHttpHandler as createRawRuntimeHttpHandler } from "./handler.ts";
 
 const principalId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const bbContextId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const instanceId = OpaqueIdSchema.parse("d".repeat(32));
 
 function runtimeReader(kind: PrincipalKind) {
   return createRequestContext({
@@ -92,6 +96,11 @@ describe("runtime loopback HTTP routes", () => {
     const context = runtimeReader("browser-session");
     const handle = createRuntimeHttpHandler({
       port: 41_721,
+      identity: {
+        runtimeVersion: "0.1.0",
+        instanceId,
+        capabilities: RUNTIME_CAPABILITIES,
+      },
       authenticate: async () => context,
     });
     const response = await handle(
@@ -103,7 +112,9 @@ describe("runtime loopback HTTP routes", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       schemaVersion: 1,
+      runtimeVersion: "0.1.0",
       apiVersion: 1,
+      instanceId: "dddddddddddddddddddddddddddddddd",
       capabilities: {
         browserBootstrap: false,
         targets: false,
@@ -118,6 +129,32 @@ describe("runtime loopback HTTP routes", () => {
         mcp: false,
       },
     });
+  });
+
+  test("rejects malformed or secret-bearing runtime identity metadata", () => {
+    for (const identity of [
+      undefined,
+      {
+        runtimeVersion: "latest",
+        instanceId: "dddddddddddddddddddddddddddddddd",
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+      {
+        runtimeVersion: "0.1.0",
+        instanceId: "not-an-opaque-id",
+        capabilities: RUNTIME_CAPABILITIES,
+      },
+      {
+        runtimeVersion: "0.1.0",
+        instanceId: "dddddddddddddddddddddddddddddddd",
+        capabilities: RUNTIME_CAPABILITIES,
+        token: "must-not-enter-public-identity",
+      },
+    ]) {
+      expect(() =>
+        createRawRuntimeHttpHandler({ port: 41_721, identity } as never),
+      ).toThrow(new TypeError("Invalid runtime HTTP identity"));
+    }
   });
 
   test("returns redacted errors for missing or insufficient authentication", async () => {

--- a/packages/runtime/src/http/handler.ts
+++ b/packages/runtime/src/http/handler.ts
@@ -1,6 +1,12 @@
 import { authorize } from "../auth/authorize.ts";
 import type { RequestContext } from "../auth/context.ts";
+import type { OpaqueId } from "../contracts/ids.ts";
 import { RuntimeError, type RuntimeErrorCode } from "../errors.ts";
+import {
+  RUNTIME_API_VERSION,
+  RuntimeCapabilityDocumentSchema,
+  type RuntimeCapabilitiesV1,
+} from "../supervision/protocol.ts";
 
 export type RuntimeHttpAuthenticator = (
   request: Request,
@@ -8,7 +14,14 @@ export type RuntimeHttpAuthenticator = (
 
 export interface RuntimeHttpHandlerOptions {
   port: number;
+  identity: RuntimeHttpIdentity;
   authenticate?: RuntimeHttpAuthenticator;
+}
+
+export interface RuntimeHttpIdentity {
+  runtimeVersion: string;
+  instanceId: OpaqueId;
+  capabilities: RuntimeCapabilitiesV1;
 }
 
 export type RuntimeHttpHandler = (request: Request) => Promise<Response>;
@@ -23,22 +36,10 @@ const SECURITY_HEADERS = {
 } as const;
 const MAX_REQUEST_BODY_BYTES = 256 * 1024;
 const MAX_CONCURRENT_REQUESTS = 32;
-const CAPABILITIES_DOCUMENT = Object.freeze({
-  schemaVersion: 1,
-  apiVersion: 1,
-  capabilities: Object.freeze({
-    browserBootstrap: false,
-    targets: false,
-    sessions: false,
-    annotations: false,
-    captures: false,
-    comparisons: false,
-    pluginBriefs: false,
-    reviews: false,
-    events: false,
-    artifacts: false,
-    mcp: false,
-  }),
+const RuntimeHttpIdentitySchema = RuntimeCapabilityDocumentSchema.pick({
+  runtimeVersion: true,
+  instanceId: true,
+  capabilities: true,
 });
 
 interface JsonResponseInit {
@@ -140,6 +141,7 @@ function statusForRuntimeError(error: RuntimeError): number {
 
 export function createRuntimeHttpHandler({
   port,
+  identity,
   authenticate = async () => undefined,
 }: RuntimeHttpHandlerOptions): RuntimeHttpHandler {
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
@@ -147,6 +149,20 @@ export function createRuntimeHttpHandler({
       "Runtime HTTP port must be an integer from 1 through 65535",
     );
   }
+
+  let parsedIdentity: RuntimeHttpIdentity;
+  try {
+    parsedIdentity = RuntimeHttpIdentitySchema.parse(identity);
+  } catch {
+    throw new TypeError("Invalid runtime HTTP identity");
+  }
+  const capabilitiesDocument = Object.freeze({
+    schemaVersion: 1 as const,
+    runtimeVersion: parsedIdentity.runtimeVersion,
+    apiVersion: RUNTIME_API_VERSION,
+    instanceId: parsedIdentity.instanceId,
+    capabilities: Object.freeze(parsedIdentity.capabilities),
+  });
 
   const origin = `http://127.0.0.1:${port}`;
   const authority = `127.0.0.1:${port}`;
@@ -264,7 +280,7 @@ export function createRuntimeHttpHandler({
           }
           return forRequestMethod(
             request,
-            json(CAPABILITIES_DOCUMENT, undefined, requestOrigin),
+            json(capabilitiesDocument, undefined, requestOrigin),
           );
         } catch (error) {
           const runtimeError =

--- a/packages/runtime/src/supervision/protocol.test.ts
+++ b/packages/runtime/src/supervision/protocol.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BbContextIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+} from "../contracts/ids.ts";
+import {
+  parseRuntimeLaunchDescriptor,
+  parseSupervisorFrame,
+  RUNTIME_CAPABILITIES,
+  RuntimeCapabilityDocumentSchema,
+  serializeRuntimeLaunchDescriptor,
+} from "./protocol.ts";
+
+const principalId = PrincipalIdSchema.parse("a".repeat(32));
+const bbContextId = BbContextIdSchema.parse("b".repeat(32));
+const instanceId = OpaqueIdSchema.parse("d".repeat(32));
+const token = Buffer.alloc(32, 7).toString("base64url");
+
+const validFrame = {
+  schemaVersion: 1,
+  expectedRuntimeVersion: "0.1.0",
+  expectedApiVersion: 1,
+  token,
+  principalId,
+  bbContextId,
+} as const;
+
+describe("supervised runtime protocol", () => {
+  test("parses the strict v1 supervisor frame", () => {
+    expect(parseSupervisorFrame(`${JSON.stringify(validFrame)}\n`)).toEqual({
+      schemaVersion: 1,
+      expectedRuntimeVersion: "0.1.0",
+      expectedApiVersion: 1,
+      token,
+      principalId,
+      bbContextId,
+    });
+  });
+
+  test("rejects supervisor frame drift, invalid credentials, and framing overflow", () => {
+    const cases: Array<string | Uint8Array> = [
+      JSON.stringify({ ...validFrame, extra: true }),
+      JSON.stringify({ ...validFrame, token: `${token}=` }),
+      JSON.stringify({ ...validFrame, token: "!".repeat(43) }),
+      JSON.stringify({ ...validFrame, token: token.slice(1) }),
+      JSON.stringify({ ...validFrame, expectedRuntimeVersion: "latest" }),
+      JSON.stringify({ ...validFrame, expectedRuntimeVersion: "1.0.0-01" }),
+      `${JSON.stringify(validFrame)}\n\n`,
+      `${JSON.stringify(validFrame)}\n{}`,
+      `${JSON.stringify(validFrame)}${" ".repeat(4 * 1024)}`,
+      new Uint8Array([0xc3, 0x28]),
+    ];
+
+    for (const input of cases) {
+      expect(() => parseSupervisorFrame(input)).toThrow(
+        new TypeError("Invalid supervisor frame"),
+      );
+    }
+  });
+
+  test("serializes and parses one canonical bounded launch descriptor line", () => {
+    const descriptor = {
+      schemaVersion: 1,
+      protocol: "bb-mate-runtime",
+      runtimeVersion: "0.1.0-beta.1+build.2",
+      apiVersion: 1,
+      pid: 42,
+      instanceId,
+      baseUrl: "http://127.0.0.1:41721",
+      capabilities: RUNTIME_CAPABILITIES,
+    } as const;
+
+    const line = serializeRuntimeLaunchDescriptor(descriptor);
+
+    expect(line.endsWith("\n")).toBe(true);
+    expect(line.indexOf("\n")).toBe(line.length - 1);
+    expect(Buffer.byteLength(line, "utf8")).toBeLessThanOrEqual(8 * 1024);
+    expect(parseRuntimeLaunchDescriptor(line)).toEqual(descriptor);
+    expect(line).toBe(
+      `${JSON.stringify({
+        apiVersion: 1,
+        baseUrl: "http://127.0.0.1:41721",
+        capabilities: RUNTIME_CAPABILITIES,
+        instanceId,
+        pid: 42,
+        protocol: "bb-mate-runtime",
+        runtimeVersion: "0.1.0-beta.1+build.2",
+        schemaVersion: 1,
+      })}\n`,
+    );
+  });
+
+  test("rejects descriptor drift, secrets, non-loopback URLs, and overflow", () => {
+    const descriptor = {
+      schemaVersion: 1,
+      protocol: "bb-mate-runtime",
+      runtimeVersion: "0.1.0",
+      apiVersion: 1,
+      pid: 42,
+      instanceId,
+      baseUrl: "http://127.0.0.1:41721",
+      capabilities: RUNTIME_CAPABILITIES,
+    } as const;
+    const invalid = [
+      { ...descriptor, token },
+      { ...descriptor, apiVersion: 2 },
+      { ...descriptor, pid: 0 },
+      { ...descriptor, baseUrl: "http://localhost:41721" },
+      { ...descriptor, baseUrl: "http://127.0.0.1:41721/healthz" },
+      { ...descriptor, baseUrl: "http://127.0.0.1:0" },
+      { ...descriptor, baseUrl: "http://127.0.0.1:65536" },
+      {
+        ...descriptor,
+        capabilities: { ...RUNTIME_CAPABILITIES, unknown: false },
+      },
+    ];
+
+    for (const input of invalid) {
+      expect(() => serializeRuntimeLaunchDescriptor(input)).toThrow(
+        new TypeError("Invalid runtime launch descriptor"),
+      );
+    }
+    expect(() =>
+      parseRuntimeLaunchDescriptor(
+        `${JSON.stringify(descriptor)}${" ".repeat(8 * 1024)}`,
+      ),
+    ).toThrow(new TypeError("Invalid runtime launch descriptor"));
+    expect(() =>
+      parseRuntimeLaunchDescriptor(new Uint8Array([0xc3, 0x28])),
+    ).toThrow(new TypeError("Invalid runtime launch descriptor"));
+  });
+
+  test("defines the exact public capability handshake document", () => {
+    const document = {
+      schemaVersion: 1,
+      runtimeVersion: "0.1.0",
+      apiVersion: 1,
+      instanceId,
+      capabilities: RUNTIME_CAPABILITIES,
+    } as const;
+
+    expect(RuntimeCapabilityDocumentSchema.parse(document)).toEqual(document);
+    expect(() =>
+      RuntimeCapabilityDocumentSchema.parse({ ...document, token }),
+    ).toThrow();
+    expect(() =>
+      RuntimeCapabilityDocumentSchema.parse({
+        ...document,
+        baseUrl: "http://127.0.0.1:41721",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/runtime/src/supervision/protocol.ts
+++ b/packages/runtime/src/supervision/protocol.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+import {
+  BbContextIdSchema,
+  OpaqueIdSchema,
+  PrincipalIdSchema,
+} from "../contracts/ids.ts";
+import { canonicalJson } from "../contracts/objects.ts";
+
+export const RUNTIME_API_VERSION = 1 as const;
+export const SUPERVISOR_FRAME_MAX_BYTES = 4 * 1024;
+export const RUNTIME_DESCRIPTOR_MAX_BYTES = 8 * 1024;
+
+const RuntimeVersionSchema = z
+  .string()
+  .max(64)
+  .regex(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*))(?:\.(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*)))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u,
+  );
+
+const SupervisorTokenSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]{43}$/u, "Expected a 32-byte base64url token")
+  .refine((value) => {
+    const decoded = Buffer.from(value, "base64url");
+    return decoded.byteLength === 32 && decoded.toString("base64url") === value;
+  }, "Expected a canonical 32-byte base64url token");
+
+export const SupervisorFrameSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  expectedRuntimeVersion: RuntimeVersionSchema,
+  expectedApiVersion: z.literal(RUNTIME_API_VERSION),
+  token: SupervisorTokenSchema,
+  principalId: PrincipalIdSchema,
+  bbContextId: BbContextIdSchema,
+});
+
+export type SupervisorFrame = z.infer<typeof SupervisorFrameSchema>;
+
+function parseBoundedJsonLine(
+  input: string | Uint8Array,
+  maxBytes: number,
+): unknown {
+  let text =
+    typeof input === "string"
+      ? input
+      : new TextDecoder("utf-8", { fatal: true }).decode(input);
+  if (Buffer.byteLength(text, "utf8") > maxBytes) throw new TypeError();
+  if (text.endsWith("\n")) text = text.slice(0, -1);
+  if (text.length === 0 || text.includes("\n") || text.includes("\r")) {
+    throw new TypeError();
+  }
+  return JSON.parse(text);
+}
+
+export function parseSupervisorFrame(
+  input: string | Uint8Array,
+): SupervisorFrame {
+  try {
+    return SupervisorFrameSchema.parse(
+      parseBoundedJsonLine(input, SUPERVISOR_FRAME_MAX_BYTES),
+    );
+  } catch {
+    throw new TypeError("Invalid supervisor frame");
+  }
+}
+
+export const RuntimeCapabilitiesSchema = z.strictObject({
+  annotations: z.boolean(),
+  artifacts: z.boolean(),
+  browserBootstrap: z.boolean(),
+  captures: z.boolean(),
+  comparisons: z.boolean(),
+  events: z.boolean(),
+  mcp: z.boolean(),
+  pluginBriefs: z.boolean(),
+  reviews: z.boolean(),
+  sessions: z.boolean(),
+  targets: z.boolean(),
+});
+
+export type RuntimeCapabilitiesV1 = z.infer<typeof RuntimeCapabilitiesSchema>;
+
+export const RUNTIME_CAPABILITIES: Readonly<RuntimeCapabilitiesV1> =
+  Object.freeze({
+    annotations: false,
+    artifacts: false,
+    browserBootstrap: false,
+    captures: false,
+    comparisons: false,
+    events: false,
+    mcp: false,
+    pluginBriefs: false,
+    reviews: false,
+    sessions: false,
+    targets: false,
+  });
+
+const LoopbackBaseUrlSchema = z
+  .string()
+  .regex(/^http:\/\/127\.0\.0\.1:([1-9]\d{0,4})$/u)
+  .refine((value) => Number(value.slice(value.lastIndexOf(":") + 1)) <= 65_535);
+
+export const RuntimeLaunchDescriptorSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  protocol: z.literal("bb-mate-runtime"),
+  runtimeVersion: RuntimeVersionSchema,
+  apiVersion: z.literal(RUNTIME_API_VERSION),
+  pid: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  instanceId: OpaqueIdSchema,
+  baseUrl: LoopbackBaseUrlSchema,
+  capabilities: RuntimeCapabilitiesSchema,
+});
+
+export type RuntimeLaunchDescriptor = z.infer<
+  typeof RuntimeLaunchDescriptorSchema
+>;
+
+export const RuntimeCapabilityDocumentSchema =
+  RuntimeLaunchDescriptorSchema.omit({
+    protocol: true,
+    pid: true,
+    baseUrl: true,
+  });
+
+export type RuntimeCapabilityDocument = z.infer<
+  typeof RuntimeCapabilityDocumentSchema
+>;
+
+export function parseRuntimeLaunchDescriptor(
+  input: string | Uint8Array,
+): RuntimeLaunchDescriptor {
+  try {
+    return RuntimeLaunchDescriptorSchema.parse(
+      parseBoundedJsonLine(input, RUNTIME_DESCRIPTOR_MAX_BYTES),
+    );
+  } catch {
+    throw new TypeError("Invalid runtime launch descriptor");
+  }
+}
+
+export function serializeRuntimeLaunchDescriptor(input: unknown): string {
+  try {
+    const line = `${canonicalJson(RuntimeLaunchDescriptorSchema.parse(input))}\n`;
+    if (Buffer.byteLength(line, "utf8") > RUNTIME_DESCRIPTOR_MAX_BYTES) {
+      throw new TypeError();
+    }
+    return line;
+  } catch {
+    throw new TypeError("Invalid runtime launch descriptor");
+  }
+}

--- a/scripts/build-standalone.test.ts
+++ b/scripts/build-standalone.test.ts
@@ -28,11 +28,9 @@ async function temporaryHomeRoot(): Promise<string> {
 }
 
 afterEach(async () => {
-  await Promise.all(
-    roots
-      .splice(0)
-      .map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
+  for (const root of roots.splice(0).reverse()) {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });
 
 describe("standalone output ownership", () => {

--- a/scripts/build-standalone.ts
+++ b/scripts/build-standalone.ts
@@ -228,6 +228,9 @@ export async function buildStandalone(
   }
 
   const graph = await inspectStandaloneAssets(labRoot);
+  const sourceManifest = JSON.parse(
+    await fs.readFile(path.join(cliRoot, "package.json"), "utf8"),
+  ) as { version: string };
   const temporaryRoot = await fs.mkdtemp(
     path.join(os.tmpdir(), "bb-mate-standalone-build-"),
   );
@@ -241,6 +244,7 @@ export async function buildStandalone(
       generateStandaloneEntry({
         assets: graph.assets,
         entrypointPath: path.join(cliRoot, "src", "entrypoint.ts"),
+        runtimeVersion: sourceManifest.version,
       }),
     );
 
@@ -263,9 +267,6 @@ export async function buildStandalone(
     }
     await fs.chmod(stagedExecutablePath, 0o755);
 
-    const sourceManifest = JSON.parse(
-      await fs.readFile(path.join(cliRoot, "package.json"), "utf8"),
-    ) as { version: string };
     const executable = await fs.readFile(stagedExecutablePath);
     const manifest = createStandaloneManifest({
       graph,

--- a/scripts/package-clean-room.ts
+++ b/scripts/package-clean-room.ts
@@ -379,6 +379,7 @@ try {
     "react-inspector@",
     "scheduler@",
     "tslib@",
+    "zod@",
     "@fontsource-variable/geist@",
     "@fontsource-variable/inter@",
     "Apache License",

--- a/scripts/standalone-assets.test.ts
+++ b/scripts/standalone-assets.test.ts
@@ -80,8 +80,10 @@ describe("standalone asset graph", () => {
     const entry = generateStandaloneEntry({
       assets: [...graph.assets].reverse(),
       entrypointPath: "/repo/apps/cli/src/entrypoint.ts",
+      runtimeVersion: "0.1.0-alpha.2",
     });
     expect(entry).toContain('mode: "standalone"');
+    expect(entry).toContain('runtimeVersion: "0.1.0-alpha.2"');
     expect(entry.indexOf('"/assets/app.js"')).toBeLessThan(
       entry.indexOf('"/index.html"'),
     );

--- a/scripts/standalone-assets.ts
+++ b/scripts/standalone-assets.ts
@@ -126,6 +126,7 @@ export async function inspectStandaloneAssets(
 export function generateStandaloneEntry(options: {
   assets: readonly StandaloneAsset[];
   entrypointPath: string;
+  runtimeVersion: string;
 }): string {
   const assets = [...options.assets].sort((left, right) =>
     compareText(left.route, right.route),
@@ -145,6 +146,7 @@ export function generateStandaloneEntry(options: {
     "",
     "const result = await runBbMateEntrypoint({",
     '  mode: "standalone",',
+    `  runtimeVersion: ${JSON.stringify(options.runtimeVersion)},`,
     "  assets: {",
     ...manifest,
     "  },",

--- a/scripts/standalone-clean-room.ts
+++ b/scripts/standalone-clean-room.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildStandalone } from "./build-standalone.ts";
 import { inspectStandalone } from "./inspect-standalone.ts";
+import { verifyStandaloneSupervision } from "./standalone-supervision-clean-room.ts";
 
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const labRoot = path.join(repositoryRoot, "apps", "workbench", "dist", "ladle");
@@ -310,6 +311,14 @@ try {
     `Standalone output did not identify its embedded lab.\n${stderr}`,
   );
   server = null;
+
+  await verifyStandaloneSupervision({
+    executable: movedExecutable,
+    cwd: workspaceRoot,
+    env: runtimeEnv,
+    runtimeVersion: inspected.manifest.runtimeVersion,
+    temporaryRoot,
+  });
 
   console.log(
     `Standalone clean room passed: ${inspected.manifest.target}, mode ${inspected.manifest.mode}, ${inspected.manifest.size} bytes, sha256 ${inspected.manifest.sha256}, ${inspected.manifest.assets.length} assets, 13 stories.`,

--- a/scripts/standalone-supervision-clean-room.ts
+++ b/scripts/standalone-supervision-clean-room.ts
@@ -11,6 +11,14 @@ function assert(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
 }
 
+function assertProcessAlive(pid: number, message: string): void {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    throw new Error(message);
+  }
+}
+
 function assertCleanOutput(
   runtime: SupervisedRuntime,
   descriptor: object,
@@ -44,7 +52,7 @@ export async function verifyStandaloneSupervision(options: {
       ),
       { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
     );
-    await waitForRuntimeHealth(descriptor.baseUrl);
+    await waitForRuntimeHealth(descriptor.baseUrl, { runtime });
     const unauthorized = await fetch(`${descriptor.baseUrl}/v1/capabilities`);
     assert(
       unauthorized.status === 401,
@@ -86,13 +94,17 @@ export async function verifyStandaloneSupervision(options: {
     );
     runtime = null;
 
-    monitoredParent = Bun.spawn(["/bin/sleep", "30"], {
+    monitoredParent = Bun.spawn(["/bin/cat"], {
       cwd: options.temporaryRoot,
       env: options.env,
-      stdin: "ignore",
+      stdin: "pipe",
       stdout: "ignore",
       stderr: "ignore",
     });
+    assertProcessAlive(
+      monitoredParent.pid,
+      "Orphan-cleanup sentinel exited before runtime launch.",
+    );
     runtime = spawnSupervisedRuntime({
       ...options,
       parentPid: monitoredParent.pid,
@@ -105,7 +117,15 @@ export async function verifyStandaloneSupervision(options: {
       ),
       { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
     );
-    await waitForRuntimeHealth(orphanDescriptor.baseUrl);
+    assertProcessAlive(
+      monitoredParent.pid,
+      "Orphan-cleanup sentinel exited before descriptor validation.",
+    );
+    await waitForRuntimeHealth(orphanDescriptor.baseUrl, { runtime });
+    assertProcessAlive(
+      monitoredParent.pid,
+      "Orphan-cleanup sentinel exited before forced parent loss.",
+    );
     monitoredParent.kill("SIGKILL");
     await monitoredParent.exited;
     monitoredParent = null;
@@ -132,7 +152,7 @@ export async function verifyStandaloneSupervision(options: {
       ),
       { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
     );
-    await waitForRuntimeHealth(signalDescriptor.baseUrl);
+    await waitForRuntimeHealth(signalDescriptor.baseUrl, { runtime });
     runtime.child.kill("SIGTERM");
     await within(
       runtime.closed,

--- a/scripts/standalone-supervision-clean-room.ts
+++ b/scripts/standalone-supervision-clean-room.ts
@@ -3,7 +3,6 @@ import {
   spawnSupervisedRuntime,
   type SupervisedRuntime,
   validateStandaloneDescriptor,
-  waitForChildExit,
   within,
 } from "./supervised-standalone.ts";
 
@@ -75,7 +74,7 @@ export async function verifyStandaloneSupervision(options: {
 
     runtime.supervisor.end();
     await within(
-      waitForChildExit(runtime.child),
+      runtime.closed,
       5_000,
       "Supervised runtime did not exit when FD3 reached EOF.",
     );
@@ -112,7 +111,7 @@ export async function verifyStandaloneSupervision(options: {
     await monitoredParent.exited;
     monitoredParent = null;
     await within(
-      waitForChildExit(runtime.child),
+      runtime.closed,
       5_000,
       "Supervised runtime survived its monitored parent's disappearance.",
     );
@@ -138,7 +137,7 @@ export async function verifyStandaloneSupervision(options: {
     assert(signalHealth.ok, "Signal-cleanup runtime did not become healthy.");
     runtime.child.kill("SIGTERM");
     await within(
-      waitForChildExit(runtime.child),
+      runtime.closed,
       5_000,
       "Supervised runtime did not stop after SIGTERM.",
     );
@@ -154,7 +153,7 @@ export async function verifyStandaloneSupervision(options: {
     if (runtime) {
       runtime.supervisor.destroy();
       runtime.child.kill("SIGKILL");
-      await waitForChildExit(runtime.child).catch(() => undefined);
+      await runtime.closed.catch(() => undefined);
     }
     if (monitoredParent) {
       monitoredParent.kill("SIGKILL");

--- a/scripts/standalone-supervision-clean-room.ts
+++ b/scripts/standalone-supervision-clean-room.ts
@@ -1,0 +1,164 @@
+import {
+  assertListenerUnavailable,
+  spawnSupervisedRuntime,
+  type SupervisedRuntime,
+  validateStandaloneDescriptor,
+  waitForChildExit,
+  within,
+} from "./supervised-standalone.ts";
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertCleanOutput(
+  runtime: SupervisedRuntime,
+  descriptor: object,
+  message: string,
+): void {
+  const stdout = runtime.stdout();
+  assert(
+    stdout === `${JSON.stringify(descriptor)}\n` &&
+      !stdout.includes(runtime.token) &&
+      !runtime.stderr().includes(runtime.token),
+    message,
+  );
+}
+
+export async function verifyStandaloneSupervision(options: {
+  executable: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  runtimeVersion: string;
+  temporaryRoot: string;
+}): Promise<void> {
+  let runtime: SupervisedRuntime | null = null;
+  let monitoredParent: ReturnType<typeof Bun.spawn> | null = null;
+  try {
+    runtime = spawnSupervisedRuntime(options);
+    const descriptor = validateStandaloneDescriptor(
+      await within(
+        runtime.descriptor,
+        10_000,
+        "Moved standalone did not emit its supervised descriptor.",
+      ),
+      { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
+    );
+    const health = await fetch(`${descriptor.baseUrl}/healthz`);
+    assert(health.ok, "Supervised runtime health check failed.");
+    const unauthorized = await fetch(`${descriptor.baseUrl}/v1/capabilities`);
+    assert(
+      unauthorized.status === 401,
+      "Supervised runtime capabilities were available without authentication.",
+    );
+    const capabilitiesResponse = await fetch(
+      `${descriptor.baseUrl}/v1/capabilities`,
+      { headers: { authorization: `Bearer ${runtime.token}` } },
+    );
+    assert(
+      capabilitiesResponse.ok,
+      "Authenticated supervised capabilities handshake failed.",
+    );
+    const capabilities = (await capabilitiesResponse.json()) as Record<
+      string,
+      unknown
+    >;
+    assert(
+      capabilities.schemaVersion === descriptor.schemaVersion &&
+        capabilities.runtimeVersion === descriptor.runtimeVersion &&
+        capabilities.apiVersion === descriptor.apiVersion &&
+        capabilities.instanceId === descriptor.instanceId &&
+        JSON.stringify(capabilities.capabilities) ===
+          JSON.stringify(descriptor.capabilities),
+      "Descriptor and authenticated capability identity differ.",
+    );
+
+    runtime.supervisor.end();
+    await within(
+      waitForChildExit(runtime.child),
+      5_000,
+      "Supervised runtime did not exit when FD3 reached EOF.",
+    );
+    await assertListenerUnavailable(descriptor.baseUrl);
+    assertCleanOutput(
+      runtime,
+      descriptor,
+      "Supervised runtime stdout or stderr was not pure.",
+    );
+    runtime = null;
+
+    monitoredParent = Bun.spawn(["/bin/sleep", "30"], {
+      cwd: options.temporaryRoot,
+      env: options.env,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    runtime = spawnSupervisedRuntime({
+      ...options,
+      parentPid: monitoredParent.pid,
+    });
+    const orphanDescriptor = validateStandaloneDescriptor(
+      await within(
+        runtime.descriptor,
+        10_000,
+        "Orphan-cleanup runtime did not emit its descriptor.",
+      ),
+      { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
+    );
+    const orphanHealth = await fetch(`${orphanDescriptor.baseUrl}/healthz`);
+    assert(orphanHealth.ok, "Orphan-cleanup runtime did not become healthy.");
+    monitoredParent.kill("SIGKILL");
+    await monitoredParent.exited;
+    monitoredParent = null;
+    await within(
+      waitForChildExit(runtime.child),
+      5_000,
+      "Supervised runtime survived its monitored parent's disappearance.",
+    );
+    await assertListenerUnavailable(orphanDescriptor.baseUrl);
+    assertCleanOutput(
+      runtime,
+      orphanDescriptor,
+      "Orphan-cleanup runtime emitted unexpected or secret output.",
+    );
+    runtime.supervisor.destroy();
+    runtime = null;
+
+    runtime = spawnSupervisedRuntime(options);
+    const signalDescriptor = validateStandaloneDescriptor(
+      await within(
+        runtime.descriptor,
+        10_000,
+        "Signal-cleanup runtime did not emit its descriptor.",
+      ),
+      { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
+    );
+    const signalHealth = await fetch(`${signalDescriptor.baseUrl}/healthz`);
+    assert(signalHealth.ok, "Signal-cleanup runtime did not become healthy.");
+    runtime.child.kill("SIGTERM");
+    await within(
+      waitForChildExit(runtime.child),
+      5_000,
+      "Supervised runtime did not stop after SIGTERM.",
+    );
+    await assertListenerUnavailable(signalDescriptor.baseUrl);
+    assertCleanOutput(
+      runtime,
+      signalDescriptor,
+      "Signal-cleanup runtime emitted unexpected or secret output.",
+    );
+    runtime.supervisor.destroy();
+    runtime = null;
+  } finally {
+    if (runtime) {
+      runtime.supervisor.destroy();
+      runtime.child.kill("SIGKILL");
+      await waitForChildExit(runtime.child).catch(() => undefined);
+    }
+    if (monitoredParent) {
+      monitoredParent.kill("SIGKILL");
+      await monitoredParent.exited.catch(() => undefined);
+    }
+  }
+}

--- a/scripts/standalone-supervision-clean-room.ts
+++ b/scripts/standalone-supervision-clean-room.ts
@@ -3,6 +3,7 @@ import {
   spawnSupervisedRuntime,
   type SupervisedRuntime,
   validateStandaloneDescriptor,
+  waitForRuntimeHealth,
   within,
 } from "./supervised-standalone.ts";
 
@@ -43,8 +44,7 @@ export async function verifyStandaloneSupervision(options: {
       ),
       { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
     );
-    const health = await fetch(`${descriptor.baseUrl}/healthz`);
-    assert(health.ok, "Supervised runtime health check failed.");
+    await waitForRuntimeHealth(descriptor.baseUrl);
     const unauthorized = await fetch(`${descriptor.baseUrl}/v1/capabilities`);
     assert(
       unauthorized.status === 401,
@@ -105,8 +105,7 @@ export async function verifyStandaloneSupervision(options: {
       ),
       { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
     );
-    const orphanHealth = await fetch(`${orphanDescriptor.baseUrl}/healthz`);
-    assert(orphanHealth.ok, "Orphan-cleanup runtime did not become healthy.");
+    await waitForRuntimeHealth(orphanDescriptor.baseUrl);
     monitoredParent.kill("SIGKILL");
     await monitoredParent.exited;
     monitoredParent = null;
@@ -133,8 +132,7 @@ export async function verifyStandaloneSupervision(options: {
       ),
       { runtimeVersion: options.runtimeVersion, pid: runtime.child.pid },
     );
-    const signalHealth = await fetch(`${signalDescriptor.baseUrl}/healthz`);
-    assert(signalHealth.ok, "Signal-cleanup runtime did not become healthy.");
+    await waitForRuntimeHealth(signalDescriptor.baseUrl);
     runtime.child.kill("SIGTERM");
     await within(
       runtime.closed,

--- a/scripts/supervised-standalone.test.ts
+++ b/scripts/supervised-standalone.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { createServer } from "node:http";
 import {
   observeChildClose,
+  requestRuntimeHealth,
   type StandaloneRuntimeDescriptor,
   validateStandaloneDescriptor,
   waitForRuntimeHealth,
@@ -114,6 +116,89 @@ describe("standalone supervision proof", () => {
     expect(sleeps).toBe(1);
   });
 
+  test("probes runtime health through a fresh connection", async () => {
+    let connections = 0;
+    const server = createServer((_request, response) => {
+      response.end();
+    });
+    server.on("connection", () => {
+      connections += 1;
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Test listener did not receive a port.");
+    }
+    try {
+      expect(
+        await requestRuntimeHealth(`http://127.0.0.1:${address.port}/healthz`),
+      ).toEqual({ status: 200 });
+      expect(
+        await requestRuntimeHealth(`http://127.0.0.1:${address.port}/healthz`),
+      ).toEqual({ status: 200 });
+      expect(connections).toBe(2);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  test("destroys a pending health request when its bound is canceled", async () => {
+    let received!: () => void;
+    const requestReceived = new Promise<void>((resolve) => {
+      received = resolve;
+    });
+    let closed!: () => void;
+    const socketClosed = new Promise<void>((resolve) => {
+      closed = resolve;
+    });
+    let socket: import("node:net").Socket | undefined;
+    const server = createServer((request) => {
+      socket = request.socket;
+      socket.once("close", closed);
+      received();
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Test listener did not receive a port.");
+    }
+    const controller = new AbortController();
+    try {
+      const requested = requestRuntimeHealth(
+        `http://127.0.0.1:${address.port}/healthz`,
+        controller.signal,
+      ).then(
+        () => "resolved",
+        () => "aborted",
+      );
+      await requestReceived;
+      controller.abort();
+      expect(
+        await Promise.race([
+          requested,
+          Bun.sleep(50).then(() => "still pending"),
+        ]),
+      ).toBe("aborted");
+      expect(
+        await Promise.race([
+          socketClosed.then(() => "closed"),
+          Bun.sleep(50).then(() => "still open"),
+        ]),
+      ).toBe("closed");
+    } finally {
+      socket?.destroy();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test("allows bounded hosted startup beyond two seconds", async () => {
     let now = 0;
     await waitForRuntimeHealth("http://127.0.0.1:41721", {
@@ -132,6 +217,27 @@ describe("standalone supervision proof", () => {
     });
 
     expect(now).toBe(2_500);
+  });
+
+  test("reports a runtime exit instead of retrying a closed listener", async () => {
+    const token = "A".repeat(43);
+    const failure = waitForRuntimeHealth("http://127.0.0.1:41721", {
+      fetch: async () => {
+        throw Object.assign(new Error("not listening"), {
+          code: "ConnectionRefused",
+        });
+      },
+      runtime: {
+        closed: Promise.resolve(),
+        child: { exitCode: 1, signalCode: null },
+        stderr: () => `parent unavailable ${token}`,
+        token,
+      },
+    });
+
+    await expect(failure).rejects.toThrow(
+      'Supervised runtime exited before becoming healthy: exitCode=1, signal=null, stderr="parent unavailable [redacted]".',
+    );
   });
 
   test("fails immediately on HTTP failure and bounds repeated refusal", async () => {

--- a/scripts/supervised-standalone.test.ts
+++ b/scripts/supervised-standalone.test.ts
@@ -4,6 +4,7 @@ import {
   observeChildClose,
   type StandaloneRuntimeDescriptor,
   validateStandaloneDescriptor,
+  waitForRuntimeHealth,
   within,
 } from "./supervised-standalone.ts";
 
@@ -87,5 +88,76 @@ describe("standalone supervision proof", () => {
     await completed;
     expect(closed).toBe(true);
     expect(chunks.join("")).toContain("late secret output");
+  });
+
+  test("retries connection refusal until health returns HTTP 200", async () => {
+    let attempts = 0;
+    let sleeps = 0;
+    await waitForRuntimeHealth("http://127.0.0.1:41721", {
+      fetch: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw Object.assign(new Error("not listening yet"), {
+            code: "ConnectionRefused",
+          });
+        }
+        return new Response(null, { status: 200 });
+      },
+      sleep: async () => {
+        sleeps += 1;
+      },
+      now: () => 0,
+      timeoutMs: 100,
+    });
+
+    expect(attempts).toBe(2);
+    expect(sleeps).toBe(1);
+  });
+
+  test("fails immediately on HTTP failure and bounds repeated refusal", async () => {
+    let sleeps = 0;
+    await expect(
+      waitForRuntimeHealth("http://127.0.0.1:41721", {
+        fetch: async () => new Response(null, { status: 503 }),
+        sleep: async () => {
+          sleeps += 1;
+        },
+      }),
+    ).rejects.toThrow("returned HTTP 503");
+    expect(sleeps).toBe(0);
+    await expect(
+      waitForRuntimeHealth("http://127.0.0.1:41721", {
+        fetch: async () => {
+          throw Object.assign(new Error("certificate failure"), {
+            code: "CERT_INVALID",
+          });
+        },
+        sleep: async () => {
+          sleeps += 1;
+        },
+      }),
+    ).rejects.toThrow("certificate failure");
+    expect(sleeps).toBe(0);
+
+    let now = 0;
+    let attempts = 0;
+    await expect(
+      waitForRuntimeHealth("http://127.0.0.1:41721", {
+        fetch: async () => {
+          attempts += 1;
+          throw Object.assign(new Error("not listening yet"), {
+            code: "ConnectionRefused",
+          });
+        },
+        sleep: async (milliseconds) => {
+          now += milliseconds;
+        },
+        now: () => now,
+        retryDelayMs: 5,
+        timeoutMs: 10,
+      }),
+    ).rejects.toThrow("did not become healthy");
+    expect(attempts).toBe(2);
+    expect(now).toBe(10);
   });
 });

--- a/scripts/supervised-standalone.test.ts
+++ b/scripts/supervised-standalone.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
+  observeChildClose,
   type StandaloneRuntimeDescriptor,
   validateStandaloneDescriptor,
   within,
@@ -66,5 +68,24 @@ describe("standalone supervision proof", () => {
     await expect(
       within(new Promise(() => undefined), 1, "bounded timeout"),
     ).rejects.toThrow("bounded timeout");
+  });
+
+  test("waits for stdio close so output arriving after exit is observable", async () => {
+    const child = new EventEmitter();
+    const chunks = ["descriptor\n"];
+    let closed = false;
+    const completed = observeChildClose(child).then(() => {
+      closed = true;
+    });
+
+    child.emit("exit", 0, null);
+    chunks.push("late secret output");
+    await Promise.resolve();
+    expect(closed).toBe(false);
+
+    child.emit("close", 0, null);
+    await completed;
+    expect(closed).toBe(true);
+    expect(chunks.join("")).toContain("late secret output");
   });
 });

--- a/scripts/supervised-standalone.test.ts
+++ b/scripts/supervised-standalone.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type StandaloneRuntimeDescriptor,
+  validateStandaloneDescriptor,
+  within,
+} from "./supervised-standalone.ts";
+
+function descriptor(): StandaloneRuntimeDescriptor & Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    protocol: "bb-mate-runtime",
+    runtimeVersion: "0.1.0-alpha.2",
+    apiVersion: 1,
+    pid: 42,
+    instanceId: "i".repeat(32),
+    baseUrl: "http://127.0.0.1:41721",
+    capabilities: {
+      annotations: false,
+      artifacts: false,
+      browserBootstrap: false,
+      captures: false,
+      comparisons: false,
+      events: false,
+      mcp: false,
+      pluginBriefs: false,
+      reviews: false,
+      sessions: false,
+      targets: false,
+    },
+  };
+}
+
+describe("standalone supervision proof", () => {
+  test("accepts only the exact bounded-loopback descriptor identity", () => {
+    expect(
+      validateStandaloneDescriptor(descriptor(), {
+        runtimeVersion: "0.1.0-alpha.2",
+        pid: 42,
+      }),
+    ).toEqual(descriptor());
+
+    expect(() =>
+      validateStandaloneDescriptor(
+        { ...descriptor(), token: "secret" },
+        { runtimeVersion: "0.1.0-alpha.2" },
+      ),
+    ).toThrow("V1 allowlist");
+    expect(() =>
+      validateStandaloneDescriptor(
+        { ...descriptor(), baseUrl: "http://localhost:41721" },
+        { runtimeVersion: "0.1.0-alpha.2" },
+      ),
+    ).toThrow("identity is invalid");
+    expect(() =>
+      validateStandaloneDescriptor(
+        { ...descriptor(), capabilities: { targets: false } },
+        { runtimeVersion: "0.1.0-alpha.2" },
+      ),
+    ).toThrow("identity is invalid");
+  });
+
+  test("bounds awaited runtime transitions", async () => {
+    await expect(within(Promise.resolve("ready"), 50, "timeout")).resolves.toBe(
+      "ready",
+    );
+    await expect(
+      within(new Promise(() => undefined), 1, "bounded timeout"),
+    ).rejects.toThrow("bounded timeout");
+  });
+});

--- a/scripts/supervised-standalone.test.ts
+++ b/scripts/supervised-standalone.test.ts
@@ -114,6 +114,26 @@ describe("standalone supervision proof", () => {
     expect(sleeps).toBe(1);
   });
 
+  test("allows bounded hosted startup beyond two seconds", async () => {
+    let now = 0;
+    await waitForRuntimeHealth("http://127.0.0.1:41721", {
+      fetch: async () => {
+        if (now < 2_500) {
+          throw Object.assign(new Error("not listening yet"), {
+            code: "ConnectionRefused",
+          });
+        }
+        return new Response(null, { status: 200 });
+      },
+      sleep: async (milliseconds) => {
+        now += milliseconds;
+      },
+      now: () => now,
+    });
+
+    expect(now).toBe(2_500);
+  });
+
   test("fails immediately on HTTP failure and bounds repeated refusal", async () => {
     let sleeps = 0;
     await expect(

--- a/scripts/supervised-standalone.ts
+++ b/scripts/supervised-standalone.ts
@@ -1,0 +1,237 @@
+import {
+  spawn as spawnChildProcess,
+  type ChildProcess,
+} from "node:child_process";
+import type { Readable, Writable } from "node:stream";
+
+export interface StandaloneRuntimeDescriptor {
+  schemaVersion: 1;
+  protocol: "bb-mate-runtime";
+  runtimeVersion: string;
+  apiVersion: 1;
+  pid: number;
+  instanceId: string;
+  baseUrl: string;
+  capabilities: unknown;
+}
+
+export interface SupervisedRuntime {
+  child: ChildProcess;
+  descriptor: Promise<Record<string, unknown>>;
+  stdout: () => string;
+  stderr: () => string;
+  supervisor: Writable;
+  token: string;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const expectedCapabilityKeys = [
+  "annotations",
+  "artifacts",
+  "browserBootstrap",
+  "captures",
+  "comparisons",
+  "events",
+  "mcp",
+  "pluginBriefs",
+  "reviews",
+  "sessions",
+  "targets",
+] as const;
+
+function hasExpectedCapabilities(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const capabilities = value as Record<string, unknown>;
+  return (
+    JSON.stringify(Object.keys(capabilities).sort()) ===
+      JSON.stringify([...expectedCapabilityKeys]) &&
+    expectedCapabilityKeys.every((key) => capabilities[key] === false)
+  );
+}
+
+export async function within<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function requireReadable(value: Readable | null, name: string): Readable {
+  assert(value, `Supervised runtime ${name} was not piped.`);
+  return value;
+}
+
+export function spawnSupervisedRuntime(options: {
+  executable: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  runtimeVersion: string;
+  parentPid?: number;
+}): SupervisedRuntime {
+  const child = spawnChildProcess(
+    options.executable,
+    [
+      "serve",
+      "--port",
+      "0",
+      "--json",
+      "--parent-pid",
+      String(options.parentPid ?? process.pid),
+      "--supervisor-fd",
+      "3",
+    ],
+    {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe", "pipe"],
+    },
+  );
+  const stdoutStream = requireReadable(child.stdout, "stdout");
+  const stderrStream = requireReadable(child.stderr, "stderr");
+  const supervisor = child.stdio[3];
+  assert(supervisor && "write" in supervisor, "Supervisor FD3 was not piped.");
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let descriptorBytes = 0;
+  let descriptorText = "";
+  let settled = false;
+  const descriptor = new Promise<Record<string, unknown>>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (!settled) {
+        reject(
+          new Error(
+            `Supervised runtime exited before its descriptor: ${code ?? signal}.`,
+          ),
+        );
+      }
+    });
+    stdoutStream.on("data", (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+      if (settled) return;
+      descriptorBytes += chunk.byteLength;
+      if (descriptorBytes > 8 * 1024) {
+        settled = true;
+        reject(new Error("Supervised runtime descriptor exceeded 8 KiB."));
+        return;
+      }
+      descriptorText += chunk.toString("utf8");
+      const newline = descriptorText.indexOf("\n");
+      if (newline === -1) return;
+      settled = true;
+      const line = descriptorText.slice(0, newline);
+      try {
+        resolve(JSON.parse(line) as Record<string, unknown>);
+      } catch (error) {
+        reject(
+          new AggregateError(
+            [error],
+            "Supervised runtime descriptor was not JSON.",
+          ),
+        );
+      }
+    });
+  });
+  stderrStream.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+  const token = "A".repeat(43);
+  supervisor.write(
+    `${JSON.stringify({
+      schemaVersion: 1,
+      expectedRuntimeVersion: options.runtimeVersion,
+      expectedApiVersion: 1,
+      token,
+      principalId: "p".repeat(32),
+      bbContextId: "b".repeat(32),
+    })}\n`,
+  );
+
+  return {
+    child,
+    descriptor,
+    stdout: () => Buffer.concat(stdoutChunks).toString("utf8"),
+    stderr: () => Buffer.concat(stderrChunks).toString("utf8"),
+    supervisor,
+    token,
+  };
+}
+
+export function validateStandaloneDescriptor(
+  descriptor: Record<string, unknown>,
+  options: { runtimeVersion: string; pid?: number },
+): StandaloneRuntimeDescriptor {
+  const expectedKeys = [
+    "apiVersion",
+    "baseUrl",
+    "capabilities",
+    "instanceId",
+    "pid",
+    "protocol",
+    "runtimeVersion",
+    "schemaVersion",
+  ].sort();
+  assert(
+    JSON.stringify(Object.keys(descriptor).sort()) ===
+      JSON.stringify(expectedKeys),
+    "Supervised descriptor fields differ from the V1 allowlist.",
+  );
+  assert(
+    descriptor.schemaVersion === 1 &&
+      descriptor.protocol === "bb-mate-runtime" &&
+      descriptor.runtimeVersion === options.runtimeVersion &&
+      descriptor.apiVersion === 1 &&
+      (options.pid === undefined || descriptor.pid === options.pid) &&
+      Number.isSafeInteger(descriptor.pid) &&
+      (descriptor.pid as number) > 0 &&
+      typeof descriptor.instanceId === "string" &&
+      /^[A-Za-z0-9_-]{32}$/u.test(descriptor.instanceId) &&
+      typeof descriptor.baseUrl === "string" &&
+      /^http:\/\/127\.0\.0\.1:[1-9][0-9]{0,4}$/u.test(descriptor.baseUrl) &&
+      Number(
+        descriptor.baseUrl.slice(descriptor.baseUrl.lastIndexOf(":") + 1),
+      ) <= 65_535 &&
+      hasExpectedCapabilities(descriptor.capabilities),
+    "Supervised descriptor identity is invalid.",
+  );
+  return descriptor as unknown as StandaloneRuntimeDescriptor;
+}
+
+export function waitForChildExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", () => resolve());
+  });
+}
+
+export async function assertListenerUnavailable(
+  baseUrl: string,
+): Promise<void> {
+  await fetch(`${baseUrl}/healthz`, {
+    signal: AbortSignal.timeout(1_000),
+  }).then(
+    () => {
+      throw new Error("Standalone listener remained reachable after shutdown.");
+    },
+    () => undefined,
+  );
+}

--- a/scripts/supervised-standalone.ts
+++ b/scripts/supervised-standalone.ts
@@ -83,6 +83,55 @@ export async function within<T>(
   }
 }
 
+function isConnectionRefused(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const code = "code" in error ? error.code : undefined;
+  if (code === "ConnectionRefused" || code === "ECONNREFUSED") return true;
+  return "cause" in error && isConnectionRefused(error.cause);
+}
+
+export async function waitForRuntimeHealth(
+  baseUrl: string,
+  options: {
+    fetch?: (url: string) => Promise<Response>;
+    sleep?: (milliseconds: number) => Promise<void>;
+    now?: () => number;
+    retryDelayMs?: number;
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const fetchHealth = options.fetch ?? ((url) => globalThis.fetch(url));
+  const sleep = options.sleep ?? ((milliseconds) => Bun.sleep(milliseconds));
+  const now = options.now ?? Date.now;
+  const retryDelayMs = options.retryDelayMs ?? 25;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  const deadline = now() + timeoutMs;
+  const deadlineMessage = "Supervised runtime did not become healthy.";
+
+  while (true) {
+    try {
+      const remaining = deadline - now();
+      if (remaining <= 0) throw new Error(deadlineMessage);
+      const response = await within(
+        fetchHealth(`${baseUrl}/healthz`),
+        remaining,
+        deadlineMessage,
+      );
+      if (response.status !== 200) {
+        throw new Error(
+          `Supervised runtime health returned HTTP ${response.status}.`,
+        );
+      }
+      return;
+    } catch (error) {
+      if (!isConnectionRefused(error)) throw error;
+      const remaining = deadline - now();
+      if (remaining <= 0) throw new Error(deadlineMessage, { cause: error });
+      await sleep(Math.min(retryDelayMs, remaining));
+    }
+  }
+}
+
 function requireReadable(value: Readable | null, name: string): Readable {
   assert(value, `Supervised runtime ${name} was not piped.`);
   return value;

--- a/scripts/supervised-standalone.ts
+++ b/scripts/supervised-standalone.ts
@@ -104,7 +104,7 @@ export async function waitForRuntimeHealth(
   const sleep = options.sleep ?? ((milliseconds) => Bun.sleep(milliseconds));
   const now = options.now ?? Date.now;
   const retryDelayMs = options.retryDelayMs ?? 25;
-  const timeoutMs = options.timeoutMs ?? 2_000;
+  const timeoutMs = options.timeoutMs ?? 10_000;
   const deadline = now() + timeoutMs;
   const deadlineMessage = "Supervised runtime did not become healthy.";
 

--- a/scripts/supervised-standalone.ts
+++ b/scripts/supervised-standalone.ts
@@ -2,6 +2,7 @@ import {
   spawn as spawnChildProcess,
   type ChildProcess,
 } from "node:child_process";
+import { get as getHttp } from "node:http";
 import type { Readable, Writable } from "node:stream";
 
 export interface StandaloneRuntimeDescriptor {
@@ -90,33 +91,87 @@ function isConnectionRefused(error: unknown): boolean {
   return "cause" in error && isConnectionRefused(error.cause);
 }
 
+export function requestRuntimeHealth(
+  url: string,
+  signal?: AbortSignal,
+): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const request = getHttp(url, { agent: false }, (response) => {
+      const status = response.statusCode ?? 0;
+      response.once("error", reject);
+      response.once("end", () => resolve({ status }));
+      response.resume();
+    });
+    const abort = () => {
+      const error = Object.assign(
+        new Error("Runtime health request aborted."),
+        {
+          cause: signal?.reason,
+          code: "ABORT_ERR",
+        },
+      );
+      request.destroy(error);
+      reject(error);
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    request.once("close", () => signal?.removeEventListener("abort", abort));
+    request.once("error", reject);
+    if (signal?.aborted) abort();
+  });
+}
+
 export async function waitForRuntimeHealth(
   baseUrl: string,
   options: {
-    fetch?: (url: string) => Promise<Response>;
+    fetch?: (url: string, signal?: AbortSignal) => Promise<{ status: number }>;
     sleep?: (milliseconds: number) => Promise<void>;
     now?: () => number;
     retryDelayMs?: number;
     timeoutMs?: number;
+    runtime?: Pick<SupervisedRuntime, "closed" | "stderr" | "token"> & {
+      child: Pick<ChildProcess, "exitCode" | "signalCode">;
+    };
   } = {},
 ): Promise<void> {
-  const fetchHealth = options.fetch ?? ((url) => globalThis.fetch(url));
+  const fetchHealth = options.fetch ?? requestRuntimeHealth;
   const sleep = options.sleep ?? ((milliseconds) => Bun.sleep(milliseconds));
   const now = options.now ?? Date.now;
   const retryDelayMs = options.retryDelayMs ?? 25;
   const timeoutMs = options.timeoutMs ?? 10_000;
   const deadline = now() + timeoutMs;
   const deadlineMessage = "Supervised runtime did not become healthy.";
+  const stopped = options.runtime?.closed.then<never>(() => {
+    const stderr = Buffer.from(
+      options
+        .runtime!.stderr()
+        .replaceAll(options.runtime!.token, "[redacted]"),
+    )
+      .subarray(0, 1_024)
+      .toString("utf8");
+    throw new Error(
+      `Supervised runtime exited before becoming healthy: exitCode=${options.runtime!.child.exitCode}, signal=${options.runtime!.child.signalCode}, stderr=${JSON.stringify(stderr)}.`,
+    );
+  });
+  const beforeRuntimeStops = <T>(promise: Promise<T>): Promise<T> =>
+    stopped ? Promise.race([promise, stopped]) : promise;
 
   while (true) {
     try {
       const remaining = deadline - now();
       if (remaining <= 0) throw new Error(deadlineMessage);
-      const response = await within(
-        fetchHealth(`${baseUrl}/healthz`),
-        remaining,
-        deadlineMessage,
-      );
+      const controller = new AbortController();
+      let response: { status: number };
+      try {
+        response = await beforeRuntimeStops(
+          within(
+            fetchHealth(`${baseUrl}/healthz`, controller.signal),
+            remaining,
+            deadlineMessage,
+          ),
+        );
+      } finally {
+        controller.abort();
+      }
       if (response.status !== 200) {
         throw new Error(
           `Supervised runtime health returned HTTP ${response.status}.`,
@@ -127,7 +182,7 @@ export async function waitForRuntimeHealth(
       if (!isConnectionRefused(error)) throw error;
       const remaining = deadline - now();
       if (remaining <= 0) throw new Error(deadlineMessage, { cause: error });
-      await sleep(Math.min(retryDelayMs, remaining));
+      await beforeRuntimeStops(sleep(Math.min(retryDelayMs, remaining)));
     }
   }
 }
@@ -278,12 +333,21 @@ export function validateStandaloneDescriptor(
 export async function assertListenerUnavailable(
   baseUrl: string,
 ): Promise<void> {
-  await fetch(`${baseUrl}/healthz`, {
-    signal: AbortSignal.timeout(1_000),
-  }).then(
-    () => {
-      throw new Error("Standalone listener remained reachable after shutdown.");
-    },
-    () => undefined,
-  );
+  const controller = new AbortController();
+  try {
+    await within(
+      requestRuntimeHealth(`${baseUrl}/healthz`, controller.signal),
+      1_000,
+      "Standalone listener reachability check timed out.",
+    ).then(
+      () => {
+        throw new Error(
+          "Standalone listener remained reachable after shutdown.",
+        );
+      },
+      () => undefined,
+    );
+  } finally {
+    controller.abort();
+  }
 }

--- a/scripts/supervised-standalone.ts
+++ b/scripts/supervised-standalone.ts
@@ -17,11 +17,22 @@ export interface StandaloneRuntimeDescriptor {
 
 export interface SupervisedRuntime {
   child: ChildProcess;
+  closed: Promise<void>;
   descriptor: Promise<Record<string, unknown>>;
   stdout: () => string;
   stderr: () => string;
   supervisor: Writable;
   token: string;
+}
+
+export function observeChildClose(child: {
+  once(event: "close", listener: () => void): unknown;
+  once(event: "error", listener: (error: Error) => void): unknown;
+}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", () => resolve());
+  });
 }
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -102,6 +113,7 @@ export function spawnSupervisedRuntime(options: {
       stdio: ["ignore", "pipe", "pipe", "pipe"],
     },
   );
+  const closed = observeChildClose(child);
   const stdoutStream = requireReadable(child.stdout, "stdout");
   const stderrStream = requireReadable(child.stderr, "stderr");
   const supervisor = child.stdio[3];
@@ -165,6 +177,7 @@ export function spawnSupervisedRuntime(options: {
 
   return {
     child,
+    closed,
     descriptor,
     stdout: () => Buffer.concat(stdoutChunks).toString("utf8"),
     stderr: () => Buffer.concat(stderrChunks).toString("utf8"),
@@ -211,16 +224,6 @@ export function validateStandaloneDescriptor(
     "Supervised descriptor identity is invalid.",
   );
   return descriptor as unknown as StandaloneRuntimeDescriptor;
-}
-
-export function waitForChildExit(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return Promise.resolve();
-  }
-  return new Promise((resolve, reject) => {
-    child.once("error", reject);
-    child.once("exit", () => resolve());
-  });
 }
 
 export async function assertListenerUnavailable(

--- a/scripts/third-party-licenses.ts
+++ b/scripts/third-party-licenses.ts
@@ -28,6 +28,12 @@ const inspectionManifest = path.join(
   "inspection",
   "package.json",
 );
+const runtimeManifest = path.join(
+  repositoryRoot,
+  "packages",
+  "runtime",
+  "package.json",
+);
 
 async function packageManifest(
   packageName: string,
@@ -136,6 +142,7 @@ export async function generateThirdPartyLicenses(): Promise<string> {
   for (const name of ["saxes", "semver"]) {
     await addPackageTree(name, inspectionManifest, records);
   }
+  await addPackageTree("zod", runtimeManifest, records);
 
   const sections = [
     "# Third-party licenses and copyright notices",


### PR DESCRIPTION
## Context

This is merge-first slice 62A of #62. The standalone executable previously had no supervised listener, private credential/liveness channel, or bounded launch descriptor, so `bb-plugin-mate` could not safely launch it.

## What changed

- adds strict 4 KiB supervisor-frame and 8 KiB launch-descriptor contracts under `@bb-mate/runtime/supervision`
- adds fixed-loopback, explicit port-zero `bb-mate serve` that dispatches before target discovery or native bb lookup
- reads one inherited-FD credential frame, keeps the FD as liveness, and rejects post-frame bytes
- emits exactly one canonical descriptor line and serves constant health plus bearer-authenticated capability identity
- converges FD EOF/error, parent disappearance, SIGINT, and SIGTERM on one awaited listener stop
- validates raw origin-form request targets before WHATWG normalization so encoded-dot and authority-like aliases cannot broaden the two-route inventory
- rejects GET/HEAD body framing before dispatch and force-closes every incomplete request after its listener or handler response flushes
- extends the moved empty-PATH standalone clean room for credential, handshake, parent-loss, signal, listener, stdio-close output purity, and no-leak proof
- probes readiness and cleanup with fresh non-pooled loopback connections; readiness is bounded to ten seconds and races child close with redacted exit diagnostics
- uses an owner-held indefinite parent sentinel, asserted alive through readiness, before deliberately removing only that parent while FD liveness remains open
- removes standalone test roots sequentially in reverse creation order so symlink safety teardown cannot race its external target under aggregate load
- includes the bundled runtime/Zod dependency in generated third-party notices and package clean-room assertions

## Verification

- `bun run format:check`
- `bun run check` and `bun run compatibility:latest`
- `bun run test`: 531 tests (inspection 136, runtime 175, CLI 75, Workbench 66, Linear 21, scripts 58)
- `bun run build`
- `bun run package:inspect` and `bun run package:test`: 41 files / 13 stories, SHA-256 `c2480bdd519e1d5bfe22691d8ccb9da64b5516162a8d9c9210e57ecc11711a9f`
- `bun run standalone:build`, `bun run standalone:inspect`, and `bun run standalone:test`
- standalone: Mach-O arm64, 0755, 64,783,586 bytes, 35 assets / 13 stories, SHA-256 `df2218e931e2c048ed0c2896a4448313169af324eca9595cc72717364a1ca16f`
- THS-001/002/003/004/005 are fixed; the exact replacement head retains the approved runtime protocol and hardens only its release proof
- slow listener-level and handler-level 400/401/403/413/415/503 responses close incomplete requests after flushing; 33-way and 32+1 concurrency proofs leave no retained socket
- a fully consumed POST body remains eligible for keep-alive and successfully serves a second request
- immutable c5 and current-state multi-process standalone builds are byte-identical within each source state; a provisional nondeterminism concern was source drift during remediation and was retracted
- readiness covers distinct fresh connections, bound-triggered socket destruction, readiness after 2.5 seconds, immediate child exit, non-200/unrelated failure, and deadline exhaustion
- five consecutive hardened moved clean rooms plus the final aggregate clean room passed with no listener, `bb-mate`, or parent-sentinel residue
- standalone teardown safety is stable through 100 focused reruns (600 tests) plus the complete aggregate lane

## Boundary and risk

No plugin package/nav shell yet, browser bootstrap, MCP, target route/mutation, Connect, publish/release, or normal-profile mutation. The bearer is private inherited-FD data; the descriptor base URL is a non-secret control origin, not a browser launch URL. JavaScript strings cannot be zeroed, but raw frame buffers and retained/received decoded token buffers are cleared and the token is never reflected. Bun's Node HTTP parser rejects asterisk-form and CONNECT authority-form before the request callback; both remain unable to reach runtime routing. 62B follows only after this exact protocol merges.

Exact readiness head: `21200fa85b675b553bd20180abbe50722509879d`.

Closes no issue; advances #62.
