### PR TITLE
docs: make Plugin Workbench baseline durable

### DIFF
--- a/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
+++ b/.agents/goals/2026-08-10-plugin-workbench/RETRO.md
@@ -1,6 +1,7 @@
 # Plugin Workbench goal retrospective and evidence ledger
 
 Date started: 2026-08-10
+Date completed: 2026-08-11
 Status: Complete
 
 ## Summary
@@ -24,8 +25,8 @@ distribution remains blocked by #77.
 ## Baseline
 
 - Repository: `/Users/mg/Developer/bb/bb-mate`
-- Reconciled main: `259293a7252735fe15b7beac0af73b683dc0852d`, the
-  merge commit for ready PR #79; issue #62 is closed.
+- 62C implementation merge: `259293a7252735fe15b7beac0af73b683dc0852d`,
+  the merge commit for ready PR #79; issue #62 is closed.
 - Compatibility PR #52 merged from exact head
   `1b047598b52f49ed8e6e0f7dd88387ff02c10445` to baseline merge commit
   `fa02c6d0d7c4ffb2f8855029def1589ed7ce7824`; issue #51 is closed.


### PR DESCRIPTION
## Context

The target-admission implementation and reconciliation are merged. This final one-line baseline correction avoids calling the historical PR #79 implementation merge “current main” after the reconciliation merge advanced main.

## What changed

- records the goal completion date
- labels `259293a...` as the stable 62C implementation merge, not the moving main head

## Verification

- Prettier check
- goal-loop doctor: 37 clean reports, prompt 3,216/4,000
- targeted diff check

## Boundaries

Documentation only. #21 remains open with #62 checked and #70/#77 open. No change to the unrelated #73 lane.