### PR TITLE
docs: reconcile Plugin Studio roadmap

### DIFF
--- a/.agents/goals/2026-08-11-bb-scoped-plugin-inventory/RETRO.md
+++ b/.agents/goals/2026-08-11-bb-scoped-plugin-inventory/RETRO.md
@@ -1,14 +1,24 @@
 # Execution Retro: bb-scoped Plugin Studio inventory
 
 Date started: 2026-08-11
-Date finalized: Pending
-Status: Executing
+Date finalized: 2026-08-12
+Status: Complete; post-completion reconciliation added 2026-08-13
 Spec: `.agents/goals/2026-08-11-bb-scoped-plugin-inventory/SPEC.md`
 Goal: `.agents/goals/2026-08-11-bb-scoped-plugin-inventory/GOAL.md`
 Prompt: `.agents/goals/2026-08-11-bb-scoped-plugin-inventory/PROMPT.md`
 Refs: `.agents/goals/2026-08-11-bb-scoped-plugin-inventory/REFS.md`
 
 ## Summary
+
+> Post-completion truth: PR #83 merged as `ff9289d1`, PR #84 merged as
+> `13d892cd`, and scanner follow-ups #89-#91 landed on current `main`
+> (`84e80f5c`). #82 is closed. The later repository move left the installed
+> path registration targeting the removed checkout; #94 owns the supported
+> preserve-state repair. Technical identity migration (#86/#95), compatibility
+> policy (#93), native-runtime convergence (#96), and bounded directory
+> enumeration (#97) are separate active follow-ups. Ready-but-unmerged, old
+> artifact, and successful-live statements below are chronological evidence,
+> not current state.
 
 - Objective: automatically inventory every bb-registered local project and its
   source plugins using workspace-aware, path-private discovery.
@@ -20,12 +30,10 @@ Refs: `.agents/goals/2026-08-11-bb-scoped-plugin-inventory/REFS.md`
   `7bdcfc3b8379ad08e0d4cd5ea36ad4eb6da60b7a` (`fix: preserve Plugin Studio
 refreshes`, following the `6d58faad` evidence head) with green exact-head
   hosted CI, two clean round-4 review lanes, and all review threads resolved;
-  it proceeds from draft to ready once this reconciliation commit's hosted CI
-  is green. Neither PR is merged.
-- Tracker/PR/source-control state: #82 open beneath #21; #62 complete; #70/#77
-  open and out of scope; PR #73 preserved; PR #83 exact head is `1c897d5`; PR
-  #84's exact implementation head is
-  `7bdcfc3b8379ad08e0d4cd5ea36ad4eb6da60b7a`.
+  it subsequently proceeded through review and merge.
+- Historical tracker/PR/source-control state at the ready-PR horizon: #82 was
+  open beneath #21; #62 complete; #70/#77 out of scope; PR #73 preserved; PR
+  #83 exact head `1c897d5`; PR #84 implementation head `7bdcfc3b…`.
 - Verification: prompt/doctor, Mate 80/80 (378 assertions), plugin check/build,
   15 Chromium screenshot/axe cases including 420px, Prettier, and diff checks
   pass on the milestone-A implementation head. Milestone B's current local
@@ -61,8 +69,8 @@ refreshes`, following the `6d58faad` evidence head) with green exact-head
   gates are green.
 - Tracker blockers: none; #82 owns the slice and #21 lists it.
 - Authority blockers: merge and release intentionally excluded.
-- Next action: push this reconciliation commit, confirm hosted CI at the docs
-  successor head, then mark PR #84 ready without merging or releasing.
+- Next action at completion was the owner-controlled merge. Current follow-up
+  work is tracked in #86, #93, #94-#102.
 
 ## Goal Amendments
 
@@ -384,13 +392,13 @@ refreshes`, following the `6d58faad` evidence head) with green exact-head
 
 ## Tracker / PR Log
 
-| Item       | State | Notes                                                                                                            |
-| ---------- | ----- | ---------------------------------------------------------------------------------------------------------------- |
-| GitHub #21 | Open  | Parent roadmap; #82 added, #62 checked, #70/#77 open.                                                            |
-| GitHub #82 | Open  | Focused all-project bb-scoped inventory sub-issue.                                                               |
-| GitHub #73 | Open  | Unrelated Biner setup lane; preserve without mutation.                                                           |
-| PR #83     | Ready | Exact head `1c897d5`; milestone-A proof remains green.                                                           |
-| PR #84     | Draft | Exact pushed evidence head `6d58faa`; local, artifact, RPC, and Browser proof green; hosted and reviews pending. |
+| Item       | State  | Notes                                                                         |
+| ---------- | ------ | ----------------------------------------------------------------------------- |
+| GitHub #21 | Open   | Parent roadmap; #82 added, #62 checked, #70/#77 open.                         |
+| GitHub #82 | Closed | Focused all-project bb-scoped inventory completed through merged PRs #83/#84. |
+| GitHub #73 | Open   | Unrelated Biner setup lane; preserve without mutation.                        |
+| PR #83     | Merged | Merge commit `ff9289d1`; milestone-A proof remains historical.                |
+| PR #84     | Merged | Merge commit `13d892cd`; later scanner follow-ups landed through #91.         |
 
 ## Follow-Ups
 
@@ -414,9 +422,9 @@ refreshes`, following the `6d58faad` evidence head) with green exact-head
   tests with the package/assertion breakdown above, standalone runtime
   `95ab3719…`, manifest `027cde5e…`, package `0d2a37d3…`, preserve-state Live
   status/refresh proof at app hash `de3682…`, and current Browser proof.
-- Forbidden actions audit: no merge, queue, publication, release, upstream edit,
-  plugin removal/reinstall, or PR #73 mutation has occurred; confirm once more
-  before readiness.
+- Authority audit at the original horizon excluded merge. The PRs were later
+  merged through the owner-controlled GitHub sequence; no publication, release,
+  plugin removal/reinstall, or upstream edit is implied by this retro.
 - Remaining findings / risks: the bounded directory-enumeration observation is
   explicitly deferred hardening, resolved on the PR with measured evidence. An
   owner-approved simplification stack (pnpm YAML block validator removal,

--- a/.agents/plans/2026-08-11-bb-plugin-studio-rename.md
+++ b/.agents/plans/2026-08-11-bb-plugin-studio-rename.md
@@ -1,7 +1,7 @@
 # bb Plugin Studio rename
 
 Date: 2026-08-11
-Status: Implementation complete — final governance runs through PR #84 and issue #86
+Status: Phase 1 complete; technical identity migration active under #86
 Issue: [#86](https://github.com/galligan/bb-plugin-studio/issues/86)
 Owning branch: `feat/plugin-workbench/bb-scoped-project-catalog` / PR #84
 
@@ -9,8 +9,10 @@ Owning branch: `feat/plugin-workbench/bb-scoped-project-catalog` / PR #84
 
 The product is named **bb Plugin Studio** in repository and explanatory copy,
 and **Plugin Studio** inside bb navigation and panel chrome. The rename explains
-the product's purpose—build, inspect, and preview bb plugins—without changing
-the technical identities that own existing plugin state.
+the product's purpose—build, inspect, and preview bb plugins. The original
+phase deliberately preserved technical identities that own existing plugin
+state; the 2026-08-13 direction supersedes that end state and migrates them
+safely under #94, #95, and #96.
 
 After the code, package, Live bb, review, and hosted gates pass, the GitHub
 repository becomes `galligan/bb-plugin-studio`. GitHub's documented repository
@@ -20,20 +22,20 @@ through its old path because action references do not redirect.
 
 ## Naming and compatibility matrix
 
-| Surface                        | Final value                               | Treatment                                                 |
-| ------------------------------ | ----------------------------------------- | --------------------------------------------------------- |
-| Full product name              | `bb Plugin Studio`                        | Rename now                                                |
-| bb navigation and panel        | `Plugin Studio`                           | Rename now                                                |
-| Product descriptor             | `Build, inspect, and preview bb plugins.` | Rename now                                                |
-| GitHub repository              | `galligan/bb-plugin-studio`               | Rename only after every gate                              |
-| npm CLI package and executable | `bb-mate`                                 | Preserve compatibility                                    |
-| Workspace packages             | `@bb-mate/*`                              | Preserve compatibility                                    |
-| bb plugin package and ID       | `bb-plugin-mate` / `mate`                 | Preserve installed state                                  |
-| Plugin source directory        | `plugins/mate`                            | Preserve build and path install                           |
-| Runtime executable/artifact    | `bb-mate`                                 | Preserve stamp and supervision                            |
-| Runtime data root              | `<bb-data>/plugins/mate/runtime`          | Preserve catalog identity                                 |
-| Panel route                    | `workbench`                               | Preserve deep links                                       |
-| Skill technical ID/path        | `plugin-workbench`                        | Preserve existing references; show Plugin Studio in prose |
+| Surface                        | Final value                               | Treatment                                         |
+| ------------------------------ | ----------------------------------------- | ------------------------------------------------- |
+| Full product name              | `bb Plugin Studio`                        | Rename now                                        |
+| bb navigation and panel        | `Plugin Studio`                           | Rename now                                        |
+| Product descriptor             | `Build, inspect, and preview bb plugins.` | Rename now                                        |
+| GitHub repository              | `galligan/bb-plugin-studio`               | Rename only after every gate                      |
+| npm CLI package and executable | `bb-plugin-studio`                        | Migrate with a bounded `bb-mate` bridge under #95 |
+| Workspace packages             | Studio-named private scope                | Rename under #95                                  |
+| bb plugin package and ID       | Studio-named canonical ID                 | Host-supported state migration under #94/#95      |
+| Plugin source directory        | Studio-named canonical directory          | Change with source/ID migration                   |
+| Runtime executable/artifact    | Remove if #96 succeeds                    | Do not perpetuate only for naming compatibility   |
+| Runtime data root              | bb-owned plugin storage                   | Transactional catalog import under #100           |
+| Panel route                    | Studio-named route                        | Preserve old deep links through an explicit alias |
+| Skill technical ID/path        | Studio-named skill                        | Preserve old references through an explicit alias |
 
 Changing a preserved identity requires a separate migration with compatibility
 aliases, rollback, and proof that settings, KV/database state, catalog IDs, and
@@ -81,12 +83,13 @@ inspection; root format/check/test/build/visual; standalone and managed package
 clean rooms; Live bb; exact-head local reviews and hosted CI; GitButler clean;
 PR #73 unchanged.
 
-Stop before changing `mate`, `bb-plugin-mate`, `bb-mate`, `@bb-mate/*`, the
-runtime/data-root identities, route, or skill ID; before plugin removal or
-reinstallation; before merge, publication, release, upstream bb edits, or
-reuse of the old repository name.
+Do not mechanically change `mate`, `bb-plugin-mate`, `bb-mate`, `@bb-mate/*`,
+runtime/data-root identities, routes, or skill IDs. Those changes are now
+authorized only through the compatibility, preserve-state, and rollback work
+in #94/#95/#96. Still stop before plugin removal/reinstallation, publication,
+release, unapproved upstream edits, or reuse of the old repository name.
 
-## Current evidence
+## Historical Phase 1 evidence
 
 - Focused naming, package-inspector, CLI, browser-workbench, and Mate suites are
   green. The complete 716-test workspace aggregate, check, build, format, and

--- a/.agents/plans/2026-08-11-bb-scoped-plugin-inventory.md
+++ b/.agents/plans/2026-08-11-bb-scoped-plugin-inventory.md
@@ -1,9 +1,8 @@
 # bb-scoped Plugin Studio inventory
 
 Date: 2026-08-11
-Status: Ready-PR reconciliation; exact head `7bdcfc3b` has green hosted CI,
-two clean round-4 review lanes, and a resolved final review thread.
-Issue: [#82](https://github.com/galligan/bb-mate/issues/82)
+Status: Complete and merged; follow-up platform work tracked separately
+Issue: [#82](https://github.com/galligan/bb-plugin-studio/issues/82)
 Goal: `.agents/goals/2026-08-11-bb-scoped-plugin-inventory/`
 
 ## Outcome
@@ -22,7 +21,7 @@ project toward the top, but an idle eligible project remains visible.
 ```text
 Open Plugin Studio
   → read eligible projects from bb
-  → start/confirm one supervised Mate runtime
+  → start/confirm the then-current supervised runtime
   → revalidate every private source record
   → perform one globally bounded multi-root scan
   → return grouped path-free project/plugin states
@@ -212,9 +211,24 @@ process/environment facts, unknown keys, and impossible runtime/project states.
        lifecycle after the latest executable and shipped-skill changes.
 8. [x] Rebuild/reload the path plugin with state preserved and verify current
        Plugin Studio status/refresh behavior in released bb.
-9. [x] Obtain exact-head hosted CI and two clean review lanes, then reconcile
-       tracker/PR truth before moving PR #84 from draft to ready. No merge is
-       authorized.
+9. [x] Obtain exact-head hosted CI and two clean review lanes, reconcile
+       tracker/PR truth, and complete the reviewed merge sequence.
+
+## Post-completion reconciliation
+
+- PR #83 merged as `ff9289d1`; PR #84 merged as `13d892cd`.
+- Scanner simplification/hardening landed through PRs #89-#91; current `main`
+  at reconciliation is `84e80f5c`. PR #90's `verify` check was red at merge,
+  while the successor #91/main matrix is green; PR #92 separately tracks the
+  deterministic force-kill fixture repair and is open/green.
+- #82 is closed. Technical identity migration is #86, compatibility policy is
+  #93, native-runtime convergence is #96, and deferred per-directory hardening
+  is #97.
+- The later repository move left the installed path registration pointing at
+  the removed checkout. #94 owns the preserve-state repair; do not treat the
+  historical successful reload below as current live health.
+- The exact ready-PR evidence that follows remains historical proof of the
+  reviewed implementation, not the current tracker/installation state.
 
 The exact implementation head is `7bdcfc3b8379ad08e0d4cd5ea36ad4eb6da60b7a`
 (`fix: preserve Plugin Studio refreshes`), stacked on PR #83 head `1c897d5`.

--- a/.agents/plans/2026-08-12-bb-plugins-split.md
+++ b/.agents/plans/2026-08-12-bb-plugins-split.md
@@ -1,5 +1,8 @@
 # Split distributable plugins into bb-plugins
 
+Date: 2026-08-12
+Status: Complete; PR #88 merged and issue #87 closed
+
 ## Outcome
 
 Create a public `galligan/bb-plugins` repository that owns independently
@@ -43,3 +46,8 @@ focused on its workbench, inspection tooling, and the Studio-owned Mate plugin.
 - The full local Studio test command also reported unrelated macOS filesystem
   mode and process-timing failures in untouched tests. The pull request CI is
   the clean Linux verification gate for those suites.
+- PR #88 merged as `170e7d8c`; #87 was reconciled and closed on 2026-08-13.
+- No active Linear installation required a source retarget during the move, so
+  no reinstall or settings/secret migration was performed.
+- Publication and any future installed-source migration now live in
+  [galligan/bb-plugins#2](https://github.com/galligan/bb-plugins/issues/2).

--- a/.agents/plans/2026-08-13-plugin-studio-convergence.md
+++ b/.agents/plans/2026-08-13-plugin-studio-convergence.md
@@ -1,0 +1,106 @@
+# Plugin Studio identity, runtime, and compatibility convergence
+
+Date: 2026-08-13
+Status: Planned; tracker reconciled and implementation split into focused issues
+Parent: [#21](https://github.com/galligan/bb-plugin-studio/issues/21)
+
+## Outcome
+
+Finish the transition from the original Mate implementation to a native bb
+Plugin Studio:
+
+- maintained technical identities converge on `bb-plugin-studio` terminology;
+- existing users and installed state migrate transactionally rather than
+  through removal/reinstallation;
+- primary-host discovery no longer requires a packaged child runtime or private
+  loopback API;
+- enrolled-host discovery waits for a bounded public bb capability rather than
+  using hidden terminals or unrestricted execution; and
+- compatibility promises a minimum bb version while newer releases remain
+  usable and auditable.
+
+## Current verified state
+
+- The GitHub repository is `galligan/bb-plugin-studio`; the old repository URL
+  redirects correctly.
+- The visible product is Plugin Studio, but active technical identities still
+  include `bb-mate`, `@bb-mate/*`, `bb-plugin-mate`, `mate`, `plugins/mate`,
+  runtime/data-root names, `workbench`, and `plugin-workbench`.
+- The installed `mate` path source still targets the removed checkout path and
+  is unhealthy. Its persistent runtime database contains real catalog and event
+  state. Current bb has no supported preserve-state source-retarget operation.
+- bb 0.37 exposes public RPC, lifecycle, storage/migrations, HTTP/realtime, CLI,
+  project/thread, and tool surfaces sufficient to remove the child runtime for
+  primary-host discovery.
+- bb's current routed file listing is not a safe substitute for the hardened
+  scanner on enrolled hosts because traversal work is not bounded before
+  result truncation.
+- The existing `>=0.36` engine promise is open-ended, but the compatibility
+  checker incorrectly treats audited 0.36 as an exact installed version. bb
+  0.37 also changes backend declarations without changing the SDK package
+  version.
+
+## Work graph
+
+### Technical identity migration
+
+- [ ] [#86](https://github.com/galligan/bb-plugin-studio/issues/86) — parent
+- [ ] [#94](https://github.com/galligan/bb-plugin-studio/issues/94) — repair the
+      installed source through a supported preserve-state path
+- [ ] [#95](https://github.com/galligan/bb-plugin-studio/issues/95) — migrate
+      CLI/package/source/plugin/runtime identities with compatibility and
+      rollback
+
+Historical release evidence and Git history retain truthful old names. Current
+old-name exceptions must be isolated to a compatibility manifest/module and
+retired under a versioned policy.
+
+### Native-runtime convergence
+
+- [ ] [#96](https://github.com/galligan/bb-plugin-studio/issues/96) — parent
+- [ ] [#98](https://github.com/galligan/bb-plugin-studio/issues/98) — runtime
+      boundary ADR and live schema inventory
+- [ ] [#99](https://github.com/galligan/bb-plugin-studio/issues/99) — in-process
+      primary-host discovery with shadow parity
+- [ ] [#100](https://github.com/galligan/bb-plugin-studio/issues/100) — migrate
+      the target catalog into bb-owned plugin storage
+- [ ] [#101](https://github.com/galligan/bb-plugin-studio/issues/101) — remove
+      child supervision, private HTTP/auth, and packaged runtime
+- [ ] [#102](https://github.com/galligan/bb-plugin-studio/issues/102) — add
+      bounded host-routed discovery to public bb
+
+Critical path: #98 → (#99 and #100) → #101. #102 can proceed in parallel and
+blocks full enrolled-machine parity, but it does not block removing the child
+runtime for primary-host Studio use.
+
+### Compatibility and scanner hardening
+
+- [ ] [#93](https://github.com/galligan/bb-plugin-studio/issues/93) — minimum
+      `0.36.0`, separately tracked verified-through `0.37.0`, and a nonfatal
+      newer-than-verified result
+- [ ] [#97](https://github.com/galligan/bb-plugin-studio/issues/97) — bounded
+      per-directory enumeration and measured pathological-tree proof
+
+Required PR CI uses immutable exact minimum and exact verified-through lanes.
+Mutable npm latest runs on a scheduled, non-required audit lane that opens or
+updates one deduplicated drift issue.
+
+## Migration rules
+
+- Do not remove/reinstall a managed plugin to apply a rename.
+- Do not read, copy, log, or directly edit host-owned secrets or databases.
+- Preserve target IDs, revisions, scopes, retirements, relevant history, routes,
+  skills, deep links, and rollback through the identity/storage migration.
+- Do not replace the hardened scanner with `bb.sdk.files.listPaths`.
+- Never use hidden terminals or arbitrary command execution as a filesystem
+  compatibility layer.
+- No private bb imports.
+- No npm publication, release, upstream PR, primary-profile destructive
+  migration, or compatibility-alias retirement without separate authority.
+
+## Verification
+
+Each implementation issue owns focused tests and must also preserve the
+appropriate exact-minimum/current-bb typecheck, build, visual/axe, migration,
+clean-room, package inspection, live Plugin Studio, path-non-disclosure, and
+rollback gates. Hosted CI must be green before a PR leaves draft.


### PR DESCRIPTION
## Context

The visible product and repository rename are complete, the project inventory stack merged, Linear moved to `galligan/bb-plugins`, and follow-up scanner simplifications landed. The durable plans still described the pre-merge ready-PR state and intentionally preserved Mate technical identities that are now approved for migration.

## What changed

- add the current Plugin Studio convergence plan for technical identity migration, native-runtime convergence, compatibility policy, and scanner hardening
- mark the repository/product rename as Phase 1 and link the preserve-state identity migration
- reconcile the inventory plan/retro with merged PRs #83/#84 and follow-ups #89-#91
- mark the Linear split complete and link `galligan/bb-plugins#2` for publication/migration
- preserve old hashes, commands, and names only as explicitly historical evidence

## Tracker state

- #86 now owns identity migration with sub-issues #94/#95
- #96 owns native-runtime convergence with sub-issues #98-#102
- #93 defines minimum and verified-through bb compatibility
- #97 tracks deferred per-directory enumeration hardening
- #87 and the old Plugin Studio copy of #29 are closed; publication moved to `galligan/bb-plugins#2`

## Verification

- Prettier write/check on all five changed Markdown files
- `git diff --check`
- GitButler branch contains only the five plan/retro files

## Boundary

Documentation and tracker reconciliation only. No runtime/code migration, plugin source mutation, publication, release, upstream bb edit, or merge is included.
