### PR TITLE
docs: add source-preview onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # bb Plugin Studio
 
 [![CI](https://github.com/galligan/bb-plugin-studio/actions/workflows/ci.yml/badge.svg)](https://github.com/galligan/bb-plugin-studio/actions/workflows/ci.yml)
-[![npm](https://img.shields.io/npm/v/bb-mate?label=npm&color=cb3837)](https://www.npmjs.com/package/bb-mate)
 [![license](https://img.shields.io/github/license/galligan/bb-plugin-studio)](LICENSE)
 
 bb Plugin Studio is an experimental, fixture-driven authoring companion for plugins
@@ -56,11 +55,14 @@ bb plugin dev .
 bb Plugin Studio can sit beside that loop, but it never becomes the runtime:
 
 ```sh
-bb-mate inspect .
-bb-mate dev .
-bb-mate check .
-bb-mate live .
+bun run bb-mate inspect .
+bun run bb-mate dev .
+bun run bb-mate check .
+bun run bb-mate live .
 ```
+
+`bb-mate` is the current compatibility command. It is not the current product
+name or a promise that a renamed public package is available.
 
 - `inspect` is passive and does not execute plugin code.
 - `dev` opens the Fixture lab.
@@ -76,39 +78,16 @@ adapter, Harness mode remains unavailable. Publication of those testing
 subpaths is tracked upstream in
 [get-bb/bb#1134](https://github.com/get-bb/bb/issues/1134).
 
-## Install the alpha
+## Try the source preview
 
 Prerequisites:
 
 - [bb](https://github.com/get-bb/bb#use-bb) for native build, install, and Live
   handoffs;
-- Bun 1.3.14 or a newer engine-compatible version to run `bb-mate`;
+- Bun 1.3.14 or a newer engine-compatible version;
 - an existing bb plugin when you want to inspect or hand off a real workspace.
 
-Install the current public prerelease:
-
-```sh
-npm install --global bb-mate@alpha
-bb-mate --help
-```
-
-Then, from a plugin directory:
-
-```sh
-bb-mate inspect .
-bb-mate dev .
-```
-
-The installed `dev` command serves a packaged, loopback-only static lab. It
-does not install, build, reload, or run the selected plugin.
-
-> [!NOTE]
-> This is an early alpha. Commands, fixtures, and package contents may change
-> between prereleases. npm currently points both `alpha` and `latest` at the
-> only published version, so use `bb-mate@alpha` when you want the intended
-> channel explicitly.
-
-## Develop bb Plugin Studio from source
+Clone and start the deterministic workbench:
 
 ```sh
 git clone https://github.com/galligan/bb-plugin-studio.git
@@ -118,7 +97,23 @@ bun run bb-mate --help
 bun run dev
 ```
 
-Useful checks:
+The browser workbench runs with fixtures and does not require a bb server. To
+inspect an existing plugin source tree explicitly:
+
+```sh
+bun run bb-mate inspect /absolute/path/to/plugin
+bun run bb-mate dev /absolute/path/to/plugin
+```
+
+bb Plugin Studio is not currently distributed as a public installable package.
+The supported first-contact path is this experimental source preview; commands,
+fixtures, and package contents may change. The older `bb-mate` npm artifact is
+not the current onboarding path. See the [Source preview guide](docs/source-preview.md)
+for exact boundaries, useful checks, and native handoff behavior.
+
+## Develop and verify from source
+
+After following the source-preview setup above, useful checks are:
 
 ```sh
 bun run format:check
@@ -159,7 +154,7 @@ plugin looks or behaves exactly the same inside bb.
 ## Repository map
 
 ```text
-apps/cli/        The published bb-mate CLI package
+apps/cli/        The source CLI (current command: bb-mate)
 apps/workbench/  Browser-only fixture workbench
 packages/        Shared inspection and authoring contracts
 plugins/mate/    Studio-owned live integration plugin
@@ -168,6 +163,7 @@ docs/            Architecture, authoring, trust, and compatibility guides
 
 Start with:
 
+- [Source preview guide](docs/source-preview.md)
 - [Plugin-author guide](docs/plugin-author-guide.md)
 - [Architecture and upstream boundary](docs/architecture.md)
 - [Product naming and compatibility](docs/product-naming.md)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,8 @@
 # Support and compatibility
 
-bb Plugin Studio is an MIT-licensed public alpha. It does not yet have a stable API,
-long-term support line, response-time commitment, or compatibility promise
-across every bb release.
+bb Plugin Studio is an MIT-licensed experimental source preview. It does not
+yet have a stable API, long-term support line, response-time commitment, or
+compatibility promise across every bb release.
 
 ## Where to ask
 
@@ -40,7 +40,7 @@ local paths.
 The actively maintained surface is:
 
 - the current green `main` branch;
-- the current `bb-mate@alpha` npm package;
+- the source preview documented in [docs/source-preview.md](docs/source-preview.md);
 - the bb target recorded in `compatibility/bb-target.json`;
 - Bun 1.3.14 and newer engine-compatible versions on a best-effort basis;
 - macOS for native bb handoffs;

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,30 +3,42 @@
 bb Plugin Studio is an experimental, fixture-driven authoring companion for native
 [bb](https://github.com/get-bb/bb) plugins.
 
-The package contains the `bb-mate` CLI and a deterministic static plugin-surface
-lab. It does not contain bb, plugin packages, a copied plugin SDK, or
-authenticated host state.
+The CLI package contains the command and deterministic static plugin-surface lab.
+It does not bundle bb, third-party plugin packages, a copied plugin SDK, or
+authenticated host state. The repository also contains the separately packaged
+Studio-owned integration plugin used for native bb testing.
 
 > bb Plugin Studio is an independent community project. Native bb and
 > `@bb/plugin-sdk` remain authoritative for plugin contracts, scaffolding,
 > build/install/dev behavior, host rendering, and runtime state.
 
-## Install
+## Try the source preview
 
 ```sh
-npm install --global bb-mate@alpha
-bb-mate --help
+git clone https://github.com/galligan/bb-plugin-studio.git
+cd bb-plugin-studio
+bun install --frozen-lockfile
+bun run bb-mate --help
+bun run dev
 ```
 
-From an existing plugin directory:
+bb Plugin Studio is not currently distributed as a public installable package.
+The supported first-contact path is this experimental source preview. The older
+`bb-mate` npm artifact is not the current onboarding path.
+
+`bb-mate` is the current compatibility command. It predates the product rename
+and is not the product name or the name of a new public package.
+
+To inspect an existing plugin source tree explicitly:
 
 ```sh
-bb-mate inspect .
-bb-mate dev .
+bun run bb-mate inspect /absolute/path/to/plugin
+bun run bb-mate dev /absolute/path/to/plugin
 ```
 
-Use the `alpha` tag explicitly. This is a prerelease and its command surface
-may change.
+See the
+[source preview guide](https://github.com/galligan/bb-plugin-studio/blob/main/docs/source-preview.md)
+for native handoff side effects, confidence levels, and current limitations.
 
 ## Commands
 
@@ -44,9 +56,10 @@ bb-mate live <plugin>     Hand off an installed path plugin to bb plugin dev
 same real plugin path is installed; otherwise it prints the native installation
 command without running it.
 
-The installed `dev` command serves the bundled 13-story lab on loopback. It
-does not install, build, reload, or run the selected plugin, and it never serves
-inspection data over HTTP.
+The source `dev` command serves the 13-story lab on loopback. It does not
+install, build, reload, or run the selected plugin. The source development
+server exposes a bounded inspection session for the explicitly selected tree;
+the packaged static lab does not serve inspection data over HTTP.
 
 ## bb, the SDK, and bb Plugin Studio
 
@@ -70,7 +83,9 @@ Learn more in the
 
 - Bun 1.3.14 is the verified runtime; newer engine-compatible Bun versions are
   best-effort until added to CI.
-- npm is the installer, but Node is not a supported CLI runtime.
+- The clean-room packaging lane uses npm for artifact inspection, but no
+  current public package is the supported installation path. Node is not a
+  supported CLI runtime.
 - Native handoffs target a supported macOS bb host.
 - Fixture and package checks are also exercised in isolated Linux CI.
 
@@ -85,9 +100,8 @@ bun run standalone:test
 
 That executable embeds the exact deterministic lab and is verified after being
 moved away from the checkout with an empty `PATH` and no global Bun. It is an
-internal build artifact: the npm package still ships the Bun-based CLI, and the
-standalone executable is not published, signed, notarized, or installed by
-these commands.
+internal build artifact: it is not published, signed, notarized, or installed
+by these commands.
 
 ## Trust and security
 

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -8,11 +8,12 @@ declaration refresh, build, install, dev/reload, and the live runtime.
 
 - Bun 1.3.14, the currently verified version; newer engine-compatible versions
   are best-effort until added to CI;
-- npm for installing the public alpha;
+- Git for obtaining the source preview;
 - an existing bb plugin when you want inspection or native handoff guidance;
-- native bb 0.36.0, the currently recorded target, for supported native
-  inspection, build, or Live handoffs. Other versions may still produce useful
-  diagnostics but are best-effort until the compatibility target is updated.
+- native bb 0.36.0 or newer, verified through 0.37.0, for supported native
+  inspection, build, or Live handoffs. Newer releases remain usable with a
+  nonfatal audit notice and are best-effort until the verified-through boundary
+  is updated.
 
 Install native bb through its own supported distribution before using native
 handoffs. The local bb Plugin Studio artifact does not bundle, install, configure, or
@@ -103,30 +104,24 @@ Set `BB_CLI` to an exact executable when you need to override the `bb` found on
 BB_CLI=/absolute/path/to/bb bun run bb-mate inspect "$plugin"
 ```
 
-## Install the public alpha
+## Use the source preview
 
-The public package supports Fixture exploration outside the source checkout:
+Plugin Studio is not currently distributed as a public installable package.
+Use a source checkout for Fixture exploration:
 
 ```sh
 plugin="/absolute/path/to/plugin"
-prefix="$(mktemp -d)"
-npm install --prefix "$prefix" --no-save --package-lock=false bb-mate@alpha
-"$prefix/node_modules/.bin/bb-mate" --help
-"$prefix/node_modules/.bin/bb-mate" dev "$plugin"
+git clone https://github.com/galligan/bb-plugin-studio.git
+cd bb-plugin-studio
+bun install --frozen-lockfile
+bun run bb-mate --help
+bun run bb-mate dev "$plugin"
 ```
 
-Open the printed loopback URL, then stop the foreground server with Control-C
-before uninstalling in the same shell:
-
-```sh
-npm uninstall --prefix "$prefix" --no-save --package-lock=false bb-mate
-```
-
-The installed `dev` serves the packaged static lab rather than the source Vite
-workbench. It binds only to loopback and does not serve inspection data. The
-package is an MIT-licensed prerelease with no stable API or support SLA. The
-reproducible artifact and clean-room lifecycle are specified in
-[local-package.md](local-package.md).
+Open the printed loopback URL, then stop the foreground server with Control-C.
+The preview has no stable API or support SLA. Its reproducible local artifact
+and clean-room lifecycle remain release-engineering evidence rather than an
+installation promise; they are specified in [local-package.md](local-package.md).
 Release-candidate maintainers can reproduce the source, packaged, and isolated
 native lanes with the [clean-room alpha trial runbook](alpha-trial-runbook.md).
 

--- a/docs/source-preview.md
+++ b/docs/source-preview.md
@@ -1,0 +1,109 @@
+# Source preview
+
+bb Plugin Studio is not currently distributed as a public installable package.
+For now, the supported first-contact experience is an experimental source
+preview from this repository. It is suitable for exploring the deterministic
+workbench, inspecting a plugin source tree, and evaluating native bb handoffs.
+It is not a release installation or a production support commitment.
+
+The command name `bb-mate` predates the product rename. `bb-mate` is a
+compatibility identifier for the current CLI command, not the product name or
+the name of a new public package.
+
+## Prerequisites
+
+- macOS for native bb handoffs;
+- [bb](https://github.com/get-bb/bb#use-bb) on `PATH` when using `check` or
+  `live`;
+- Bun 1.3.14 or a newer engine-compatible version;
+- Git;
+- an existing bb plugin source tree for plugin-specific inspection.
+
+The fixture workbench itself runs without a bb server, a sibling bb source
+checkout, credentials, or a plugin installation.
+
+## Start the fixture workbench
+
+```sh
+git clone https://github.com/galligan/bb-plugin-studio.git
+cd bb-plugin-studio
+bun install --frozen-lockfile
+bun run bb-mate --help
+bun run dev
+```
+
+Open the local URL printed by the development server. The workbench uses
+deterministic fixtures so its states remain reproducible and safe to discuss.
+It does not read authenticated host state or run plugin code.
+
+## Inspect a plugin source tree
+
+Pass a plugin path explicitly so it is clear which workspace is in scope:
+
+```sh
+bun run bb-mate inspect /absolute/path/to/plugin
+bun run bb-mate dev /absolute/path/to/plugin
+```
+
+`inspect` reads the selected plugin's manifest, generated native metadata, and
+passive bb status. It does not import or execute the plugin. `dev` opens the
+Fixture lab and does not install, build, reload, or run the selected plugin.
+
+The native handoff commands have a wider boundary:
+
+```sh
+bun run bb-mate check /absolute/path/to/plugin
+bun run bb-mate live /absolute/path/to/plugin
+```
+
+- `check` reports compatibility, delegates `bb plugin build` to the bb CLI,
+  and inspects the result again. The build may write generated output inside
+  the selected plugin.
+- `live` delegates `bb plugin dev` only after bb confirms that the same plugin
+  path is already installed. Otherwise it prints the native install command
+  and stops; it does not install the plugin for you.
+
+Use disposable or intentionally selected plugin workspaces for native handoffs.
+Do not point this preview at a primary managed plugin merely to change its
+source path: removing and reinstalling a managed plugin can discard settings or
+other persisted state.
+
+## What the preview proves
+
+bb Plugin Studio distinguishes three confidence levels:
+
+- **Fixture** is a deterministic approximation for visual iteration.
+- **Harness** validates public behavior only when the selected plugin can
+  resolve the official `@bb/plugin-sdk/testing` contracts and Studio has an
+  upstream-backed adapter.
+- **Live bb** is the plugin running in the native host. Live bb is the visual
+  and integration authority.
+
+A successful Fixture preview does not prove that the plugin will look or behave
+identically in bb. The source preview also does not provide a signed standalone
+application, a stable installer, a published Plugin Studio package, or support
+for silently migrating an existing `mate` installation.
+
+## Verify the checkout
+
+Use the smallest relevant command while iterating. Before reporting a checkout
+as healthy, run:
+
+```sh
+bun run format:check
+bun run check
+bun run test
+bun run build
+bun run visual:test
+```
+
+Some checks exercise browser tooling or native macOS behavior and may require
+their documented local prerequisites. A failure should be reported rather than
+treated as proof that the remaining lanes passed.
+
+## Feedback
+
+Please report source-preview problems and focused feature proposals in
+[GitHub Issues](https://github.com/galligan/bb-plugin-studio/issues). Problems
+with bb scaffolding, installation, runtime, host UI, or SDK contracts generally
+belong in the [upstream bb issue tracker](https://github.com/get-bb/bb/issues).

--- a/scripts/source-preview-docs.test.ts
+++ b/scripts/source-preview-docs.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
+
+describe("bb Plugin Studio source preview documentation", () => {
+  test("presents source checkout as the supported first-contact path", async () => {
+    const readme = await Bun.file(`${repositoryRoot}/README.md`).text();
+    const preview = await Bun.file(
+      `${repositoryRoot}/docs/source-preview.md`,
+    ).text();
+    const packageReadme = await Bun.file(
+      `${repositoryRoot}/apps/cli/README.md`,
+    ).text();
+    const support = await Bun.file(`${repositoryRoot}/SUPPORT.md`).text();
+    const authorGuide = await Bun.file(
+      `${repositoryRoot}/docs/plugin-author-guide.md`,
+    ).text();
+    const packageProse = packageReadme.replace(/\s+/gu, " ");
+    const authorProse = authorGuide.replace(/\s+/gu, " ");
+
+    for (const firstContactSurface of [readme, packageReadme]) {
+      expect(firstContactSurface).not.toContain(
+        "npm install --global bb-mate@alpha",
+      );
+      expect(firstContactSurface).toContain(
+        "`bb-mate` is the current compatibility command",
+      );
+    }
+
+    expect(readme).not.toContain("img.shields.io/npm/v/bb-mate");
+    expect(readme).toContain("## Try the source preview");
+    expect(readme).toContain("[Source preview guide](docs/source-preview.md)");
+
+    expect(preview).toContain(
+      "git clone https://github.com/galligan/bb-plugin-studio.git\ncd bb-plugin-studio",
+    );
+    expect(preview).toContain("bun install --frozen-lockfile");
+    expect(preview).toContain("bun run bb-mate --help");
+    expect(preview).toContain("bun run dev");
+    expect(preview).toContain(
+      "bb Plugin Studio is not currently distributed as a public installable package",
+    );
+    expect(preview).toMatch(
+      /`bb-mate` is a\s+compatibility identifier for the current CLI command/,
+    );
+    expect(preview).toMatch(
+      /Live bb is the visual\s+and integration authority/,
+    );
+
+    expect(packageProse).toContain(
+      "The CLI package contains the command and deterministic static plugin-surface lab",
+    );
+    expect(packageProse).not.toContain("The source workspace contains a CLI");
+    expect(packageProse).toContain(
+      "The source development server exposes a bounded inspection session",
+    );
+    expect(packageProse).toContain(
+      "the packaged static lab does not serve inspection data over HTTP",
+    );
+    expect(packageProse).not.toContain(
+      "it never serves inspection data over HTTP",
+    );
+    expect(authorProse).toContain(
+      "native bb 0.36.0 or newer, verified through 0.37.0",
+    );
+    expect(authorProse).toContain(
+      "Newer releases remain usable with a nonfatal audit notice",
+    );
+    expect(authorProse).not.toContain(
+      "native bb 0.36.0, the currently recorded target",
+    );
+    for (const maintainedGuide of [support, authorGuide]) {
+      expect(maintainedGuide).not.toContain("bb-mate@alpha");
+      expect(maintainedGuide).toContain("source preview");
+    }
+  });
+});


### PR DESCRIPTION
## Context

The first-contact documentation still advertised an older `bb-mate` npm alpha as the way to try Plugin Studio, even though there is no current public installable Plugin Studio package. This made it too easy to discuss or test the wrong artifact.

This is a focused, source-preview slice of #95. It builds on the now-merged #104 compatibility policy so the documented ordinary check works with current bb.

## What changed

- makes a source checkout the supported experimental first-contact path
- removes the stale npm badge and global alpha installation instructions
- labels `bb-mate` as the current compatibility command, not the product name or a promise of a renamed package
- documents exact Fixture, Harness, Live bb, filesystem, build, and primary-profile boundaries
- aligns the CLI package README with the same source-preview truth
- adds a regression preventing the stale install path from returning

## Verification

- `bun test scripts/source-preview-docs.test.ts scripts/product-naming.test.ts`
- `bun run format:check`
- full local tests, build, visual/accessibility, standalone, and managed-package gates passed on the stacked tree

## Boundary

This PR does not publish or reserve a package name, rename persisted plugin identities, retarget the installed primary-profile plugin, or promise release support. Those remain tracked under #86, #94, and #95.