### PR TITLE
fix: support bb compatibility boundaries

### DIFF
--- a/.bb/skills/update-bb-mate-compatibility/SKILL.md
+++ b/.bb/skills/update-bb-mate-compatibility/SKILL.md
@@ -6,8 +6,8 @@ description: Audit and adopt a newly released stable bb version in bb Plugin Stu
 # Update bb Plugin Studio Compatibility
 
 Keep the update evidence-led and reversible. Native bb owns plugin lifecycle and
-public contracts; bb Plugin Studio records, tests, and adopts released contracts without
-editing upstream or inventing substitutes.
+public contracts; bb Plugin Studio compatibility adoption records, tests, and
+adopts released contracts without editing upstream or inventing substitutes.
 
 ## Establish the release
 
@@ -43,20 +43,24 @@ editing upstream or inventing substitutes.
 - Compare the public SDK version and exports, component registry digest and
   item set, tracked dependency ranges, measured theme tokens, and public
   registration paths.
-- Run `bb plugin types --check plugins/linear`. If stale, refresh only through
+- Run `bb plugin types --check plugins/mate`. If stale, refresh only through
   the selected released bb and review the generated declaration diff.
-- Build the Linear plugin with the selected bb and inspect every
+- Build the Studio-owned integration plugin with the selected bb and inspect every
   `dist/*.meta.json` identity and SDK stamp.
-- Exercise `bb-mate inspect`, `check`, `dev`, and the guarded `live` handoff
-  against the isolated profile. Passive discovery must not execute plugin code.
+- Exercise `bun run bb-mate inspect`, `check`, `dev`, and the guarded `live`
+  handoff against the isolated profile. `bb-mate` is the current compatibility
+  command; passive discovery must not execute plugin code.
 - Compare representative Fixture states with live bb. Keep Fixture, Harness,
   and Live claims distinct; unavailable Harness support remains unavailable.
 
 ## Make the minimum adoption change
 
 - Update `compatibility/bb-target.json` only after reviewing the observations.
-- Keep the workspace `bb-app` build pin aligned with the verified release and
-  regenerate the lockfile through Bun.
+- Keep the workspace `bb-app` build pin aligned with the minimum release so the
+  default local/package lane continuously proves the support floor. Exercise
+  the verified-through and candidate releases through the exact isolated CI
+  installs; do not move the workspace pin merely to adopt a newer verified
+  boundary.
 - Update current compatibility and authoring instructions. Preserve dated
   trial reports and release handoffs as historical evidence.
 - Change implementation only when the released public contract requires it.
@@ -70,7 +74,7 @@ Run, at minimum:
 ```sh
 bun run compatibility:latest --json
 bun run compatibility:check
-bb plugin types --check plugins/linear
+bb plugin types --check plugins/mate
 bun run format:check
 bun run check
 bun run test

--- a/.bb/skills/update-bb-mate-compatibility/agents/openai.yaml
+++ b/.bb/skills/update-bb-mate-compatibility/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Update bb Plugin Studio Compatibility"
   short_description: "Audit and adopt new stable bb releases"
-  default_prompt: "Use $update-bb-mate-compatibility to check the latest stable bb release and prepare a verified compatibility update."
+  default_prompt: "Use $update-bb-mate-compatibility to check the latest stable bb release and prepare a verified Plugin Studio compatibility update."

--- a/.github/workflows/bb-compatibility-watch.yml
+++ b/.github/workflows/bb-compatibility-watch.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     permissions:
       contents: read
       issues: write
@@ -33,12 +33,60 @@ jobs:
           set -e
           if [ "$status" -eq 10 ]; then
             echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "version=$(jq -r .latestVersion bb-release-report.json)" >> "$GITHUB_OUTPUT"
           elif [ "$status" -eq 0 ]; then
             echo "drift=false" >> "$GITHUB_OUTPUT"
           else
             test ! -s bb-release-report.json || cat bb-release-report.json
             exit "$status"
           fi
+      - name: Audit npm stable without changing the committed target
+        if: steps.release.outputs.drift == 'true'
+        id: audit
+        shell: bash
+        run: |
+          version='${{ steps.release.outputs.version }}'
+          prefix="$RUNNER_TEMP/bb-latest"
+          npm install --prefix "$prefix" --ignore-scripts --no-audit --no-fund "bb-app@$version"
+          bb_cli="$prefix/node_modules/.bin/bb"
+
+          set +e
+          BB_CLI="$bb_cli" bun scripts/compatibility-check.ts \
+            --candidate-version "$version" --json > bb-candidate-report.json
+          contract_status=$?
+          "$bb_cli" plugin types plugins/mate
+          types_status=$?
+          bun --cwd plugins/mate run check
+          typecheck_status=$?
+          "$bb_cli" plugin build plugins/mate
+          build_status=$?
+          bun --cwd plugins/mate test
+          test_status=$?
+
+          # The managed-package clean room uses the plugin-local bb binary and
+          # a disposable data directory, so this replacement cannot touch a
+          # developer profile or the committed lockfile in the ephemeral runner.
+          bun add --cwd plugins/mate --no-save --ignore-scripts "bb-app@$version"
+          activation_install_status=$?
+          if [ "$activation_install_status" -eq 0 ]; then
+            BB_PLUGIN_STUDIO_EXPECTED_BB_VERSION="$version" bun run mate:package:test
+            activation_status=$?
+          else
+            activation_status=125
+          fi
+          set -e
+
+          {
+            echo "| Probe | Exit |"
+            echo "| --- | ---: |"
+            echo "| Immutable contract drift | $contract_status |"
+            echo "| Declaration generation | $types_status |"
+            echo "| Typecheck | $typecheck_status |"
+            echo "| Build | $build_status |"
+            echo "| Plugin tests | $test_status |"
+            echo "| Activation CLI install | $activation_install_status |"
+            echo "| Disposable managed activation | $activation_status |"
+          } > bb-candidate-smoke.md
       - name: Create or update the compatibility issue
         if: steps.release.outputs.drift == 'true'
         uses: actions/github-script@v9
@@ -48,7 +96,13 @@ jobs:
             const report = JSON.parse(
               fs.readFileSync("bb-release-report.json", "utf8"),
             );
-            const marker = "<!-- bb-mate-compatibility-watch -->";
+            const contract = fs.readFileSync(
+              "bb-candidate-report.json",
+              "utf8",
+            );
+            const smoke = fs.readFileSync("bb-candidate-smoke.md", "utf8");
+            const marker = "<!-- bb-plugin-studio-compatibility-watch -->";
+            const legacyMarker = "<!-- bb-mate-compatibility-watch -->";
             const title = `Adopt bb ${report.latestVersion}`;
             const body = [
               marker,
@@ -56,11 +110,23 @@ jobs:
               "## Compatibility drift detected",
               "",
               `npm's stable \`bb-app\` release is **${report.latestVersion}**;`,
-              `bb Plugin Studio currently targets **${report.targetVersion}**.`,
+              `bb Plugin Studio supports **${report.minimumVersion}+** and is`,
+              `verified through **${report.verifiedThroughVersion}**.`,
               "",
               "Use `$update-bb-mate-compatibility` from this repository to audit",
               "the immutable upstream release, run the isolated native and visual",
               "gates, and prepare a reviewable target update.",
+              "",
+              "## Isolated candidate probes",
+              "",
+              smoke,
+              "",
+              "<details><summary>Immutable contract report</summary>",
+              "",
+              "```json",
+              contract.trim(),
+              "```",
+              "</details>",
               "",
               "This issue was created by the scheduled compatibility watch. The",
               "automation does not edit code, upgrade bb, publish, or touch the",
