### PR TITLE
test: make TERM-ignoring descendant force-kill test deterministic

### DIFF
--- a/apps/cli/src/native.test.ts
+++ b/apps/cli/src/native.test.ts
@@ -160,20 +160,29 @@ describe("native command boundary", () => {
       "stubborn-tree",
       [
         "#!/bin/sh",
+        // Ignore TERM before forking so the descendant inherits SIG_IGN and
+        // setup cannot be interrupted between its fork and its own trap line.
+        'trap "" TERM',
         "sh -c 'trap \"\" TERM; while :; do :; done' &",
         "descendant=$!",
         `printf '%s' \"$descendant\" > ${JSON.stringify(descendantPidFile)}`,
+        // Readiness signal: exceeding maxOutputBytes triggers termination, so
+        // the kill sequence is causally ordered after the pid file write
+        // instead of racing shell startup against a wall-clock timeout.
+        "head -c 2048 /dev/zero",
         'wait "$descendant"',
         "",
       ].join("\n"),
     );
 
     const result = await runCapturedCommand(stalled.file, [], stalled.root, {
-      timeoutMs: 20,
+      timeoutMs: 5_000,
+      maxOutputBytes: 1_024,
     });
     const descendantPid = Number(await fs.readFile(descendantPidFile, "utf8"));
 
-    expect(result.exitCode).toBe(124);
+    expect(descendantPid).toBeGreaterThan(0);
+    expect(result.exitCode).toBe(125);
     expect(() => process.kill(descendantPid, 0)).toThrow();
   });
 


### PR DESCRIPTION
## Context

`native command boundary > force-kills a TERM-ignoring descendant before settling` (`apps/cli/src/native.test.ts`) fails persistently on at least one macOS dev machine (0/3 local runs) while passing in hosted CI, which erodes trust in the suite. No plugin-author-facing behavior changes; this hardens the test for the native command boundary.

## What changed

Diagnosis: the test raced a 20ms wall-clock timeout against shell setup. `runCapturedCommand`'s timer starts at `spawn()` and SIGTERMs the child's process group on expiry. The fixture's parent `sh` did not ignore TERM, so on machines where `sh` startup + fork + pid-file write exceeds 20ms (~78ms warm, ~580ms cold on the affected macOS machine) the group SIGTERM killed it before `descendant.pid` was written — every failure was `ENOENT` on the pid file at ~289ms (20ms timeout + 250ms SIGKILL grace + settle). Linux CI shells spawn in a few ms and won the race.

Fix (test-only; `packages/inspection` production code untouched):

- The script now writes `descendant.pid`, **then** emits output past a 1 KiB `maxOutputBytes` bound. That triggers the same `terminate()` → SIGTERM → 250ms → SIGKILL escalation, but causally ordered after the pid write — no wall-clock race. `timeoutMs` becomes a 5s never-fires safety net; the test still completes in ~300ms.
- The parent traps TERM before forking so the descendant inherits `SIG_IGN`, closing the window between the descendant's fork and its own `trap` line.
- Expected exit code changes 124 → 125 to match the output-bound trigger. The timeout→124 force-kill path stays covered by the two preceding tests. The core assertion is intact and slightly stronger: the entire tree now ignores TERM, so `process.kill(descendantPid, 0)` throwing proves the descendant died only via the SIGKILL escalation. Added a `descendantPid > 0` guard so an empty pid file cannot false-pass via `NaN`.

## Verification

- `bun test apps/cli/src/native.test.ts -t "force-kills"` — 10/10 passes on the previously-failing macOS machine (0/3 before)
- `bun test apps/cli` — 83 pass / 0 fail
- `bun run format:check` — clean
- `bun --filter '*' check` and `tsc -p scripts/tsconfig.json` — pass. `bun run compatibility:check` fails locally on a pre-existing environment mismatch (installed bb 0.37.0 vs targeted 0.36.0), unrelated to this change; tracked in a separate issue.

## Risk and compatibility

Test-only change to one fixture script and its assertions; no runtime, package, or SDK-boundary effects. Relies on POSIX `trap`/`SIG_IGN` inheritance and `head -c`, both available in macOS `/bin/sh` and dash on CI.

- [x] I kept native bb and `@bb/plugin-sdk` authoritative for their contracts and lifecycle.
- [x] I added or updated focused tests where behavior changed.
- [x] I ran the smallest relevant checks and the complete applicable gate.
- [x] I did not include credentials, customer data, authenticated state, or local absolute paths.