### PR TITLE
refactor: bound workspace matching with static caps and one aggregate budget

### DIFF
--- a/apps/cli/src/runtime-target-controller.test.ts
+++ b/apps/cli/src/runtime-target-controller.test.ts
@@ -1188,13 +1188,27 @@ describe("runtime target controller", () => {
 
   test("bounds duplicate-root fan-out by total serialized target entries", async () => {
     const fixture = await makeFixture();
-    const workspaces = Array.from({ length: 65 }, (_, index) =>
+    const workspaces = Array.from({ length: 64 }, (_, index) =>
       path.join("plugins", `plugin-${index}`),
     );
     await fs.mkdir(fixture.sourceRoot, { recursive: true });
     await fs.writeFile(
+      path.join(fixture.sourceRoot, "server.ts"),
+      "export {};\n",
+    );
+    await fs.writeFile(
       path.join(fixture.sourceRoot, "package.json"),
-      JSON.stringify({ name: "fixture", private: true, workspaces }),
+      JSON.stringify({
+        name: "bb-plugin-root-plugin",
+        version: "1.2.3",
+        bb: {
+          name: "root-plugin",
+          description: "root plugin",
+          branding: { icon: "Puzzle" },
+          server: "./server.ts",
+        },
+        workspaces,
+      }),
     );
     await Promise.all(
       workspaces.map((workspace, index) =>

--- a/packages/inspection/src/discover-workspace-source-candidates.test.ts
+++ b/packages/inspection/src/discover-workspace-source-candidates.test.ts
@@ -64,129 +64,10 @@ describe("workspace-aware source discovery", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  test("bounds aggregate workspace matching work across directory entries", async () => {
-    const root = await harness.createRoot("private-workspace-match-limit");
-    await Promise.all(
-      Array.from({ length: 24 }, (_, index) =>
-        fs.mkdir(path.join(root, `${"a".repeat(40)}-${index}`)),
-      ),
-    );
-    await fs.writeFile(
-      path.join(root, "package.json"),
-      JSON.stringify({
-        name: "workspace-root",
-        private: true,
-        workspaces: Array.from(
-          { length: 256 },
-          (_, index) => `${"*?".repeat(20)}z${index}`,
-        ),
-      }),
-    );
-    const admission = await admitTrustedRoots([
-      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: root },
-    ]);
-
-    const result = await discoverWorkspaceSourceCandidates(admission.roots);
-
-    expect(result.candidates).toEqual([]);
-    expect(result.diagnostics).toEqual([
-      expect.objectContaining({
-        code: "workspace-config-invalid",
-        rootKey: WORKSPACE_ROOT_KEY,
-        displayPath: "private-workspace-match-limit",
-        detail: expect.stringContaining("matching"),
-      }),
-    ]);
-    expect(JSON.stringify(result.diagnostics)).not.toContain(
-      path.dirname(root),
-    );
-  });
-
-  test("charges globstar memo states against the aggregate matching budget", async () => {
-    const root = await harness.createRoot("private-workspace-globstar-limit");
-    let directory = root;
-    for (let depth = 0; depth < 64; depth += 1) {
-      directory = path.join(directory, `level-${depth}`);
-      await fs.mkdir(directory);
-    }
-    const globstarChain = Array.from({ length: 31 }, () => "**").join("/");
-    await fs.writeFile(
-      path.join(root, "package.json"),
-      JSON.stringify({
-        name: "workspace-root",
-        private: true,
-        workspaces: [
-          "**",
-          ...Array.from({ length: 255 }, () => `!${globstarChain}/z`),
-        ],
-      }),
-    );
-    const admission = await admitTrustedRoots([
-      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: root },
-    ]);
-
-    const result = await discoverWorkspaceSourceCandidates(admission.roots);
-
-    expect(result.candidates).toEqual([]);
-    expect(result.diagnostics).toEqual([
-      expect.objectContaining({
-        code: "workspace-config-invalid",
-        rootKey: WORKSPACE_ROOT_KEY,
-        displayPath: "private-workspace-globstar-limit",
-        detail: expect.stringContaining("matching"),
-      }),
-    ]);
-    expect(JSON.stringify(result.diagnostics)).not.toContain(
-      path.dirname(root),
-    );
-  });
-
-  test("charges triangular globstar closure visits against the matching budget", async () => {
-    const root = await harness.createRoot("private-workspace-closure-limit");
-    let directory = root;
-    for (let depth = 0; depth < 31; depth += 1) {
-      directory = path.join(directory, `level-${depth}`);
-      await fs.mkdir(directory);
-    }
-    await Promise.all(
-      Array.from({ length: 600 }, (_, index) =>
-        fs.symlink("missing", path.join(directory, `link-${index}`)),
-      ),
-    );
-    await fs.writeFile(
-      path.join(root, "package.json"),
-      JSON.stringify({
-        name: "workspace-root",
-        private: true,
-        workspaces: [
-          `${Array.from({ length: 31 }, () => "**").join("/")}/target`,
-        ],
-      }),
-    );
-    const admission = await admitTrustedRoots([
-      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: root },
-    ]);
-
-    const result = await discoverWorkspaceSourceCandidates(admission.roots);
-
-    expect(result.candidates).toEqual([]);
-    expect(result.diagnostics).toContainEqual(
-      expect.objectContaining({
-        code: "workspace-config-invalid",
-        rootKey: WORKSPACE_ROOT_KEY,
-        displayPath: "private-workspace-closure-limit",
-        detail: expect.stringContaining("matching"),
-      }),
-    );
-    expect(JSON.stringify(result.diagnostics)).not.toContain(
-      path.dirname(root),
-    );
-  });
-
-  test("completes a valid sixty-five-candidate workspace below the matching budget", async () => {
+  test("completes a valid sixty-four-candidate workspace", async () => {
     const root = await harness.createRoot();
     const workspaces = Array.from(
-      { length: 65 },
+      { length: 64 },
       (_, index) => `plugins/plugin-${index}`,
     );
     await Promise.all(
@@ -206,48 +87,97 @@ describe("workspace-aware source discovery", () => {
 
     const result = await discoverWorkspaceSourceCandidates(admission.roots);
 
-    expect(result.candidates).toHaveLength(65);
+    expect(result.candidates).toHaveLength(64);
     expect(result.diagnostics).toEqual([]);
   });
 
-  test("marks a later unscanned root partial when the global matching budget is exhausted", async () => {
-    const expensiveRoot = await harness.createRoot("00-expensive");
-    const validRoot = path.join(path.dirname(expensiveRoot), "zz-valid");
-    await fs.mkdir(validRoot);
-    await harness.writePlugin(validRoot, "valid");
-    await Promise.all(
-      Array.from({ length: 24 }, (_, index) =>
-        fs.mkdir(path.join(expensiveRoot, `${"a".repeat(40)}-${index}`)),
-      ),
-    );
+  test("rejects a workspace declaring sixty-five patterns", async () => {
+    const root = await harness.createRoot("private-workspace-pattern-count");
+    const plugin = path.join(root, "plugins", "plugin-0");
+    await fs.mkdir(plugin, { recursive: true });
+    await harness.writePlugin(plugin, "plugin-0");
     await fs.writeFile(
-      path.join(expensiveRoot, "package.json"),
+      path.join(root, "package.json"),
       JSON.stringify({
         name: "workspace-root",
         private: true,
         workspaces: Array.from(
-          { length: 256 },
-          (_, index) => `${"*?".repeat(20)}z${index}`,
+          { length: 65 },
+          (_, index) => `plugins/plugin-${index}`,
         ),
       }),
     );
     const admission = await admitTrustedRoots([
-      {
-        rootKey: WORKSPACE_ROOT_KEY,
-        kind: "current-project",
-        path: expensiveRoot,
-      },
-      { rootKey: EXAMPLE_ROOT_KEY, kind: "explicit", path: validRoot },
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: root },
     ]);
 
     const result = await discoverWorkspaceSourceCandidates(admission.roots);
 
     expect(result.candidates).toEqual([]);
-    expect(
-      result.diagnostics.map(({ code, rootKey }) => ({ code, rootKey })),
-    ).toEqual([
-      { code: "workspace-config-invalid", rootKey: WORKSPACE_ROOT_KEY },
-      { code: "workspace-config-invalid", rootKey: EXAMPLE_ROOT_KEY },
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "workspace-config-invalid",
+        rootKey: WORKSPACE_ROOT_KEY,
+        displayPath: "private-workspace-pattern-count",
+      }),
+    ]);
+  });
+
+  test("accepts a 256-byte pattern and rejects a 257-byte pattern", async () => {
+    const acceptedRoot = await harness.createRoot("workspace-pattern-bytes-ok");
+    const acceptedName = "a".repeat(248);
+    const acceptedPlugin = path.join(acceptedRoot, "plugins", acceptedName);
+    await fs.mkdir(acceptedPlugin, { recursive: true });
+    await harness.writePlugin(acceptedPlugin, "sized");
+    await fs.writeFile(
+      path.join(acceptedRoot, "package.json"),
+      JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: [`plugins/${acceptedName}`],
+      }),
+    );
+    const acceptedAdmission = await admitTrustedRoots([
+      {
+        rootKey: WORKSPACE_ROOT_KEY,
+        kind: "current-project",
+        path: acceptedRoot,
+      },
+    ]);
+
+    const accepted = await discoverWorkspaceSourceCandidates(
+      acceptedAdmission.roots,
+    );
+
+    expect(accepted.candidates.map(({ pluginId }) => pluginId)).toEqual([
+      "sized",
+    ]);
+    expect(accepted.diagnostics).toEqual([]);
+
+    const rejectedRoot = await harness.createRoot("workspace-pattern-bytes");
+    await fs.writeFile(
+      path.join(rejectedRoot, "package.json"),
+      JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: [`plugins/${"a".repeat(249)}`],
+      }),
+    );
+    const rejectedAdmission = await admitTrustedRoots([
+      { rootKey: EXAMPLE_ROOT_KEY, kind: "explicit", path: rejectedRoot },
+    ]);
+
+    const rejected = await discoverWorkspaceSourceCandidates(
+      rejectedAdmission.roots,
+    );
+
+    expect(rejected.candidates).toEqual([]);
+    expect(rejected.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "workspace-config-invalid",
+        rootKey: EXAMPLE_ROOT_KEY,
+        displayPath: "workspace-pattern-bytes",
+      }),
     ]);
   });
 

--- a/packages/inspection/src/discover-workspace-source-candidates.test.ts
+++ b/packages/inspection/src/discover-workspace-source-candidates.test.ts
@@ -43,6 +43,43 @@ describe("workspace-aware source discovery", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  test("stops pathological matching at the aggregate work budget", async () => {
+    const root = await harness.createRoot();
+    const names = Array.from(
+      { length: 8 },
+      (_, index) => `${String.fromCharCode(97 + index)}${"z".repeat(240)}`,
+    );
+    await Promise.all(names.map((name) => fs.mkdir(path.join(root, name))));
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "workspace-root",
+        private: true,
+        workspaces: Array.from(
+          { length: 64 },
+          (_, index) =>
+            `${"*?".repeat(119)}${index.toString(36).padStart(2, "0")}`,
+        ),
+      }),
+    );
+    const admission = await admitTrustedRoots([
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "current-project", path: root },
+    ]);
+
+    const started = performance.now();
+    const result = await discoverWorkspaceSourceCandidates(admission.roots);
+
+    expect(performance.now() - started).toBeLessThan(2_000);
+    expect(result.candidates).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "workspace-config-invalid",
+        rootKey: WORKSPACE_ROOT_KEY,
+        detail: expect.stringContaining("global matching budget"),
+      }),
+    ]);
+  });
+
   test("bounds a separated-wildcard segment nonmatch", async () => {
     const root = await harness.createRoot();
     await fs.mkdir(path.join(root, `${"a".repeat(120)}c`));

--- a/packages/inspection/src/discover-workspace-source-candidates.ts
+++ b/packages/inspection/src/discover-workspace-source-candidates.ts
@@ -32,11 +32,10 @@ import type {
   TrustedRoot,
 } from "./discovery-types.ts";
 
-const MAX_WORKSPACE_PATTERN_COUNT = 256;
-const MAX_WORKSPACE_PATTERN_BYTES = 1_024;
+const MAX_WORKSPACE_PATTERN_COUNT = 64;
+const MAX_WORKSPACE_PATTERN_BYTES = 256;
 const MAX_WORKSPACE_PATTERN_SEGMENTS = 32;
 const MAX_PNPM_WORKSPACE_BYTES = 64 * 1024;
-const MAX_WORKSPACE_MATCH_WORK = 8_000_000;
 
 interface WorkspacePattern {
   readonly negative: boolean;
@@ -45,20 +44,7 @@ interface WorkspacePattern {
 
 interface WorkspaceScanState extends RootScanState {
   readonly patterns: readonly WorkspacePattern[];
-  readonly matchBudget: WorkspaceMatchBudget;
   readonly signal?: AbortSignal;
-  matchComplete: boolean;
-}
-
-interface WorkspaceMatchBudget {
-  activeRoot: TrustedRoot | null;
-  used: number;
-}
-
-class WorkspaceMatchLimitError extends Error {
-  constructor(readonly root: TrustedRoot) {
-    super("workspace match limit");
-  }
 }
 
 export async function discoverWorkspaceSourceCandidates(
@@ -70,43 +56,25 @@ export async function discoverWorkspaceSourceCandidates(
   const diagnostics: DiscoveryDiagnostic[] = [];
   const baseStates = createRootScanStates(roots);
   const states: WorkspaceScanState[] = [];
-  const matchBudget: WorkspaceMatchBudget = { activeRoot: null, used: 0 };
 
   for (const state of baseStates) {
     options.signal?.throwIfAborted();
     states.push({
       ...state,
       patterns: await readWorkspacePatterns(state, diagnostics, options.signal),
-      matchBudget,
-      matchComplete: false,
       signal: options.signal,
     });
   }
-  try {
-    for (const state of states) {
-      options.signal?.throwIfAborted();
-      await scanAvailable(state, candidates, diagnostics);
-    }
-    await redistributeUnusedEntryCapacity(
-      states,
-      candidates,
-      diagnostics,
-      scanWorkspaceRootState,
-    );
-  } catch (error) {
-    if (!(error instanceof WorkspaceMatchLimitError)) throw error;
-    for (const state of states) {
-      if (state.matchComplete) continue;
-      diagnostics.push(
-        discoveryDiagnostic(
-          "workspace-config-invalid",
-          state.root,
-          state.root.displayName,
-          `Workspace matching at ${state.root.displayName} did not complete because the global ${MAX_WORKSPACE_MATCH_WORK}-step limit was reached; results are partial.`,
-        ),
-      );
-    }
+  for (const state of states) {
+    options.signal?.throwIfAborted();
+    await scanAvailable(state, candidates, diagnostics);
   }
+  await redistributeUnusedEntryCapacity(
+    states,
+    candidates,
+    diagnostics,
+    scanWorkspaceRootState,
+  );
   redistributeUnusedCandidateCapacity(states, candidates);
   reportTrueLimits(states, candidates.length, diagnostics);
   options.signal?.throwIfAborted();
@@ -300,19 +268,7 @@ async function scanAvailable(
   candidates: SourceCandidate[],
   diagnostics: DiscoveryDiagnostic[],
 ): Promise<void> {
-  state.matchComplete = false;
   state.signal?.throwIfAborted();
-  state.matchBudget.activeRoot = state.root;
-  await scanAvailableInner(state, candidates, diagnostics);
-  state.matchComplete =
-    state.queue.length === 0 && state.continuations.length === 0;
-}
-
-async function scanAvailableInner(
-  state: WorkspaceScanState,
-  candidates: SourceCandidate[],
-  diagnostics: DiscoveryDiagnostic[],
-): Promise<void> {
   while (true) {
     while (state.queue.length > 0) {
       state.signal?.throwIfAborted();
@@ -360,8 +316,7 @@ async function inspectPendingDirectory(
   state.signal?.throwIfAborted();
   if (!attestation) return;
   const matched =
-    current.relative === "" ||
-    matches(state.patterns, current.relative, state.matchBudget);
+    current.relative === "" || matches(state.patterns, current.relative);
   let packageBoundary = false;
   if (matched) {
     const candidate = await inspectDirectory(
@@ -386,11 +341,7 @@ async function inspectPendingDirectory(
   if (
     !stable ||
     (packageBoundary &&
-      !couldContainStrictMatch(
-        state.patterns,
-        current.relative,
-        state.matchBudget,
-      )) ||
+      !couldContainStrictMatch(state.patterns, current.relative)) ||
     state.patterns.length === 0
   )
     return;
@@ -449,12 +400,11 @@ function consumeEntries(
         state.patterns,
         relative,
         entry.name,
-        state.matchBudget,
       )
     )
       continue;
     if (entry.isSymbolicLink()) {
-      if (couldContainMatch(state.patterns, relative, state.matchBudget)) {
+      if (couldContainMatch(state.patterns, relative)) {
         const displayPath = displayPathFor(
           state.root,
           relative.split("/").join(path.sep),
@@ -471,8 +421,7 @@ function consumeEntries(
       continue;
     }
     if (!entry.isDirectory()) continue;
-    if (!couldContainMatch(state.patterns, relative, state.matchBudget))
-      continue;
+    if (!couldContainMatch(state.patterns, relative)) continue;
     state.queue.push({
       directory: path.join(current.directory, entry.name),
       relative: relative.split("/").join(path.sep),
@@ -611,18 +560,16 @@ async function attestDirectoryOrReport(
 function matches(
   patterns: readonly WorkspacePattern[],
   relative: string,
-  budget: WorkspaceMatchBudget,
 ): boolean {
   const segments = relative.split(path.sep);
   return (
     patterns.some(
       (pattern) =>
-        !pattern.negative &&
-        matchesSegments(pattern.segments, segments, budget),
+        !pattern.negative && matchesSegments(pattern.segments, segments),
     ) &&
     !patterns.some(
       (pattern) =>
-        pattern.negative && matchesSegments(pattern.segments, segments, budget),
+        pattern.negative && matchesSegments(pattern.segments, segments),
     )
   );
 }
@@ -630,7 +577,6 @@ function matches(
 function couldContainMatch(
   patterns: readonly WorkspacePattern[],
   relative: string,
-  budget: WorkspaceMatchBudget,
 ): boolean {
   const segments = relative.split("/");
   if (
@@ -638,20 +584,19 @@ function couldContainMatch(
       (pattern) =>
         pattern.negative &&
         pattern.segments.at(-1) === "**" &&
-        matchesSegments(pattern.segments, segments, budget),
+        matchesSegments(pattern.segments, segments),
     )
   )
     return false;
   return patterns.some(
     (pattern) =>
-      !pattern.negative && prefixCanMatch(pattern.segments, segments, budget),
+      !pattern.negative && prefixCanMatch(pattern.segments, segments),
   );
 }
 
 function couldContainStrictMatch(
   patterns: readonly WorkspacePattern[],
   relative: string,
-  budget: WorkspaceMatchBudget,
 ): boolean {
   const segments = relative.split(path.sep);
   if (
@@ -659,30 +604,26 @@ function couldContainStrictMatch(
       (pattern) =>
         pattern.negative &&
         pattern.segments.at(-1) === "**" &&
-        matchesSegments(pattern.segments, segments, budget),
+        matchesSegments(pattern.segments, segments),
     )
   )
     return false;
   return patterns.some(
     (pattern) =>
       !pattern.negative &&
-      prefixCanMatch(pattern.segments, segments, budget, {
-        strictDescendant: true,
-      }),
+      prefixCanMatch(pattern.segments, segments, { strictDescendant: true }),
   );
 }
 
 function matchesSegments(
   pattern: readonly string[],
   input: readonly string[],
-  budget: WorkspaceMatchBudget,
 ): boolean {
   const seen = new Set<string>();
   const visit = (patternIndex: number, inputIndex: number): boolean => {
     const key = `${patternIndex}:${inputIndex}`;
     if (seen.has(key)) return false;
     seen.add(key);
-    chargeWorkspaceMatchWork(budget, 1);
     if (patternIndex === pattern.length) return inputIndex === input.length;
     const segment = pattern[patternIndex]!;
     if (segment === "**")
@@ -694,7 +635,7 @@ function matchesSegments(
       );
     return (
       inputIndex < input.length &&
-      matchesPatternSegment(segment, input[inputIndex]!, budget) &&
+      matchesPatternSegment(segment, input[inputIndex]!) &&
       visit(patternIndex + 1, inputIndex + 1)
     );
   };
@@ -704,25 +645,24 @@ function matchesSegments(
 function prefixCanMatch(
   pattern: readonly string[],
   input: readonly string[],
-  budget: WorkspaceMatchBudget,
   options: { strictDescendant?: boolean } = {},
 ): boolean {
   let states = new Set([0]);
   for (const inputSegment of input) {
     const next = new Set<number>();
-    for (const state of closeGlobstars(pattern, states, budget)) {
+    for (const state of closeGlobstars(pattern, states)) {
       if (pattern[state] === "**" && !inputSegment.startsWith("."))
         next.add(state);
       else if (
         state < pattern.length &&
-        matchesPatternSegment(pattern[state]!, inputSegment, budget)
+        matchesPatternSegment(pattern[state]!, inputSegment)
       )
         next.add(state + 1);
     }
     states = next;
     if (states.size === 0) return false;
   }
-  const reachable = closeGlobstars(pattern, states, budget);
+  const reachable = closeGlobstars(pattern, states);
   return options.strictDescendant
     ? [...reachable].some((state) => state < pattern.length)
     : reachable.size > 0;
@@ -731,14 +671,11 @@ function prefixCanMatch(
 function closeGlobstars(
   pattern: readonly string[],
   input: ReadonlySet<number>,
-  budget: WorkspaceMatchBudget,
 ): Set<number> {
   const result = new Set(input);
   for (const state of [...result]) {
     let index = state;
-    while (true) {
-      chargeWorkspaceMatchWork(budget, 1);
-      if (pattern[index] !== "**") break;
+    while (pattern[index] === "**") {
       index += 1;
       result.add(index);
     }
@@ -746,17 +683,9 @@ function closeGlobstars(
   return result;
 }
 
-function matchesSegment(
-  pattern: string,
-  input: string,
-  budget: WorkspaceMatchBudget,
-): boolean {
+function matchesSegment(pattern: string, input: string): boolean {
   const patternCharacters = [...pattern];
   const inputCharacters = [...input];
-  chargeWorkspaceMatchWork(
-    budget,
-    patternCharacters.length * (inputCharacters.length + 1),
-  );
   let reachable = new Uint8Array(inputCharacters.length + 1);
   reachable[0] = 1;
   for (const patternCharacter of patternCharacters) {
@@ -787,26 +716,11 @@ function matchesSegment(
   return reachable[inputCharacters.length] === 1;
 }
 
-function matchesPatternSegment(
-  pattern: string,
-  input: string,
-  budget: WorkspaceMatchBudget,
-): boolean {
+function matchesPatternSegment(pattern: string, input: string): boolean {
   return (
     (!input.startsWith(".") || pattern.startsWith(".")) &&
-    matchesSegment(pattern, input, budget)
+    matchesSegment(pattern, input)
   );
-}
-
-function chargeWorkspaceMatchWork(
-  budget: WorkspaceMatchBudget,
-  cost: number,
-): void {
-  if (budget.used + cost > MAX_WORKSPACE_MATCH_WORK) {
-    if (!budget.activeRoot) throw new Error("workspace match root unavailable");
-    throw new WorkspaceMatchLimitError(budget.activeRoot);
-  }
-  budget.used += cost;
 }
 
 function matchesWildcard(character: string): boolean {
@@ -829,7 +743,6 @@ function isExplicitlyIncludedIgnoredDirectory(
   patterns: readonly WorkspacePattern[],
   relative: string,
   name: string,
-  budget: WorkspaceMatchBudget,
 ): boolean {
   if (name === "node_modules") return false;
   const segments = relative.split("/");
@@ -839,12 +752,8 @@ function isExplicitlyIncludedIgnoredDirectory(
       pattern.segments.some(
         (segment, index) =>
           segment !== "**" &&
-          matchesPatternSegment(segment, name, budget) &&
-          matchesSegments(
-            pattern.segments.slice(0, index + 1),
-            segments,
-            budget,
-          ),
+          matchesPatternSegment(segment, name) &&
+          matchesSegments(pattern.segments.slice(0, index + 1), segments),
       ),
   );
 }

--- a/packages/inspection/src/discover-workspace-source-candidates.ts
+++ b/packages/inspection/src/discover-workspace-source-candidates.ts
@@ -35,6 +35,11 @@ import type {
 const MAX_WORKSPACE_PATTERN_COUNT = 64;
 const MAX_WORKSPACE_PATTERN_BYTES = 256;
 const MAX_WORKSPACE_PATTERN_SEGMENTS = 32;
+// One admission's total character-level matching work. The static pattern
+// caps bound each comparison, but 64 wildcard patterns against every budgeted
+// directory entry still multiply into seconds of synchronous matching; this
+// aggregate cap keeps the worst case far below the request deadline.
+const MAX_WORKSPACE_MATCH_WORK = 8_000_000;
 const MAX_PNPM_WORKSPACE_BYTES = 64 * 1024;
 
 interface WorkspacePattern {
@@ -44,7 +49,24 @@ interface WorkspacePattern {
 
 interface WorkspaceScanState extends RootScanState {
   readonly patterns: readonly WorkspacePattern[];
+  readonly work: MatchWork;
   readonly signal?: AbortSignal;
+  budgetReported?: boolean;
+}
+
+interface MatchWork {
+  used: number;
+}
+
+class WorkspaceMatchWorkError extends Error {
+  constructor() {
+    super("workspace match work limit");
+  }
+}
+
+function chargeMatchWork(work: MatchWork, cost: number): void {
+  work.used += cost;
+  if (work.used > MAX_WORKSPACE_MATCH_WORK) throw new WorkspaceMatchWorkError();
 }
 
 export async function discoverWorkspaceSourceCandidates(
@@ -56,12 +78,14 @@ export async function discoverWorkspaceSourceCandidates(
   const diagnostics: DiscoveryDiagnostic[] = [];
   const baseStates = createRootScanStates(roots);
   const states: WorkspaceScanState[] = [];
+  const work: MatchWork = { used: 0 };
 
   for (const state of baseStates) {
     options.signal?.throwIfAborted();
     states.push({
       ...state,
       patterns: await readWorkspacePatterns(state, diagnostics, options.signal),
+      work,
       signal: options.signal,
     });
   }
@@ -269,35 +293,49 @@ async function scanAvailable(
   diagnostics: DiscoveryDiagnostic[],
 ): Promise<void> {
   state.signal?.throwIfAborted();
-  while (true) {
-    while (state.queue.length > 0) {
+  try {
+    while (true) {
+      while (state.queue.length > 0) {
+        state.signal?.throwIfAborted();
+        const current = state.queue.shift();
+        if (!current) break;
+        await inspectPendingDirectory(state, current, candidates, diagnostics);
+      }
+      if (state.budget.visitedEntries >= state.budget.maxVisitedEntries) return;
       state.signal?.throwIfAborted();
-      const current = state.queue.shift();
-      if (!current) break;
-      await inspectPendingDirectory(state, current, candidates, diagnostics);
-    }
-    if (state.budget.visitedEntries >= state.budget.maxVisitedEntries) return;
-    state.signal?.throwIfAborted();
-    const continuation = state.continuations.shift();
-    if (!continuation) return;
-    if (continuation.kind === "entries") {
-      consumeEntries(
+      const continuation = state.continuations.shift();
+      if (!continuation) return;
+      if (continuation.kind === "entries") {
+        consumeEntries(
+          state,
+          continuation.current,
+          continuation.entries,
+          diagnostics,
+        );
+        continue;
+      }
+      const entries = await readDirectoryEntries(
         state,
         continuation.current,
-        continuation.entries,
         diagnostics,
+        continuation.attestation,
       );
-      continue;
+      state.signal?.throwIfAborted();
+      if (entries)
+        consumeEntries(state, continuation.current, entries, diagnostics);
     }
-    const entries = await readDirectoryEntries(
-      state,
-      continuation.current,
-      diagnostics,
-      continuation.attestation,
+  } catch (error) {
+    if (!(error instanceof WorkspaceMatchWorkError)) throw error;
+    if (state.budgetReported) return;
+    state.budgetReported = true;
+    diagnostics.push(
+      discoveryDiagnostic(
+        "workspace-config-invalid",
+        state.root,
+        state.root.displayName,
+        `Workspace matching at ${state.root.displayName} stopped at the global matching budget; results are partial.`,
+      ),
     );
-    state.signal?.throwIfAborted();
-    if (entries)
-      consumeEntries(state, continuation.current, entries, diagnostics);
   }
 }
 
@@ -316,7 +354,8 @@ async function inspectPendingDirectory(
   state.signal?.throwIfAborted();
   if (!attestation) return;
   const matched =
-    current.relative === "" || matches(state.patterns, current.relative);
+    current.relative === "" ||
+    matches(state.patterns, current.relative, state.work);
   let packageBoundary = false;
   if (matched) {
     const candidate = await inspectDirectory(
@@ -341,7 +380,7 @@ async function inspectPendingDirectory(
   if (
     !stable ||
     (packageBoundary &&
-      !couldContainStrictMatch(state.patterns, current.relative)) ||
+      !couldContainStrictMatch(state.patterns, current.relative, state.work)) ||
     state.patterns.length === 0
   )
     return;
@@ -400,11 +439,12 @@ function consumeEntries(
         state.patterns,
         relative,
         entry.name,
+        state.work,
       )
     )
       continue;
     if (entry.isSymbolicLink()) {
-      if (couldContainMatch(state.patterns, relative)) {
+      if (couldContainMatch(state.patterns, relative, state.work)) {
         const displayPath = displayPathFor(
           state.root,
           relative.split("/").join(path.sep),
@@ -421,7 +461,7 @@ function consumeEntries(
       continue;
     }
     if (!entry.isDirectory()) continue;
-    if (!couldContainMatch(state.patterns, relative)) continue;
+    if (!couldContainMatch(state.patterns, relative, state.work)) continue;
     state.queue.push({
       directory: path.join(current.directory, entry.name),
       relative: relative.split("/").join(path.sep),
@@ -560,16 +600,17 @@ async function attestDirectoryOrReport(
 function matches(
   patterns: readonly WorkspacePattern[],
   relative: string,
+  work: MatchWork,
 ): boolean {
   const segments = relative.split(path.sep);
   return (
     patterns.some(
       (pattern) =>
-        !pattern.negative && matchesSegments(pattern.segments, segments),
+        !pattern.negative && matchesSegments(pattern.segments, segments, work),
     ) &&
     !patterns.some(
       (pattern) =>
-        pattern.negative && matchesSegments(pattern.segments, segments),
+        pattern.negative && matchesSegments(pattern.segments, segments, work),
     )
   );
 }
@@ -577,6 +618,7 @@ function matches(
 function couldContainMatch(
   patterns: readonly WorkspacePattern[],
   relative: string,
+  work: MatchWork,
 ): boolean {
   const segments = relative.split("/");
   if (
@@ -584,19 +626,20 @@ function couldContainMatch(
       (pattern) =>
         pattern.negative &&
         pattern.segments.at(-1) === "**" &&
-        matchesSegments(pattern.segments, segments),
+        matchesSegments(pattern.segments, segments, work),
     )
   )
     return false;
   return patterns.some(
     (pattern) =>
-      !pattern.negative && prefixCanMatch(pattern.segments, segments),
+      !pattern.negative && prefixCanMatch(pattern.segments, segments, work),
   );
 }
 
 function couldContainStrictMatch(
   patterns: readonly WorkspacePattern[],
   relative: string,
+  work: MatchWork,
 ): boolean {
   const segments = relative.split(path.sep);
   if (
@@ -604,26 +647,30 @@ function couldContainStrictMatch(
       (pattern) =>
         pattern.negative &&
         pattern.segments.at(-1) === "**" &&
-        matchesSegments(pattern.segments, segments),
+        matchesSegments(pattern.segments, segments, work),
     )
   )
     return false;
   return patterns.some(
     (pattern) =>
       !pattern.negative &&
-      prefixCanMatch(pattern.segments, segments, { strictDescendant: true }),
+      prefixCanMatch(pattern.segments, segments, work, {
+        strictDescendant: true,
+      }),
   );
 }
 
 function matchesSegments(
   pattern: readonly string[],
   input: readonly string[],
+  work: MatchWork,
 ): boolean {
   const seen = new Set<string>();
   const visit = (patternIndex: number, inputIndex: number): boolean => {
     const key = `${patternIndex}:${inputIndex}`;
     if (seen.has(key)) return false;
     seen.add(key);
+    chargeMatchWork(work, 1);
     if (patternIndex === pattern.length) return inputIndex === input.length;
     const segment = pattern[patternIndex]!;
     if (segment === "**")
@@ -635,7 +682,7 @@ function matchesSegments(
       );
     return (
       inputIndex < input.length &&
-      matchesPatternSegment(segment, input[inputIndex]!) &&
+      matchesPatternSegment(segment, input[inputIndex]!, work) &&
       visit(patternIndex + 1, inputIndex + 1)
     );
   };
@@ -645,24 +692,25 @@ function matchesSegments(
 function prefixCanMatch(
   pattern: readonly string[],
   input: readonly string[],
+  work: MatchWork,
   options: { strictDescendant?: boolean } = {},
 ): boolean {
   let states = new Set([0]);
   for (const inputSegment of input) {
     const next = new Set<number>();
-    for (const state of closeGlobstars(pattern, states)) {
+    for (const state of closeGlobstars(pattern, states, work)) {
       if (pattern[state] === "**" && !inputSegment.startsWith("."))
         next.add(state);
       else if (
         state < pattern.length &&
-        matchesPatternSegment(pattern[state]!, inputSegment)
+        matchesPatternSegment(pattern[state]!, inputSegment, work)
       )
         next.add(state + 1);
     }
     states = next;
     if (states.size === 0) return false;
   }
-  const reachable = closeGlobstars(pattern, states);
+  const reachable = closeGlobstars(pattern, states, work);
   return options.strictDescendant
     ? [...reachable].some((state) => state < pattern.length)
     : reachable.size > 0;
@@ -671,11 +719,14 @@ function prefixCanMatch(
 function closeGlobstars(
   pattern: readonly string[],
   input: ReadonlySet<number>,
+  work: MatchWork,
 ): Set<number> {
   const result = new Set(input);
   for (const state of [...result]) {
     let index = state;
-    while (pattern[index] === "**") {
+    while (true) {
+      chargeMatchWork(work, 1);
+      if (pattern[index] !== "**") break;
       index += 1;
       result.add(index);
     }
@@ -683,9 +734,17 @@ function closeGlobstars(
   return result;
 }
 
-function matchesSegment(pattern: string, input: string): boolean {
+function matchesSegment(
+  pattern: string,
+  input: string,
+  work: MatchWork,
+): boolean {
   const patternCharacters = [...pattern];
   const inputCharacters = [...input];
+  chargeMatchWork(
+    work,
+    patternCharacters.length * (inputCharacters.length + 1),
+  );
   let reachable = new Uint8Array(inputCharacters.length + 1);
   reachable[0] = 1;
   for (const patternCharacter of patternCharacters) {
@@ -716,10 +775,14 @@ function matchesSegment(pattern: string, input: string): boolean {
   return reachable[inputCharacters.length] === 1;
 }
 
-function matchesPatternSegment(pattern: string, input: string): boolean {
+function matchesPatternSegment(
+  pattern: string,
+  input: string,
+  work: MatchWork,
+): boolean {
   return (
     (!input.startsWith(".") || pattern.startsWith(".")) &&
-    matchesSegment(pattern, input)
+    matchesSegment(pattern, input, work)
   );
 }
 
@@ -743,6 +806,7 @@ function isExplicitlyIncludedIgnoredDirectory(
   patterns: readonly WorkspacePattern[],
   relative: string,
   name: string,
+  work: MatchWork,
 ): boolean {
   if (name === "node_modules") return false;
   const segments = relative.split("/");
@@ -752,8 +816,8 @@ function isExplicitlyIncludedIgnoredDirectory(
       pattern.segments.some(
         (segment, index) =>
           segment !== "**" &&
-          matchesPatternSegment(segment, name) &&
-          matchesSegments(pattern.segments.slice(0, index + 1), segments),
+          matchesPatternSegment(segment, name, work) &&
+          matchesSegments(pattern.segments.slice(0, index + 1), segments, work),
       ),
   );
 }

--- a/plugins/mate/src/generated/runtime-artifact-stamp.ts
+++ b/plugins/mate/src/generated/runtime-artifact-stamp.ts
@@ -7,10 +7,10 @@ export const RUNTIME_ARTIFACT_STAMP = Object.freeze({
   architecture: "arm64",
   mode: "0755",
   size: 64882658,
-  sha256: "2bcc53fdc7b3578410ed5ea69664127f439ed553566ca1fb7f96c554f8c8be2b",
+  sha256: "82430afa6b247fb5bb1de2e467a13a29b12f2fbda7bca30fdf2f663cec9f5608",
   runtimeVersion: "0.1.0-alpha.3",
   manifestSize: 6494,
   manifestSha256:
-    "f38c7014a6ac4d9218176c50c7adf595a691e1cb9525790979b5e26b8ae94614",
+    "070cdac584525ca52c718507c90250b1b7c2c05e0a5182b86a12bfeb65a1c44c",
   expectedApiVersion: 2,
 } as const);

--- a/plugins/mate/src/generated/runtime-artifact-stamp.ts
+++ b/plugins/mate/src/generated/runtime-artifact-stamp.ts
@@ -7,10 +7,10 @@ export const RUNTIME_ARTIFACT_STAMP = Object.freeze({
   architecture: "arm64",
   mode: "0755",
   size: 64882658,
-  sha256: "2ab42053109b07e8bb599da592ba1afe24828201227a2fd31a9ac88f3a6e2e32",
+  sha256: "2bcc53fdc7b3578410ed5ea69664127f439ed553566ca1fb7f96c554f8c8be2b",
   runtimeVersion: "0.1.0-alpha.3",
   manifestSize: 6494,
   manifestSha256:
-    "8fe44b9c051ec81f54c8250413ff19d0373de474efc3f54d309a470ed4aaccc7",
+    "f38c7014a6ac4d9218176c50c7adf595a691e1cb9525790979b5e26b8ae94614",
   expectedApiVersion: 2,
 } as const);


### PR DESCRIPTION
refactor: bound workspace matching with static caps and one aggregate budget

Replaces the per-root match-work accounting machinery (per-root budget snapshots, active-root tracking, matchComplete bookkeeping, root-carrying error type) with two simpler layers:

1. Tighter static input caps: at most 64 workspace patterns (was 256) and 256 bytes per pattern (was 1,024); segments stay capped at 32. Cap violations surface as the existing workspace-config-invalid root-only fallback, pinned by boundary tests (64/65 patterns, 256/257 bytes).

2. One aggregate 8,000,000-step match-work counter shared across the admission, charged at the DP hot spots. Static caps bound each comparison but not the product: 64 near-cap wildcard patterns against every budgeted directory entry still multiply into billions of synchronous character operations that block abort delivery (credit: Codex review). On exhaustion the affected roots degrade to honest partial results in well under a second, pinned by a pathological-workspace regression test.

The matcher itself, dot-segment rules, traversal pruning, and entry/candidate budgets are unchanged. One CLI fan-out test was restructured (64 workspace plugins plus a root plugin) to keep exercising the 128-target serialization cap. Runtime identity refreshed at the stack tip (f8ee7d81). Net -130 lines versus the original accounting.

Follow-up 2 of 3 from the discovery architecture audit; owner-approved simplification stack.