@@ -76,7 +142,10 @@ jobs:
               },
             );
             const existing = issues.find(
-              (issue) => !issue.pull_request && issue.body?.includes(marker),
+              (issue) =>
+                !issue.pull_request &&
+                (issue.body?.includes(marker) ||
+                  issue.body?.includes(legacyMarker)),
             );
             if (existing) {
               await github.rest.issues.update({

--- a/.github/workflows/bb-compatibility.yml
+++ b/.github/workflows/bb-compatibility.yml
@@ -1,0 +1,45 @@
+name: BB compatibility
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  host-contract:
+    name: bb ${{ matrix.boundary }} boundary
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        boundary:
+          - minimumBbVersion
+          - verifiedThroughBbVersion
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - name: Install the exact boundary CLI in isolation
+        id: bb
+        shell: bash
+        run: |
+          version=$(jq -r '.target["${{ matrix.boundary }}"]' compatibility/bb-target.json)
+          test -n "$version" && test "$version" != null
+          prefix="$RUNNER_TEMP/bb-${{ matrix.boundary }}"
+          npm install --prefix "$prefix" --ignore-scripts --no-audit --no-fund "bb-app@$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "executable=$prefix/node_modules/.bin/bb" >> "$GITHUB_OUTPUT"
+      - name: Regenerate declarations from bb ${{ steps.bb.outputs.version }}
+        run: ${{ steps.bb.outputs.executable }} plugin types plugins/mate
+      - name: Typecheck against regenerated declarations
+        run: bun --cwd plugins/mate run check
+      - name: Build with the exact host CLI
+        run: ${{ steps.bb.outputs.executable }} plugin build plugins/mate
+      - name: Run plugin contract tests
+        run: bun --cwd plugins/mate test

--- a/compatibility/bb-target.json
+++ b/compatibility/bb-target.json
@@ -1,19 +1,31 @@
 {
   "$schema": "./bb-target.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "acceptedDecision": null,
   "target": {
-    "bbVersion": "0.36.0",
+    "minimumBbVersion": "0.36.0",
+    "verifiedThroughBbVersion": "0.37.0",
     "pluginSdkVersion": "0.4.1",
     "pluginSdkEngineRange": "^0.4.1",
-    "upstreamRef": "desktop-v0.36.0"
+    "upstreamRef": "desktop-v0.37.0"
   },
   "publicArtifacts": {
-    "appPackageUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.36.0/apps/app/package.json",
-    "pluginSdkPackageUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.36.0/packages/plugin-sdk/package.json",
-    "themeCssUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.36.0/apps/app/src/components/ui/theme.css",
+    "appPackageUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/apps/app/package.json",
+    "pluginSdkPackageUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-sdk/package.json",
+    "themeCssUrl": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/apps/app/src/components/ui/theme.css",
+    "themeCssSha256": "c2ed653f27a5836f98733a027425cfa87eff7ce9a43b3f6cac4723c315b83282",
+    "declarations": {
+      "backend": {
+        "url": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts",
+        "sha256": "92ed82ff874280ab0c239e11669da3ed040b800aa1e8dd59cdf9c617dafcaccb"
+      },
+      "app": {
+        "url": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-sdk/bundled-types/bb-plugin-sdk-app.d.ts",
+        "sha256": "984e0539c6926d42ddaf666c6b6890a567d08f711d9ae73a9b986620230eed9a"
+      }
+    },
     "registry": {
-      "url": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.36.0/packages/plugin-registry/r/index.json",
+      "url": "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-registry/r/index.json",
       "sha256": "ae65ae093d2435540e445707529337598cfa9f3446a8535986affef0939fe1e2",
       "items": [
         "accordion",

--- a/compatibility/bb-target.schema.json
+++ b/compatibility/bb-target.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://bb-mate.local/compatibility/bb-target.schema.json",
+  "$id": "https://raw.githubusercontent.com/galligan/bb-plugin-studio/main/compatibility/bb-target.schema.json",
   "title": "bb Plugin Studio compatibility target",
   "type": "object",
   "required": [
@@ -13,7 +13,7 @@
     "registrationPaths"
   ],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
     "acceptedDecision": {
       "type": ["string", "null"],
       "pattern": "^compatibility/decisions/[A-Za-z0-9._-]+\\.md$"
@@ -21,11 +21,20 @@
     "target": {
       "type": "object",
       "required": [
-        "bbVersion",
+        "minimumBbVersion",
+        "verifiedThroughBbVersion",
         "pluginSdkVersion",
         "pluginSdkEngineRange",
         "upstreamRef"
-      ]
+      ],
+      "properties": {
+        "minimumBbVersion": { "type": "string" },
+        "verifiedThroughBbVersion": { "type": "string" },
+        "pluginSdkVersion": { "type": "string" },
+        "pluginSdkEngineRange": { "type": "string" },
+        "upstreamRef": { "type": "string" }
+      },
+      "additionalProperties": false
     },
     "publicArtifacts": {
       "type": "object",
@@ -33,8 +42,27 @@
         "appPackageUrl",
         "pluginSdkPackageUrl",
         "themeCssUrl",
+        "themeCssSha256",
+        "declarations",
         "registry"
-      ]
+      ],
+      "properties": {
+        "appPackageUrl": { "type": "string", "format": "uri" },
+        "pluginSdkPackageUrl": { "type": "string", "format": "uri" },
+        "themeCssUrl": { "type": "string", "format": "uri" },
+        "themeCssSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "declarations": {
+          "type": "object",
+          "required": ["backend", "app"],
+          "properties": {
+            "backend": { "$ref": "#/$defs/hashedArtifact" },
+            "app": { "$ref": "#/$defs/hashedArtifact" }
+          },
+          "additionalProperties": false
+        },
+        "registry": { "type": "object" }
+      },
+      "additionalProperties": false
     },
     "dependencies": { "type": "array", "minItems": 1 },
     "measuredTokens": { "type": "array", "minItems": 1 },
@@ -45,5 +73,16 @@
       "uniqueItems": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "$defs": {
+    "hashedArtifact": {
+      "type": "object",
+      "required": ["url", "sha256"],
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/docs/compatibility-target.md
+++ b/docs/compatibility-target.md
@@ -1,8 +1,22 @@
 # bb Plugin Studio compatibility target
 
-`compatibility/bb-target.json` is the reviewable record of the public bb
-contracts and deliberately measured fixture values that bb Plugin Studio targets. The
-check is an alarm, not an updater.
+`compatibility/bb-target.json` is the reviewable record of bb Plugin Studio's
+host support policy, public bb contracts, and deliberately measured fixture
+values. The check is an alarm, not an updater.
+
+The policy separates three values:
+
+- `minimumBbVersion` is the oldest promised host (`0.36.0`). A lower observed
+  version fails as unsupported.
+- `verifiedThroughBbVersion` is the newest immutable release fully audited
+  (`0.37.0`). Versions from the minimum through this boundary pass.
+- the observed version comes from the selected native `bb` executable. A newer
+  version emits a nonfatal `notice`; its presence alone never makes an ordinary
+  repository check fail.
+
+`plugins/mate/package.json` expresses the same open-ended host floor as
+`engines.bb: ">=0.36.0"`. The SDK contract remains independent in
+`engines.bbPluginSdk`.
 
 ```sh
 bun run compatibility:check
@@ -12,7 +26,10 @@ bun run compatibility:latest --json
 
 The check reads local manifests, the surface catalog, and the small named token
 set; executes only `bb --version`; and fetches immutable public artifacts from
-the recorded bb release tag. `BB_CLI` wins when set, then `bb` on `PATH`, then
+the verified-through bb release tag. It hashes the complete public theme,
+component registry, backend SDK declaration bundle, and app SDK declaration
+bundle. Declaration hashes are checked even when the SDK package version is
+unchanged. `BB_CLI` wins when set, then `bb` on `PATH`, then
 the workspace's pinned `bb-app` binary so clean CI observes the same release
 used for plugin builds. It does not load plugin code, contact Connect, or use
 the sibling bb checkout. A failed network or native probe is `unverified` and
@@ -22,20 +39,55 @@ The target is validated before any network request. Guard lists must be
 non-empty and unique, and artifact URLs must be exact immutable paths on
 `raw.githubusercontent.com/get-bb/bb`. Redirects are rejected.
 
-`compatibility:latest` compares the committed target with npm's stable
+`compatibility:latest` compares the verified-through boundary with npm's stable
 `bb-app` release. It exits 0 when current, 10 when a newer release is
 available, and 1 for an invalid or unverified state. It never edits the target
 or upgrades bb. The scheduled compatibility watch uses that result to maintain
-one deduplicated GitHub issue. Perform the resulting work with the repository's
-`$update-bb-mate-compatibility` skill.
+one deduplicated GitHub issue.
+
+The required `BB compatibility` workflow reads both boundary versions from the
+manifest, installs each exact CLI in isolation, regenerates declarations, then
+typechecks, builds, and tests the Mate plugin. The scheduled watch is separate
+from pull-request CI. For a newer npm release it projects only immutable probe
+URLs to that release (without accepting new hashes), runs the same declaration,
+typecheck, build, and test probes, and exercises managed activation in a
+disposable profile. Drift updates an issue; it cannot turn an unrelated pull
+request red.
+
+For a one-off candidate audit:
+
+```sh
+BB_CLI=/absolute/path/to/candidate-bb \
+  bun run compatibility:check --candidate-version 0.38.0 --json
+```
+
+Candidate projection preserves the committed hashes, so changed declarations,
+registry data, or theme CSS remain actionable failures rather than being
+silently accepted.
+
+## Verified 0.37.0 evidence
+
+The `0.37.0` audit recorded:
+
+- component registry digest and item inventory unchanged from `0.36.0`;
+- the tracked sidebar row-height tokens unchanged;
+- the complete theme changed (`8fc5264c…` to `c2ed653f…`);
+- backend SDK declarations changed (`5c7c8349…` to `92ed82ff…`) while the
+  package version remained `0.4.1`;
+- app SDK declarations unchanged (`984e0539…`).
+
+The committed manifest contains the full verified-through hashes. The shortened
+values above are for human comparison only.
 
 ## Updating the target
 
 1. Read every failed check and its next action. Do not update values merely to
    make CI green.
-2. Inspect the public diff between the old and proposed bb release refs. Review
-   registry item and digest changes together. Reconcile SDK and registration
-   changes with the public surface catalog first.
+2. Inspect the public diff between the old and proposed verified-through refs.
+   Review registry item and digest changes together. Review backend and app
+   declaration hashes independently, even if `@bb/plugin-sdk` has the same
+   version. Reconcile SDK and registration changes with the public surface
+   catalog first.
 3. Run the full repository gate against the proposed values.
 4. Open live bb at the proposed version and manually compare the representative
    sidebar and composer fixtures at their recorded viewport. Confirm row
@@ -44,7 +96,16 @@ one deduplicated GitHub issue. Perform the resulting work with the repository's
    a green fixture check is not parity proof.
 5. Record the live comparison and rationale in the pull request. Update only
    `compatibility/bb-target.json` and code genuinely required by the public
-   contract. The expected target-only change should remain a small diff.
+   contract. Raising the verified-through boundary does not automatically raise
+   the minimum version.
+
+The workspace `plugins/mate` `bb-app` pin stays on `minimumBbVersion`. It makes
+the ordinary build and package lifecycle a continuous floor check. The required
+verified-through lane and the scheduled candidate audit install their exact bb
+versions in isolation; the candidate package probe supplies that exact version
+to the strict metadata inspector through
+`BB_PLUGIN_STUDIO_EXPECTED_BB_VERSION`. This override changes the expected build
+stamp only. It does not relax the engine range or any package-integrity check.
 
 The local Inter range intentionally differs from the targeted bb app range.
 Both values are recorded so either change is visible instead of being silently

--- a/plugins/mate/package.json
+++ b/plugins/mate/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "engines": {
-    "bb": ">=0.36",
+    "bb": ">=0.36.0",
     "bbPluginSdk": "^0.4.1"
   },
   "bb": {

--- a/scripts/check-latest-bb.test.ts
+++ b/scripts/check-latest-bb.test.ts
@@ -23,17 +23,20 @@ describe("stable bb release comparison", () => {
 
 describe("bb release drift report", () => {
   test("is quiet-state compatible when the target is current", () => {
-    expect(evaluateBbRelease("0.36.0", "0.36.0")).toMatchObject({
-      targetVersion: "0.36.0",
-      latestVersion: "0.36.0",
+    expect(evaluateBbRelease("0.36.0", "0.37.0", "0.37.0")).toMatchObject({
+      minimumVersion: "0.36.0",
+      verifiedThroughVersion: "0.37.0",
+      latestVersion: "0.37.0",
       status: "current",
     });
   });
 
   test("distinguishes an update from a suspicious target-ahead state", () => {
-    expect(evaluateBbRelease("0.36.0", "0.37.0").status).toBe(
+    expect(evaluateBbRelease("0.36.0", "0.37.0", "0.38.0").status).toBe(
       "update-available",
     );
-    expect(evaluateBbRelease("0.37.0", "0.36.0").status).toBe("target-ahead");
+    expect(evaluateBbRelease("0.36.0", "0.37.0", "0.36.0").status).toBe(
+      "target-ahead",
+    );
   });
 });

--- a/scripts/check-latest-bb.ts
+++ b/scripts/check-latest-bb.ts
@@ -13,7 +13,8 @@ export type BbReleaseStatus = "current" | "update-available" | "target-ahead";
 export interface BbReleaseReport {
   schemaVersion: 1;
   package: "bb-app";
-  targetVersion: string;
+  minimumVersion: string;
+  verifiedThroughVersion: string;
   latestVersion: string;
   status: BbReleaseStatus;
   registryUrl: string;
@@ -37,14 +38,19 @@ export function compareStableVersions(left: string, right: string): number {
 }
 
 export function evaluateBbRelease(
-  targetVersion: string,
+  minimumVersion: string,
+  verifiedThroughVersion: string,
   latestVersion: string,
 ): BbReleaseReport {
-  const comparison = compareStableVersions(latestVersion, targetVersion);
+  const comparison = compareStableVersions(
+    latestVersion,
+    verifiedThroughVersion,
+  );
   return {
     schemaVersion: 1,
     package: "bb-app",
-    targetVersion,
+    minimumVersion,
+    verifiedThroughVersion,
     latestVersion,
     status:
       comparison > 0
@@ -60,10 +66,18 @@ export async function checkLatestBbRelease(
   fetcher: typeof fetch = fetch,
 ): Promise<BbReleaseReport> {
   const target = JSON.parse(await readFile(targetPath, "utf8")) as {
-    target?: { bbVersion?: unknown };
+    target?: {
+      minimumBbVersion?: unknown;
+      verifiedThroughBbVersion?: unknown;
+    };
   };
-  if (typeof target.target?.bbVersion !== "string") {
-    throw new Error("compatibility/bb-target.json has no target.bbVersion.");
+  if (
+    typeof target.target?.minimumBbVersion !== "string" ||
+    typeof target.target?.verifiedThroughBbVersion !== "string"
+  ) {
+    throw new Error(
+      "compatibility/bb-target.json must declare minimum and verified-through bb versions.",
+    );
   }
   const response = await fetcher(registryUrl, {
     headers: { "user-agent": "bb-mate-release-check" },
@@ -79,15 +93,19 @@ export async function checkLatestBbRelease(
   if (typeof latest.version !== "string") {
     throw new Error("npm registry response has no version.");
   }
-  return evaluateBbRelease(target.target.bbVersion, latest.version);
+  return evaluateBbRelease(
+    target.target.minimumBbVersion,
+    target.target.verifiedThroughBbVersion,
+    latest.version,
+  );
 }
 
 function formatReport(report: BbReleaseReport): string {
   if (report.status === "current") return "";
   if (report.status === "update-available") {
-    return `bb-app ${report.latestVersion} is available; bb Plugin Studio targets ${report.targetVersion}.\n`;
+    return `bb-app ${report.latestVersion} is available; bb Plugin Studio is verified through ${report.verifiedThroughVersion}.\n`;
   }
-  return `bb Plugin Studio targets ${report.targetVersion}, ahead of npm latest ${report.latestVersion}.\n`;
+  return `bb Plugin Studio is verified through ${report.verifiedThroughVersion}, ahead of npm latest ${report.latestVersion}.\n`;
 }
 
 async function main(): Promise<void> {

--- a/scripts/compatibility-check.test.ts
+++ b/scripts/compatibility-check.test.ts
@@ -7,6 +7,7 @@ import {
   formatCompatibilityReport,
   observeBbVersion,
   parseCompatibilityTarget,
+  projectCompatibilityTargetToRelease,
   resolveCompatibilityDecisionPath,
   validCompatibilityDecision,
   type CompatibilityObservations,
@@ -58,24 +59,36 @@ describe("native bb version probe", () => {
 });
 
 const target: CompatibilityTarget = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   acceptedDecision: null,
   target: {
-    bbVersion: "0.35.1",
+    minimumBbVersion: "0.36.0",
+    verifiedThroughBbVersion: "0.37.0",
     pluginSdkVersion: "0.4.1",
     pluginSdkEngineRange: "^0.4.1",
-    upstreamRef: "desktop-v0.35.1",
+    upstreamRef: "desktop-v0.37.0",
   },
   publicArtifacts: {
     appPackageUrl:
-      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/apps/app/package.json",
+      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/apps/app/package.json",
     pluginSdkPackageUrl:
-      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/packages/plugin-sdk/package.json",
+      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-sdk/package.json",
     themeCssUrl:
-      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/apps/app/src/components/ui/theme.css",
+      "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/apps/app/src/components/ui/theme.css",
+    themeCssSha256: "c".repeat(64),
+    declarations: {
+      backend: {
+        url: "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts",
+        sha256: "d".repeat(64),
+      },
+      app: {
+        url: "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-sdk/bundled-types/bb-plugin-sdk-app.d.ts",
+        sha256: "e".repeat(64),
+      },
+    },
     registry: {
-      url: "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.35.1/packages/plugin-registry/r/index.json",
-      sha256: "abc",
+      url: "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.37.0/packages/plugin-registry/r/index.json",
+      sha256: "a".repeat(64),
       items: ["button"],
     },
   },
@@ -100,11 +113,13 @@ const target: CompatibilityTarget = {
 
 function matchingObservations(): CompatibilityObservations {
   return {
-    bbVersion: "0.35.1",
+    bbVersion: "0.36.0",
     pluginSdkEngineRange: "^0.4.1",
     pluginSdkVersion: "0.4.1",
-    registrySha256: "abc",
+    registrySha256: "a".repeat(64),
     registryItems: ["button"],
+    themeCssSha256: "c".repeat(64),
+    declarationSha256: { backend: "d".repeat(64), app: "e".repeat(64) },
     dependencies: { icons: { local: "^1.0.0", upstream: "^1.0.0" } },
     tokens: { "--row-height": { local: "1rem", upstream: "1rem" } },
     registrationPaths: ["slots.example"],
@@ -112,10 +127,44 @@ function matchingObservations(): CompatibilityObservations {
 }
 
 describe("compatibility evaluation", () => {
-  test("passes a completely matching observation", () => {
+  test("passes the exact minimum supported host", () => {
     const report = evaluateCompatibility(target, matchingObservations());
     expect(report.outcome).toBe("pass");
     expect(report.checks.every(({ status }) => status === "pass")).toBe(true);
+  });
+
+  test("passes a host at the verified-through boundary", () => {
+    const observed = matchingObservations();
+    observed.bbVersion = "0.37.0";
+    const report = evaluateCompatibility(target, observed);
+    expect(report.outcome).toBe("pass");
+    expect(report.checks.find(({ id }) => id === "bb.version")).toMatchObject({
+      status: "pass",
+      observed: "0.37.0",
+    });
+  });
+
+  test("fails a host below the minimum supported version", () => {
+    const observed = matchingObservations();
+    observed.bbVersion = "0.35.9";
+    const report = evaluateCompatibility(target, observed);
+    expect(report.outcome).toBe("fail");
+    expect(report.checks.find(({ id }) => id === "bb.version")).toMatchObject({
+      status: "fail",
+      observed: "0.35.9",
+    });
+  });
+
+  test("reports a newer-than-verified host without failing", () => {
+    const observed = matchingObservations();
+    observed.bbVersion = "0.38.0";
+    const report = evaluateCompatibility(target, observed);
+    expect(report.outcome).toBe("pass");
+    expect(report.checks.find(({ id }) => id === "bb.version")).toMatchObject({
+      status: "notice",
+      observed: "0.38.0",
+      nextAction: expect.stringContaining("audit"),
+    });
   });
 
   test("fails when release identity and immutable URLs diverge", () => {
@@ -134,11 +183,6 @@ describe("compatibility evaluation", () => {
   });
 
   test.each([
-    [
-      "bb version",
-      (value: CompatibilityObservations) => (value.bbVersion = "0.36.0"),
-      "bb.version",
-    ],
     [
       "SDK engine",
       (value: CompatibilityObservations) =>
@@ -160,6 +204,24 @@ describe("compatibility evaluation", () => {
       (value: CompatibilityObservations) =>
         (value.registryItems = ["button", "card"]),
       "component-registry.items",
+    ],
+    [
+      "full theme",
+      (value: CompatibilityObservations) =>
+        (value.themeCssSha256 = "theme-def"),
+      "theme.sha256",
+    ],
+    [
+      "backend declarations",
+      (value: CompatibilityObservations) =>
+        (value.declarationSha256.backend = "backend-def"),
+      "plugin-sdk.declaration.backend.sha256",
+    ],
+    [
+      "app declarations",
+      (value: CompatibilityObservations) =>
+        (value.declarationSha256.app = "app-def"),
+      "plugin-sdk.declaration.app.sha256",
     ],
     [
       "local dependency",
@@ -225,7 +287,7 @@ describe("compatibility evaluation", () => {
 
   test("formats a concise actionable terminal report", () => {
     const observed = matchingObservations();
-    observed.bbVersion = "0.36.0";
+    observed.bbVersion = "0.34.0";
     const output = formatCompatibilityReport(
       evaluateCompatibility(target, observed),
     );
@@ -291,6 +353,35 @@ describe("target validation", () => {
       }),
     ).toThrow("immutable public");
   });
+
+  test("rejects malformed immutable artifact hashes", () => {
+    expect(() =>
+      parseCompatibilityTarget({
+        ...target,
+        publicArtifacts: {
+          ...target.publicArtifacts,
+          themeCssSha256: "not-a-sha256",
+        },
+      }),
+    ).toThrow("SHA-256");
+  });
+});
+
+test("projects immutable probe URLs to a candidate without accepting new hashes", () => {
+  const projected = projectCompatibilityTargetToRelease(target, "0.38.0");
+  expect(projected.target).toMatchObject({
+    minimumBbVersion: "0.36.0",
+    verifiedThroughBbVersion: "0.38.0",
+    upstreamRef: "desktop-v0.38.0",
+  });
+  expect(projected.publicArtifacts.themeCssUrl).toContain("desktop-v0.38.0");
+  expect(projected.publicArtifacts.declarations.backend.url).toContain(
+    "desktop-v0.38.0",
+  );
+  expect(projected.publicArtifacts.themeCssSha256).toBe("c".repeat(64));
+  expect(projected.publicArtifacts.declarations.backend.sha256).toBe(
+    "d".repeat(64),
+  );
 });
 
 test("the checked-in target mirrors the catalog registration paths", async () => {

--- a/scripts/compatibility-check.ts
+++ b/scripts/compatibility-check.ts
@@ -25,10 +25,11 @@ interface TokenTarget {
 }
 
 export interface CompatibilityTarget {
-  schemaVersion: 1;
+  schemaVersion: 2;
   acceptedDecision?: string | null;
   target: {
-    bbVersion: string;
+    minimumBbVersion: string;
+    verifiedThroughBbVersion: string;
     pluginSdkVersion: string;
     pluginSdkEngineRange: string;
     upstreamRef: string;
@@ -37,6 +38,8 @@ export interface CompatibilityTarget {
     appPackageUrl: string;
     pluginSdkPackageUrl: string;
     themeCssUrl: string;
+    themeCssSha256: string;
+    declarations: Record<"backend" | "app", { url: string; sha256: string }>;
     registry: { url: string; sha256: string; items: string[] };
   };
   dependencies: DependencyTarget[];
@@ -67,12 +70,16 @@ export interface CompatibilityObservations {
   registrySha256?: string;
   registryItems?: string[];
   registryError?: string;
+  themeCssSha256?: string;
+  themeCssError?: string;
+  declarationSha256: Partial<Record<"backend" | "app", string>>;
+  declarationErrors?: Partial<Record<"backend" | "app", string>>;
   dependencies: Record<string, DependencyObservation>;
   tokens: Record<string, TokenObservation>;
   registrationPaths: string[];
 }
 
-export type CompatibilityStatus = "pass" | "fail" | "unverified";
+export type CompatibilityStatus = "pass" | "fail" | "unverified" | "notice";
 
 export interface CompatibilityCheck {
   id: string;
@@ -115,6 +122,68 @@ function exactCheck(
     : { id, status: "fail", target, observed, nextAction };
 }
 
+function semanticVersion(version: string): [number, number, number, string?] {
+  const match =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?$/.exec(
+      version,
+    );
+  if (!match) throw new Error(`Expected a semantic version, got ${version}.`);
+  return [Number(match[1]), Number(match[2]), Number(match[3]), match[4]];
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = semanticVersion(left);
+  const rightParts = semanticVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = Number(leftParts[index]) - Number(rightParts[index]);
+    if (difference !== 0) return Math.sign(difference);
+  }
+  if (leftParts[3] === rightParts[3]) return 0;
+  if (leftParts[3] === undefined) return 1;
+  if (rightParts[3] === undefined) return -1;
+  return leftParts[3].localeCompare(rightParts[3]);
+}
+
+function bbVersionCheck(
+  target: CompatibilityTarget["target"],
+  observed?: string,
+  error?: string,
+): CompatibilityCheck {
+  const supported = {
+    minimum: target.minimumBbVersion,
+    verifiedThrough: target.verifiedThroughBbVersion,
+  };
+  if (error || observed === undefined) {
+    return {
+      id: "bb.version",
+      status: "unverified",
+      target: supported,
+      observed: error ?? "No observation was produced.",
+      nextAction: "Install a supported bb release and rerun the probe.",
+    };
+  }
+  if (compareVersions(observed, target.minimumBbVersion) < 0) {
+    return {
+      id: "bb.version",
+      status: "fail",
+      target: supported,
+      observed,
+      nextAction: `Upgrade bb to ${target.minimumBbVersion} or newer.`,
+    };
+  }
+  if (compareVersions(observed, target.verifiedThroughBbVersion) > 0) {
+    return {
+      id: "bb.version",
+      status: "notice",
+      target: supported,
+      observed,
+      nextAction:
+        "Run the latest-release compatibility audit; this installed version is newer than the verified-through boundary.",
+    };
+  }
+  return { id: "bb.version", status: "pass", target: supported, observed };
+}
+
 export function evaluateCompatibility(
   target: CompatibilityTarget,
   observed: CompatibilityObservations,
@@ -124,15 +193,9 @@ export function evaluateCompatibility(
       "target.release-coherence",
       [],
       targetCoherenceIssues(target),
-      "Make upstreamRef, bbVersion, SDK range, and every public artifact URL identify one release.",
+      "Make upstreamRef, verifiedThroughBbVersion, SDK range, and every public artifact URL identify one release.",
     ),
-    exactCheck(
-      "bb.version",
-      target.target.bbVersion,
-      observed.bbVersion,
-      "Install the targeted bb release or update compatibility/bb-target.json after verification.",
-      observed.bbError,
-    ),
+    bbVersionCheck(target.target, observed.bbVersion, observed.bbError),
     exactCheck(
       "plugin-sdk.engine-range",
       target.target.pluginSdkEngineRange,
@@ -159,6 +222,22 @@ export function evaluateCompatibility(
       observed.registryItems,
       "Review added or removed public components before updating the recorded item list.",
       observed.registryError,
+    ),
+    exactCheck(
+      "theme.sha256",
+      target.publicArtifacts.themeCssSha256,
+      observed.themeCssSha256,
+      "Review the complete public theme diff before updating the verified-through target.",
+      observed.themeCssError,
+    ),
+    ...(["backend", "app"] as const).map((name) =>
+      exactCheck(
+        `plugin-sdk.declaration.${name}.sha256`,
+        target.publicArtifacts.declarations[name].sha256,
+        observed.declarationSha256[name],
+        `Review the ${name} SDK declaration diff even if the SDK package version is unchanged.`,
+        observed.declarationErrors?.[name],
+      ),
     ),
   ];
 
@@ -218,14 +297,18 @@ export function evaluateCompatibility(
   return {
     schemaVersion: 1,
     upstreamRef: target.target.upstreamRef,
-    outcome: checks.every(({ status }) => status === "pass") ? "pass" : "fail",
+    outcome: checks.every(
+      ({ status }) => status === "pass" || status === "notice",
+    )
+      ? "pass"
+      : "fail",
     checks,
   };
 }
 
 function targetCoherenceIssues(target: CompatibilityTarget): string[] {
   const issues: string[] = [];
-  const expectedRef = `desktop-v${target.target.bbVersion}`;
+  const expectedRef = `desktop-v${target.target.verifiedThroughBbVersion}`;
   if (target.target.upstreamRef !== expectedRef) {
     issues.push(`upstreamRef must be ${expectedRef}`);
   }
@@ -234,11 +317,21 @@ function targetCoherenceIssues(target: CompatibilityTarget): string[] {
   ) {
     issues.push("plugin SDK engine range must target the recorded SDK version");
   }
+  if (
+    compareVersions(
+      target.target.minimumBbVersion,
+      target.target.verifiedThroughBbVersion,
+    ) > 0
+  ) {
+    issues.push("minimum bb version cannot exceed verified-through bb version");
+  }
   const urls = [
     target.publicArtifacts.appPackageUrl,
     target.publicArtifacts.pluginSdkPackageUrl,
     target.publicArtifacts.themeCssUrl,
     target.publicArtifacts.registry.url,
+    target.publicArtifacts.declarations.backend.url,
+    target.publicArtifacts.declarations.app.url,
   ];
   if (urls.some((url) => !url.includes(`/${target.target.upstreamRef}/`))) {
     issues.push(
@@ -333,6 +426,7 @@ export async function collectCompatibilityObservations(
   const observed: CompatibilityObservations = {
     dependencies: {},
     tokens: {},
+    declarationSha256: {},
     registrationPaths: surfaceCatalog.map(
       ({ registrationPath }) => registrationPath,
     ),
@@ -423,13 +517,33 @@ export async function collectCompatibilityObservations(
   let upstreamCss: string | undefined;
   try {
     upstreamCss = await fetchText(target.publicArtifacts.themeCssUrl);
+    observed.themeCssSha256 = createHash("sha256")
+      .update(upstreamCss)
+      .digest("hex");
   } catch (error) {
     const detail = `Could not read public theme CSS: ${message(error)}`;
+    observed.themeCssError = detail;
     for (const token of target.measuredTokens) {
       if (token.upstreamValue !== undefined)
         observed.tokens[token.name] = { upstreamError: detail };
     }
   }
+  await Promise.all(
+    (["backend", "app"] as const).map(async (name) => {
+      try {
+        const declarations = await fetchText(
+          target.publicArtifacts.declarations[name].url,
+        );
+        observed.declarationSha256[name] = createHash("sha256")
+          .update(declarations)
+          .digest("hex");
+      } catch (error) {
+        observed.declarationErrors ??= {};
+        observed.declarationErrors[name] =
+          `Could not read public ${name} declarations: ${message(error)}`;
+      }
+    }),
+  );
   for (const token of target.measuredTokens) {
     const current = observed.tokens[token.name] ?? {};
     observed.tokens[token.name] = {
@@ -494,7 +608,7 @@ export function formatCompatibilityReport(report: CompatibilityReport): string {
   ];
   for (const check of report.checks) {
     lines.push(
-      `${check.status === "pass" ? "✓" : "✗"} ${check.id}: ${check.status}`,
+      `${check.status === "pass" ? "✓" : check.status === "notice" ? "!" : "✗"} ${check.id}: ${check.status}`,
     );
     if (check.status !== "pass") {
       lines.push(`  targeted: ${serialized(check.target)}`);
@@ -518,6 +632,14 @@ function string(value: unknown, name: string): string {
     throw new Error(`${name} must be a non-empty string.`);
   }
   return value;
+}
+
+function sha256(value: unknown, name: string): string {
+  const text = string(value, name);
+  if (!/^[a-f0-9]{64}$/.test(text)) {
+    throw new Error(`${name} must be a lowercase SHA-256 digest.`);
+  }
+  return text;
 }
 
 function stringArray(value: unknown, name: string): string[] {
@@ -557,9 +679,18 @@ function publicArtifactUrl(
 
 export function parseCompatibilityTarget(value: unknown): CompatibilityTarget {
   const root = record(value, "compatibility target");
-  if (root.schemaVersion !== 1) throw new Error("schemaVersion must be 1.");
+  if (root.schemaVersion !== 2) throw new Error("schemaVersion must be 2.");
   const target = record(root.target, "target");
-  const bbVersion = string(target.bbVersion, "target.bbVersion");
+  const minimumBbVersion = string(
+    target.minimumBbVersion,
+    "target.minimumBbVersion",
+  );
+  const verifiedThroughBbVersion = string(
+    target.verifiedThroughBbVersion,
+    "target.verifiedThroughBbVersion",
+  );
+  semanticVersion(minimumBbVersion);
+  semanticVersion(verifiedThroughBbVersion);
   const pluginSdkVersion = string(
     target.pluginSdkVersion,
     "target.pluginSdkVersion",
@@ -571,6 +702,10 @@ export function parseCompatibilityTarget(value: unknown): CompatibilityTarget {
   const upstreamRef = string(target.upstreamRef, "target.upstreamRef");
   const artifacts = record(root.publicArtifacts, "publicArtifacts");
   const registry = record(artifacts.registry, "publicArtifacts.registry");
+  const declarations = record(
+    artifacts.declarations,
+    "publicArtifacts.declarations",
+  );
   const dependencies = (
     Array.isArray(root.dependencies) ? root.dependencies : []
   ).map((entry, index) => {
@@ -627,9 +762,15 @@ export function parseCompatibilityTarget(value: unknown): CompatibilityTarget {
     );
   }
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     acceptedDecision,
-    target: { bbVersion, pluginSdkVersion, pluginSdkEngineRange, upstreamRef },
+    target: {
+      minimumBbVersion,
+      verifiedThroughBbVersion,
+      pluginSdkVersion,
+      pluginSdkEngineRange,
+      upstreamRef,
+    },
     publicArtifacts: {
       appPackageUrl: publicArtifactUrl(
         artifacts.appPackageUrl,
@@ -649,6 +790,33 @@ export function parseCompatibilityTarget(value: unknown): CompatibilityTarget {
         "apps/app/src/components/ui/theme.css",
         "publicArtifacts.themeCssUrl",
       ),
+      themeCssSha256: sha256(
+        artifacts.themeCssSha256,
+        "publicArtifacts.themeCssSha256",
+      ),
+      declarations: Object.fromEntries(
+        (["backend", "app"] as const).map((name) => {
+          const declaration = record(
+            declarations[name],
+            `publicArtifacts.declarations.${name}`,
+          );
+          return [
+            name,
+            {
+              url: publicArtifactUrl(
+                declaration.url,
+                upstreamRef,
+                `packages/plugin-sdk/bundled-types/bb-plugin-sdk${name === "app" ? "-app" : ""}.d.ts`,
+                `publicArtifacts.declarations.${name}.url`,
+              ),
+              sha256: sha256(
+                declaration.sha256,
+                `publicArtifacts.declarations.${name}.sha256`,
+              ),
+            },
+          ];
+        }),
+      ) as CompatibilityTarget["publicArtifacts"]["declarations"],
       registry: {
         url: publicArtifactUrl(
           registry.url,
@@ -656,7 +824,7 @@ export function parseCompatibilityTarget(value: unknown): CompatibilityTarget {
           "packages/plugin-registry/r/index.json",
           "publicArtifacts.registry.url",
         ),
-        sha256: string(registry.sha256, "publicArtifacts.registry.sha256"),
+        sha256: sha256(registry.sha256, "publicArtifacts.registry.sha256"),
         items: stringArray(registry.items, "publicArtifacts.registry.items"),
       },
     },
@@ -672,22 +840,78 @@ export async function loadCompatibilityTarget(): Promise<CompatibilityTarget> {
   );
 }
 
+export function projectCompatibilityTargetToRelease(
+  target: CompatibilityTarget,
+  version: string,
+): CompatibilityTarget {
+  semanticVersion(version);
+  const from = `/${target.target.upstreamRef}/`;
+  const upstreamRef = `desktop-v${version}`;
+  const to = `/${upstreamRef}/`;
+  const projectUrl = (url: string) => url.replace(from, to);
+  return {
+    ...target,
+    target: {
+      ...target.target,
+      verifiedThroughBbVersion: version,
+      upstreamRef,
+    },
+    publicArtifacts: {
+      ...target.publicArtifacts,
+      appPackageUrl: projectUrl(target.publicArtifacts.appPackageUrl),
+      pluginSdkPackageUrl: projectUrl(
+        target.publicArtifacts.pluginSdkPackageUrl,
+      ),
+      themeCssUrl: projectUrl(target.publicArtifacts.themeCssUrl),
+      declarations: {
+        backend: {
+          ...target.publicArtifacts.declarations.backend,
+          url: projectUrl(target.publicArtifacts.declarations.backend.url),
+        },
+        app: {
+          ...target.publicArtifacts.declarations.app,
+          url: projectUrl(target.publicArtifacts.declarations.app.url),
+        },
+      },
+      registry: {
+        ...target.publicArtifacts.registry,
+        url: projectUrl(target.publicArtifacts.registry.url),
+      },
+    },
+  };
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const json = args.includes("--json");
+  const candidateIndex = args.indexOf("--candidate-version");
+  const candidateVersion =
+    candidateIndex >= 0 ? args[candidateIndex + 1] : undefined;
   const decisionIndex = args.indexOf("--decision");
   const decisionPath = decisionIndex >= 0 ? args[decisionIndex + 1] : undefined;
   const unknown = args.filter(
     (arg, index) =>
-      arg !== "--json" && arg !== "--decision" && index !== decisionIndex + 1,
+      arg !== "--json" &&
+      arg !== "--decision" &&
+      arg !== "--candidate-version" &&
+      index !== decisionIndex + 1 &&
+      index !== candidateIndex + 1,
   );
-  if (unknown.length > 0 || (decisionIndex >= 0 && !decisionPath)) {
+  if (
+    unknown.length > 0 ||
+    (decisionIndex >= 0 && !decisionPath) ||
+    (candidateIndex >= 0 && !candidateVersion) ||
+    (candidateVersion && decisionPath)
+  ) {
     throw new Error(
-      "Usage: bun run compatibility:check [--json] [--decision <record.md>]",
+      "Usage: bun run compatibility:check [--json] [--decision <record.md> | --candidate-version <version>]",
     );
   }
 
-  const target = await loadCompatibilityTarget();
+  const committedTarget = await loadCompatibilityTarget();
+  const target = candidateVersion
+    ? projectCompatibilityTargetToRelease(committedTarget, candidateVersion)
+    : committedTarget;
   const observations = await collectCompatibilityObservations(target);
   const report = evaluateCompatibility(target, observations);
   if (report.outcome === "fail" && decisionPath) {

--- a/scripts/inspect-mate-package.test.ts
+++ b/scripts/inspect-mate-package.test.ts
@@ -7,6 +7,7 @@ import {
   assertMatePackageFileSize,
   assertMatePackageMetadata,
   assertMateThirdPartyCoverage,
+  expectedMatePackageBbVersion,
   gunzipMateTar,
   inspectMatePackageArchive,
   preflightMateTarBytes,
@@ -32,7 +33,7 @@ function packageManifest() {
     private: true,
     type: "module",
     license: "MIT",
-    engines: { bb: ">=0.36", bbPluginSdk: "^0.4.1" },
+    engines: { bb: ">=0.36.0", bbPluginSdk: "^0.4.1" },
     bb: {
       name: "Plugin Studio",
       description: "Build, inspect, and preview bb plugins.",
@@ -45,7 +46,7 @@ function packageManifest() {
   };
 }
 
-describe("Mate package inspection", () => {
+describe("Plugin Studio package inspection", () => {
   test("ships the Plugin Studio product name without changing compatibility identities", () => {
     const manifest = packageManifest();
     expect(manifest.name).toBe("bb-plugin-mate");
@@ -107,6 +108,35 @@ describe("Mate package inspection", () => {
     ).not.toThrow();
   });
 
+  test("pins normal inspection to the minimum build and permits one explicit candidate build", () => {
+    expect(expectedMatePackageBbVersion({})).toBe("0.36.0");
+    expect(
+      expectedMatePackageBbVersion({
+        BB_PLUGIN_STUDIO_EXPECTED_BB_VERSION: "0.38.0",
+      }),
+    ).toBe("0.38.0");
+    expect(() =>
+      expectedMatePackageBbVersion({
+        BB_PLUGIN_STUDIO_EXPECTED_BB_VERSION: "latest",
+      }),
+    ).toThrow("stable semantic version");
+
+    expect(() =>
+      assertMatePackageMetadata(
+        packageManifest(),
+        {
+          ...buildMetadata(),
+          builtWith: { bbVersion: "0.38.0", pluginSdkVersion: "0.4.1" },
+        },
+        {
+          ...buildMetadata(),
+          builtWith: { bbVersion: "0.38.0", pluginSdkVersion: "0.4.1" },
+        },
+        "0.38.0",
+      ),
+    ).not.toThrow();
+  });
+
   test("rejects source entrypoints and build-version drift", () => {
     expect(() =>
       assertMatePackageMetadata(
@@ -147,7 +177,7 @@ describe("Mate package inspection", () => {
         buildMetadata(),
         buildMetadata(),
       ),
-    ).toThrow("branding");
+    ).toThrow("Plugin Studio package branding");
   });
 
   test("rejects dependency drift in the local-verification manifest", () => {

--- a/scripts/inspect-mate-package.ts
+++ b/scripts/inspect-mate-package.ts
@@ -19,7 +19,7 @@ import { generateThirdPartyLicenses } from "./third-party-licenses.ts";
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const expectedPackageName = "bb-plugin-mate";
 const expectedPackageVersion = "0.1.0-alpha.2";
-const expectedBbVersion = "0.36.0";
+const defaultExpectedBbVersion = "0.36.0";
 const expectedSdkVersion = "0.4.1";
 const MAX_COMPRESSED_PACKAGE_BYTES = 128 * 1024 * 1024;
 const MAX_EXPANDED_PACKAGE_BYTES = 256 * 1024 * 1024;
@@ -69,15 +69,28 @@ interface BuildMetadata {
   builtWith?: Record<string, unknown>;
 }
 
+export function expectedMatePackageBbVersion(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): string {
+  const override = environment.BB_PLUGIN_STUDIO_EXPECTED_BB_VERSION;
+  if (override === undefined) return defaultExpectedBbVersion;
+  assert(
+    /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(override),
+    "BB_PLUGIN_STUDIO_EXPECTED_BB_VERSION must be a stable semantic version.",
+  );
+  return override;
+}
+
 export function assertMatePackageMetadata(
   manifest: PackagedManifest,
   serverMetadata: BuildMetadata,
   appMetadata: BuildMetadata,
+  expectedBbVersion = defaultExpectedBbVersion,
 ): void {
   assertExactKeys(
     manifest as Record<string, unknown>,
     ["bb", "engines", "files", "license", "name", "private", "type", "version"],
-    "Mate package manifest",
+    "Plugin Studio package manifest",
   );
   assert(
     manifest.name === expectedPackageName &&
@@ -85,49 +98,53 @@ export function assertMatePackageMetadata(
       manifest.private === true &&
       manifest.type === "module" &&
       manifest.license === "MIT",
-    "Unexpected Mate package identity or local-only publication guard.",
+    "Unexpected Plugin Studio package identity or local-only publication guard.",
   );
-  assertExactKeys(manifest.engines!, ["bb", "bbPluginSdk"], "Mate engines");
+  assertExactKeys(
+    manifest.engines!,
+    ["bb", "bbPluginSdk"],
+    "Plugin Studio compatibility engines",
+  );
   assertExactKeys(
     manifest.bb!,
     ["app", "branding", "description", "name", "server", "skills"],
-    "Mate bb manifest",
+    "Plugin Studio bb manifest",
   );
   assert(
     JSON.stringify(manifest.files) ===
       JSON.stringify(
         MATE_PACKAGE_ALLOWLIST.filter((file) => file !== "package.json"),
       ),
-    "Mate package files manifest differs from the exact payload allowlist.",
+    "Plugin Studio package files manifest differs from the exact payload allowlist.",
   );
   assert(
-    manifest.engines?.bb === ">=0.36" &&
+    manifest.engines?.bb === ">=0.36.0" &&
       manifest.engines?.bbPluginSdk === "^0.4.1",
-    "Unexpected Mate engine requirements.",
+    "Unexpected Plugin Studio engine requirements.",
   );
   assert(
     manifest.bb?.server === "./dist/server.js" &&
       manifest.bb?.app === "./dist/app.js",
-    "Mate package entrypoints must reference built dist files.",
+    "Plugin Studio package entrypoints must reference built dist files.",
   );
   assert(
     manifest.bb?.name === "Plugin Studio" &&
       manifest.bb?.description === "Build, inspect, and preview bb plugins.",
-    "Mate package plugin identity differs from the approved metadata.",
+    "Plugin Studio package identity differs from the approved metadata.",
   );
   assert(
     JSON.stringify(manifest.bb?.branding) ===
       JSON.stringify({ icon: "Toolbox" }),
-    "Mate package branding differs from the approved Toolbox icon.",
+    "Plugin Studio package branding differs from the approved Toolbox icon.",
   );
   assert(
     JSON.stringify(manifest.bb?.skills) ===
       JSON.stringify(["./skills/plugin-workbench"]),
-    "Mate package skill paths differ from the approved payload.",
+    "Plugin Studio package skill paths differ from the approved payload.",
   );
   assert(
     manifest.scripts === undefined && manifest.devDependencies === undefined,
-    "Mate package may not contain private build configuration.",
+    "Plugin Studio package may not contain private build configuration.",
   );
   for (const metadata of [serverMetadata, appMetadata]) {
     assert(
@@ -138,7 +155,7 @@ export function assertMatePackageMetadata(
         metadata.pluginVersion === expectedPackageVersion &&
         metadata.builtWith?.bbVersion === expectedBbVersion &&
         metadata.builtWith?.pluginSdkVersion === expectedSdkVersion,
-      "Unexpected Mate plugin build metadata.",
+      "Unexpected Plugin Studio plugin build metadata.",
     );
   }
 }
@@ -162,7 +179,7 @@ export function assertMateThirdPartyCoverage(
       /^## @radix-ui\/react-slot@/mu.test(licenses) &&
       /^## @radix-ui\/react-tooltip@/mu.test(licenses) &&
       /^## zod@/mu.test(licenses),
-    "Mate third-party notices do not cover the native component dependencies, bundled Zod, and the compiled runtime.",
+    "Plugin Studio third-party notices do not cover the native component dependencies, bundled Zod, and the compiled runtime.",
   );
 }
 
@@ -178,11 +195,14 @@ async function collectPackageFiles(
       files.push(...(await collectPackageFiles(root, absolute)));
       continue;
     }
-    assert(entry.isFile(), `Mate package contains a non-file: ${entry.name}`);
+    assert(
+      entry.isFile(),
+      `Plugin Studio package contains a non-file: ${entry.name}`,
+    );
     const stat = await fs.lstat(absolute);
     assert(
       stat.isFile() && stat.nlink === 1,
-      `Mate package contains a linked file: ${entry.name}`,
+      `Plugin Studio package contains a linked file: ${entry.name}`,
     );
     const relative = path.relative(root, absolute).split(path.sep).join("/");
     assertMatePackageFileSize(relative, stat.size);
@@ -200,7 +220,7 @@ export function assertMatePackageFileSize(
       Number.isSafeInteger(size) &&
         size >= 0 &&
         size <= MAX_NON_RUNTIME_FILE_BYTES,
-      `Mate package file is oversized: ${relative}.`,
+      `Plugin Studio package file is oversized: ${relative}.`,
     );
   }
 }
@@ -215,6 +235,7 @@ export interface MatePackageInspection {
 export async function inspectMatePackageDirectory(
   packageRoot: string,
   canonicalStandaloneRoot?: string,
+  expectedBbVersion = expectedMatePackageBbVersion(),
 ): Promise<MatePackageInspection> {
   const resolvedRoot = path.resolve(packageRoot);
   const paths = await collectPackageFiles(resolvedRoot);
@@ -240,7 +261,12 @@ export async function inspectMatePackageDirectory(
       .readFile(path.join(resolvedRoot, "dist", "app.meta.json"), "utf8")
       .then((value) => JSON.parse(value) as BuildMetadata),
   ]);
-  assertMatePackageMetadata(manifest, serverMetadata, appMetadata);
+  assertMatePackageMetadata(
+    manifest,
+    serverMetadata,
+    appMetadata,
+    expectedBbVersion,
+  );
   assert(
     JSON.stringify(packagedRuntime.manifest) ===
       JSON.stringify(canonicalRuntime.manifest),
@@ -280,7 +306,7 @@ export async function inspectMatePackageDirectory(
       !bundle.includes("sourcesContent") &&
         !bundle.includes("sourceMappingURL") &&
         !/^\/\/ (?:src\/|\.\.\/\.\.\/packages\/)/mu.test(bundle),
-      `Mate package exposes workspace source names in dist/${name}.`,
+      `Plugin Studio package exposes workspace source names in dist/${name}.`,
     );
   }
   const [
@@ -335,19 +361,19 @@ export async function inspectMatePackageDirectory(
         sourceNotices,
         packagedRuntime.manifest.bunVersion,
       ) && licenses === expectedLicenses,
-    "Mate third-party notice bytes differ from their generated sources.",
+    "Plugin Studio third-party notice bytes differ from their generated sources.",
   );
   assert(
     createHash("sha256").update(packagedReadme).digest("hex") ===
       "dae96e1eb1edc711861b4f8354f16f27d1039c4ff193f8e73b8ad67f56c17cbe" &&
       Buffer.compare(packagedReadme, approvedReadme) === 0,
-    "Mate packaged README differs from the approved usage document.",
+    "Plugin Studio packaged README differs from the approved usage document.",
   );
   assert(
     createHash("sha256").update(packagedLicense).digest("hex") ===
       "e417aaf9e252bd066a2d03c54789efa73f757a62daea00a8b1edba7efd453760" &&
       Buffer.compare(packagedLicense, approvedLicense) === 0,
-    "Mate package LICENSE differs from the approved MIT license.",
+    "Plugin Studio package LICENSE differs from the approved MIT license.",
   );
   assert(
     createHash("sha256").update(packagedBunLicense).digest("hex") ===
@@ -356,7 +382,7 @@ export async function inspectMatePackageDirectory(
         packagedBunLicense,
         pinnedBunLicenseBytes(approvedBunLicense),
       ) === 0,
-    "Mate package Bun license differs from the pinned Bun 1.3.14 license.",
+    "Plugin Studio package Bun license differs from the pinned Bun 1.3.14 license.",
   );
   const skillText = packagedSkill.toString("utf8");
   assert(
@@ -366,14 +392,14 @@ export async function inspectMatePackageDirectory(
       skillText.startsWith("---\nname: plugin-workbench\ndescription:") &&
       skillText.includes("# Plugin Studio") &&
       skillText.includes("On mount, Plugin Studio automatically performs"),
-    "Mate packaged skill identity differs from the approved plugin-workbench skill.",
+    "Plugin Studio packaged skill identity differs from the approved plugin-workbench skill.",
   );
   for (const file of paths.filter((file) => !file.endsWith("/bb-mate"))) {
     const contents = await fs.readFile(path.join(resolvedRoot, file));
     assert(
       !contents.includes(Buffer.from(repositoryRoot)) &&
         !contents.includes(Buffer.from("/Users/mg/")),
-      `Mate package leaks a checkout path in ${file}.`,
+      `Plugin Studio package leaks a checkout path in ${file}.`,
     );
   }
   return {
@@ -435,22 +461,22 @@ export function preflightMateTarBytes(compressed: Uint8Array): string[] {
         !/[\u0000-\u001f\u007f\\]/u.test(entry) &&
         !entry.startsWith("/") &&
         !entry.split("/").some((part) => part === ".." || part === ""),
-      `Mate archive contains an unsafe raw header: ${JSON.stringify(entry)}.`,
+      `Plugin Studio archive contains an unsafe raw header: ${JSON.stringify(entry)}.`,
     );
     const type = header[156];
     assert(
       type === 0 || type === 0x30,
-      `Mate archive contains unsupported raw header type ${type} for ${entry}.`,
+      `Plugin Studio archive contains unsupported raw header type ${type} for ${entry}.`,
     );
     const sizeText = readTarText(header, 124, 12).trim();
     assert(
       /^[0-7]+$/u.test(sizeText),
-      `Mate archive has invalid size for ${entry}.`,
+      `Plugin Studio archive has invalid size for ${entry}.`,
     );
     const size = Number.parseInt(sizeText, 8);
     assert(
       Number.isSafeInteger(size) && size >= 0,
-      `Mate archive has invalid size for ${entry}.`,
+      `Plugin Studio archive has invalid size for ${entry}.`,
     );
     entries.push(entry);
     offset += 512 + Math.ceil(size / 512) * 512;
@@ -459,14 +485,14 @@ export function preflightMateTarBytes(compressed: Uint8Array): string[] {
   assert(
     canonicalEnd.byteLength === 1024 &&
       canonicalEnd.every((byte) => byte === 0),
-    "Mate archive does not have one canonical end or contains trailing decompressed data.",
+    "Plugin Studio archive does not have one canonical end or contains trailing decompressed data.",
   );
   const expected = MATE_PACKAGE_ALLOWLIST.map((file) => `package/${file}`).sort(
     compareText,
   );
   assert(
     JSON.stringify([...entries].sort(compareText)) === JSON.stringify(expected),
-    `Mate archive raw header allowlist mismatch: ${entries.join(", ")}`,
+    `Plugin Studio archive raw header allowlist mismatch: ${entries.join(", ")}`,
   );
   return entries;
 }
@@ -477,11 +503,11 @@ export function assertSafeMateTarHeaders(
 ): void {
   assert(
     paths.length === verboseLines.length,
-    "Mate archive header listing is inconsistent.",
+    "Plugin Studio archive header listing is inconsistent.",
   );
   assert(
     new Set(paths).size === paths.length,
-    "Mate archive has duplicate entries.",
+    "Plugin Studio archive has duplicate entries.",
   );
   for (let index = 0; index < paths.length; index += 1) {
     const entry = paths[index]!;
@@ -491,7 +517,7 @@ export function assertSafeMateTarHeaders(
     const type = verboseLines[index]?.[0];
     assert(
       type === "-" || type === "d",
-      `Mate archive contains a non-file archive entry: ${entry}`,
+      `Plugin Studio archive contains a non-file archive entry: ${entry}`,
     );
     assert(
       !entry.includes("\\") &&
@@ -500,7 +526,7 @@ export function assertSafeMateTarHeaders(
             !pathWithoutTrailingSlash
               .split("/")
               .some((part) => part === ".." || part === ""))),
-      `Mate archive contains an unsafe entry: ${entry}`,
+      `Plugin Studio archive contains an unsafe entry: ${entry}`,
     );
   }
 }
@@ -509,6 +535,7 @@ export async function inspectMatePackageArchive(
   archivePath: string,
   tarExecutable: string,
   canonicalStandaloneRoot?: string,
+  expectedBbVersion = expectedMatePackageBbVersion(),
 ): Promise<MatePackageInspection> {
   assert(path.isAbsolute(tarExecutable), "tarExecutable must be absolute.");
   const resolvedArchive = path.resolve(archivePath);
@@ -522,7 +549,7 @@ export async function inspectMatePackageArchive(
         archiveStat.nlink === 1 &&
         archiveStat.size > 0 &&
         archiveStat.size <= MAX_COMPRESSED_PACKAGE_BYTES,
-      "Mate archive must be one bounded regular file.",
+      "Plugin Studio archive must be one bounded regular file.",
     );
     preflightMateTarBytes(await fs.readFile(resolvedArchive));
     const listed = (
@@ -544,6 +571,7 @@ export async function inspectMatePackageArchive(
     return await inspectMatePackageDirectory(
       path.join(temporaryRoot, "package"),
       canonicalStandaloneRoot,
+      expectedBbVersion,
     );
   } finally {
     await fs.rm(temporaryRoot, { recursive: true, force: true });

--- a/scripts/mate-package-artifact.test.ts
+++ b/scripts/mate-package-artifact.test.ts
@@ -124,7 +124,7 @@ describe("Mate package runtime artifact", () => {
       private: true,
       type: "module",
       license: "MIT",
-      engines: { bb: ">=0.36", bbPluginSdk: "^0.4.1" },
+      engines: { bb: ">=0.36.0", bbPluginSdk: "^0.4.1" },
       bb: {
         name: "Plugin Studio",
         description: "Develop source plugins.",
@@ -144,7 +144,7 @@ describe("Mate package runtime artifact", () => {
       private: true,
       type: "module",
       license: "MIT",
-      engines: { bb: ">=0.36", bbPluginSdk: "^0.4.1" },
+      engines: { bb: ">=0.36.0", bbPluginSdk: "^0.4.1" },
       bb: {
         name: "Plugin Studio",
         description: "Develop source plugins.",

--- a/scripts/mate-package-registry.test.ts
+++ b/scripts/mate-package-registry.test.ts
@@ -24,7 +24,7 @@ describe("Mate package clean-room registry", () => {
       name: MATE_PACKAGE_NAME,
       version: MATE_PACKAGE_VERSION,
       license: "MIT",
-      engines: { bb: ">=0.36", bbPluginSdk: "^0.4.1" },
+      engines: { bb: ">=0.36.0", bbPluginSdk: "^0.4.1" },
       dist: {
         integrity: "sha512-exact",
         shasum: "exact-sha1",

--- a/scripts/mate-package-registry.ts
+++ b/scripts/mate-package-registry.ts
@@ -17,7 +17,7 @@ export function createMateRegistryDocument(args: {
         name: MATE_PACKAGE_NAME,
         version: MATE_PACKAGE_VERSION,
         license: "MIT",
-        engines: { bb: ">=0.36", bbPluginSdk: "^0.4.1" },
+        engines: { bb: ">=0.36.0", bbPluginSdk: "^0.4.1" },
         dist: { integrity: args.integrity, shasum: args.shasum, tarball },
       },
     },

--- a/scripts/product-naming.test.ts
+++ b/scripts/product-naming.test.ts
@@ -75,6 +75,15 @@ describe("bb Plugin Studio product naming", () => {
     expect(stale).toEqual([]);
   });
 
+  test("uses the canonical repository URL for the compatibility schema identity", async () => {
+    const schema = await Bun.file(
+      `${repositoryRoot}/compatibility/bb-target.schema.json`,
+    ).json();
+    expect(schema.$id).toBe(
+      "https://raw.githubusercontent.com/galligan/bb-plugin-studio/main/compatibility/bb-target.schema.json",
+    );
+  });
+
   test("uses the renamed repository directory after fresh clone commands", async () => {
     for (const relative of ["CONTRIBUTING.md", "docs/plugin-author-guide.md"]) {
       const text = await Bun.file(`${repositoryRoot}/${relative}`).text();
@@ -119,5 +128,22 @@ describe("bb Plugin Studio product naming", () => {
     expect(changelog).toContain("## Unreleased");
     expect(changelog).toContain("Rename the product to **bb Plugin Studio**");
     expect(changelog).toContain("Historical release notes below retain");
+  });
+
+  test("keeps the compatibility skill ID while using current Studio guidance", async () => {
+    const [skill, agent] = await Promise.all([
+      Bun.file(
+        `${repositoryRoot}/.bb/skills/update-bb-mate-compatibility/SKILL.md`,
+      ).text(),
+      Bun.file(
+        `${repositoryRoot}/.bb/skills/update-bb-mate-compatibility/agents/openai.yaml`,
+      ).text(),
+    ]);
+
+    expect(skill).toContain("name: update-bb-mate-compatibility");
+    expect(agent).toContain("$update-bb-mate-compatibility");
+    expect(skill).toContain("bb plugin types --check plugins/mate");
+    expect(skill).not.toContain("plugins/linear");
+    expect(skill).toContain("Plugin Studio compatibility");
   });
 });


### PR DESCRIPTION
## Context

Plugin Studio promised bb `>=0.36.0`, but the compatibility checker treated the audited 0.36 release as an exact installed version. That made ordinary development fail on the compatible 0.37 release and could not detect declaration drift when `@bb/plugin-sdk` kept the same package version.

Closes #93.

## What changed

- separates `minimumBbVersion` (`0.36.0`) from `verifiedThroughBbVersion` (`0.37.0`)
- fails below-minimum hosts, passes the verified range, and reports newer hosts as a nonfatal audit notice
- pins immutable registry, theme, backend declaration, and app declaration hashes for the verified release
- adds required exact-minimum and exact-verified CI lanes that regenerate public declarations before typecheck/build/test
- expands the scheduled latest audit without making mutable npm latest a required PR gate
- normalizes the plugin engine to `>=0.36.0`
- updates maintained compatibility guidance and package inspection while retaining current technical compatibility IDs

## Verification

- `bun run format:check`
- `bun run check` with installed bb 0.37.0
- `bun run test`
- `bun run build`
- `bun run visual:test` (14 Workbench + 20 Plugin Studio cases)
- `bun run standalone:test`
- `bun run mate:package:test`
- `actionlint .github/workflows/bb-compatibility.yml .github/workflows/bb-compatibility-watch.yml`

The managed package proof produced runtime SHA `f8ee7d81b551124e148b7b27e54535b9cb14076e1303d7d12aec3411457605a0` and 14-file package SHA `98d73a945e62656eb80cc0f92fbd8e1f76341d55fa54df18b2e362497e3089df`.

## Risk and rollout

The required lanes use immutable committed versions. npm latest remains scheduled and non-required, so a newly published bb cannot turn an unrelated PR red solely by being newer. No package publication, release, upstream edit, or installed-profile mutation is included.
