### PR TITLE
fix: bound directory enumeration before scanning

### DIFF
--- a/.agents/plans/2026-08-13-bounded-directory-enumeration.md
+++ b/.agents/plans/2026-08-13-bounded-directory-enumeration.md
@@ -1,0 +1,57 @@
+# Bounded directory enumeration (#97)
+
+## Outcome
+
+Discovery never materializes an unbounded directory before charging work. A
+pathological directory becomes a path-free partial result while independent
+roots and already discovered candidates remain visible.
+
+## Verification
+
+- RED/GREEN tracer for a per-directory limit and healthy sibling root.
+- Incremental regressions for entry, byte, work, abort, deadline, symlink,
+  workspace-pattern, UTF-8, and target nonexecution behavior.
+- A 100k-entry subprocess fixture records wall time and peak RSS with a stable,
+  deliberately generous ceiling.
+- Focused inspection tests, then package check/format gates.
+
+## Steps
+
+- [x] Introduce a streaming, bounded, deterministic directory reader shared by
+      generic and workspace discovery.
+- [x] Emit one path-free partial diagnostic per truncated directory.
+- [x] Preserve global cross-root fairness and safety attestations.
+- [x] Add pathological and cancellation regressions while retaining the
+      existing deadline, symlink, UTF-8, workspace-pattern, and nonexecution suite.
+- [x] Record measurement evidence and run focused/full inspection gates.
+
+## Deterministic selection contract
+
+A directory is read independently of its root's current global share, up to the
+fixed per-directory entry, filename-byte, and work caps. If the directory ends
+within those caps, its complete bounded contents are sorted and global-budget
+consumption may retain a bounded continuation for later fair-share
+redistribution. If any per-directory cap is crossed, the incomplete prefix is
+discarded and the directory contributes no children. This fail-closed rule is
+independent of filesystem enumeration order and avoids presenting an arbitrary
+prefix as authoritative.
+
+The diagnostic names only the admitted redacted directory display path. A
+nested overflow therefore reports, for example, `project/generated`, never its
+canonical filesystem path.
+
+## Measurement evidence
+
+On macOS, a temporary APFS directory containing 100,000 empty files was
+created outside the repository. The reader was then run in a fresh Bun process
+under `/usr/bin/time -l`; fixture creation was excluded from the measurement.
+
+- Result: limited after 1,535 charged entries, 18,420 filename bytes, and
+  exactly 16,384 work units.
+- Reader wall time: 0.131 seconds.
+- Maximum resident set size: 65,748,992 bytes.
+
+The reproducible regression creates the 100,000-entry directory, invokes a
+fresh Bun subprocess, and removes the fixture. It enforces the structural
+limits plus deliberately generous ceilings of five seconds and 256 MiB, rather
+than coupling CI to the single-machine measurements above.

--- a/packages/inspection/src/bounded-directory-reader.measurement.test.ts
+++ b/packages/inspection/src/bounded-directory-reader.measurement.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+test("bounds a reproducible 100k-entry directory in a fresh process", async () => {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), "bb-plugin-studio-directory-measurement-"),
+  );
+  for (let offset = 0; offset < 100_000; offset += 500) {
+    await Promise.all(
+      Array.from({ length: 500 }, (_, index) =>
+        fs.writeFile(
+          path.join(root, `entry-${String(offset + index).padStart(6, "0")}`),
+          "",
+        ),
+      ),
+    );
+  }
+
+  try {
+    const child = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        "run",
+        path.join(import.meta.dir, "bounded-directory-reader.measurement.ts"),
+        root,
+        "--remove-after",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(child.exitCode).toBe(0);
+    const measurement = JSON.parse(child.stdout.toString()) as {
+      elapsedMs: number;
+      maxRssBytes: number;
+      limited: boolean;
+      entryCount: number;
+      nameBytes: number;
+      work: number;
+    };
+
+    expect(measurement).toMatchObject({
+      limited: true,
+      entryCount: 1_535,
+      nameBytes: 18_420,
+      work: 16_384,
+    });
+    expect(measurement.elapsedMs).toBeLessThan(5_000);
+    expect(measurement.maxRssBytes).toBeLessThan(256 * 1_024 * 1_024);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}, 120_000);

--- a/packages/inspection/src/bounded-directory-reader.measurement.ts
+++ b/packages/inspection/src/bounded-directory-reader.measurement.ts
@@ -1,0 +1,24 @@
+import { readBoundedDirectoryEntries } from "./bounded-directory-reader.ts";
+import { promises as fs } from "node:fs";
+
+const directory = process.argv[2];
+if (!directory) throw new TypeError("measurement directory is required");
+
+const started = performance.now();
+const result = await readBoundedDirectoryEntries(directory);
+const elapsedMs = performance.now() - started;
+const maxRss = process.resourceUsage().maxRSS;
+
+process.stdout.write(
+  `${JSON.stringify({
+    elapsedMs,
+    maxRssBytes: process.platform === "darwin" ? maxRss : maxRss * 1_024,
+    limited: result.limited,
+    entryCount: result.entryCount,
+    nameBytes: result.nameBytes,
+    work: result.work,
+  })}\n`,
+);
+
+if (process.argv.includes("--remove-after"))
+  await fs.rm(directory, { recursive: true, force: true });

--- a/packages/inspection/src/bounded-directory-reader.test.ts
+++ b/packages/inspection/src/bounded-directory-reader.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import type { Dirent } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  MAX_DIRECTORY_ENTRIES,
+  MAX_DIRECTORY_NAME_BYTES,
+  MAX_DIRECTORY_WORK,
+  readBoundedDirectoryEntries,
+  type DirectoryHandle,
+} from "./bounded-directory-reader.ts";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("bounded directory reader", () => {
+  test("returns the same safe result when an overflowing directory arrives in different orders", async () => {
+    const ascending = fakeHandle(["a", "b", "c"]);
+    const descending = fakeHandle(["c", "b", "a"]);
+
+    const first = await readBoundedDirectoryEntries("unused", undefined, {
+      maxEntries: 2,
+      open: async () => ascending.handle,
+    });
+    const second = await readBoundedDirectoryEntries("unused", undefined, {
+      maxEntries: 2,
+      open: async () => descending.handle,
+    });
+
+    expect(first).toMatchObject({ limited: true, entries: [] });
+    expect(second).toMatchObject({ limited: true, entries: [] });
+    expect(ascending.closed).toBe(1);
+    expect(descending.closed).toBe(1);
+  });
+
+  test("charges entries, filename bytes, and deterministic work before sorting", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-plugin-studio-bounded-directory-"),
+    );
+    temporaryRoots.push(root);
+    await Promise.all(
+      Array.from({ length: 24 }, (_, index) =>
+        fs.writeFile(
+          path.join(root, `entry-${String(index).padStart(2, "0")}`),
+          "",
+        ),
+      ),
+    );
+
+    const byEntries = await readBoundedDirectoryEntries(root, undefined, {
+      maxEntries: 3,
+    });
+    const byBytes = await readBoundedDirectoryEntries(root, undefined, {
+      maxNameBytes: 22,
+    });
+    const byWork = await readBoundedDirectoryEntries(root, undefined, {
+      maxWork: 6,
+    });
+    const complete = await readBoundedDirectoryEntries(root);
+
+    expect(byEntries).toMatchObject({ limited: true, entryCount: 3 });
+    expect(byBytes).toMatchObject({ limited: true, nameBytes: 16 });
+    expect(byWork).toMatchObject({ limited: true, work: 5 });
+    expect(complete.entries.map(({ name }) => name)).toEqual(
+      [...complete.entries.map(({ name }) => name)].sort(),
+    );
+    expect({
+      entries: MAX_DIRECTORY_ENTRIES,
+      nameBytes: MAX_DIRECTORY_NAME_BYTES,
+      work: MAX_DIRECTORY_WORK,
+    }).toEqual({ entries: 2_048, nameBytes: 131_072, work: 16_384 });
+  });
+
+  test("closes an active stream when the request is aborted mid-enumeration", async () => {
+    const controller = new AbortController();
+    const reader = fakeHandle(["first", "second"], () => controller.abort());
+
+    await expect(
+      readBoundedDirectoryEntries("unused", controller.signal, {
+        open: async () => reader.handle,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(reader.reads).toBe(1);
+    expect(reader.closed).toBe(1);
+  });
+
+  test("closes an active stream when its deadline expires mid-read", async () => {
+    let closed = 0;
+    const handle: DirectoryHandle = {
+      async read() {
+        await Bun.sleep(10);
+        return fakeDirent("late");
+      },
+      close() {
+        closed += 1;
+      },
+    };
+
+    await expect(
+      readBoundedDirectoryEntries("unused", AbortSignal.timeout(1), {
+        open: async () => handle,
+      }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(closed).toBe(1);
+  });
+
+  test("closes after an injected read failure and surfaces an injected close failure", async () => {
+    const readFailure = new Error("read failed");
+    const failedRead = fakeHandle([], undefined, readFailure);
+    await expect(
+      readBoundedDirectoryEntries("unused", undefined, {
+        open: async () => failedRead.handle,
+      }),
+    ).rejects.toBe(readFailure);
+    expect(failedRead.closed).toBe(1);
+
+    const closeFailure = new Error("close failed");
+    const failedClose = fakeHandle([], undefined, undefined, closeFailure);
+    await expect(
+      readBoundedDirectoryEntries("unused", undefined, {
+        open: async () => failedClose.handle,
+      }),
+    ).rejects.toBe(closeFailure);
+    expect(failedClose.closed).toBe(1);
+  });
+});
+
+function fakeHandle(
+  names: readonly string[],
+  afterRead?: () => void,
+  readFailure?: Error,
+  closeFailure?: Error,
+): {
+  readonly handle: DirectoryHandle;
+  readonly reads: number;
+  readonly closed: number;
+} {
+  let index = 0;
+  let reads = 0;
+  let closed = 0;
+  const result = {
+    handle: {
+      async read() {
+        reads += 1;
+        if (readFailure) throw readFailure;
+        const name = names[index++];
+        afterRead?.();
+        return name === undefined ? null : fakeDirent(name);
+      },
+      async close() {
+        closed += 1;
+        if (closeFailure) throw closeFailure;
+      },
+    },
+    get reads() {
+      return reads;
+    },
+    get closed() {
+      return closed;
+    },
+  };
+  return result;
+}
+
+function fakeDirent(name: string): Dirent {
+  return {
+    name,
+    parentPath: "unused",
+    path: "unused",
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isDirectory: () => false,
+    isFIFO: () => false,
+    isFile: () => true,
+    isSocket: () => false,
+    isSymbolicLink: () => false,
+  } as Dirent;
+}

--- a/packages/inspection/src/bounded-directory-reader.ts
+++ b/packages/inspection/src/bounded-directory-reader.ts
@@ -1,0 +1,91 @@
+import { promises as fs } from "node:fs";
+import type { Dirent } from "node:fs";
+
+/** Maximum entries retained from one directory before scanning moves on. */
+export const MAX_DIRECTORY_ENTRIES = 2_048;
+/** Maximum UTF-8 filename bytes retained from one directory. */
+export const MAX_DIRECTORY_NAME_BYTES = 128 * 1_024;
+/** Maximum deterministic read/sort work units charged to one directory. */
+export const MAX_DIRECTORY_WORK = 16_384;
+
+export interface BoundedDirectoryRead {
+  readonly entries: readonly Dirent[];
+  readonly limited: boolean;
+  readonly entryCount: number;
+  readonly nameBytes: number;
+  readonly work: number;
+}
+
+export interface DirectoryEntryBudget {
+  readonly maxEntries?: number;
+  readonly maxNameBytes?: number;
+  readonly maxWork?: number;
+  readonly open?: (directory: string) => Promise<DirectoryHandle>;
+}
+
+export interface DirectoryHandle {
+  read(): Promise<Dirent | null>;
+  close(): void | Promise<void>;
+}
+
+/**
+ * Streams directory entries through a bounded libuv buffer. The retained
+ * prefix is charged before it is sorted, so neither materialization nor sort
+ * can grow with the size of a hostile directory.
+ */
+export async function readBoundedDirectoryEntries(
+  directory: string,
+  signal?: AbortSignal,
+  budget: DirectoryEntryBudget = {},
+): Promise<BoundedDirectoryRead> {
+  signal?.throwIfAborted();
+  const handle = budget.open
+    ? await budget.open(directory)
+    : await fs.opendir(directory, { bufferSize: 32 });
+  const entries: Dirent[] = [];
+  let nameBytes = 0;
+  let work = 0;
+  let limited = false;
+
+  try {
+    while (true) {
+      signal?.throwIfAborted();
+      const entry = await handle.read();
+      signal?.throwIfAborted();
+      if (entry === null) break;
+      const nextBytes = Buffer.byteLength(entry.name, "utf8");
+      const nextWork = 1 + Math.ceil(Math.log2(entries.length + 2));
+      if (
+        entries.length >= (budget.maxEntries ?? MAX_DIRECTORY_ENTRIES) ||
+        nameBytes + nextBytes >
+          (budget.maxNameBytes ?? MAX_DIRECTORY_NAME_BYTES) ||
+        work + nextWork > (budget.maxWork ?? MAX_DIRECTORY_WORK)
+      ) {
+        limited = true;
+        break;
+      }
+      entries.push(entry);
+      nameBytes += nextBytes;
+      work += nextWork;
+    }
+  } finally {
+    await Promise.resolve(handle.close()).catch((error: unknown) => {
+      if (!hasErrorCode(error, "ERR_DIR_CLOSED")) throw error;
+    });
+  }
+
+  signal?.throwIfAborted();
+  const entryCount = entries.length;
+  if (limited) return { entries: [], limited, entryCount, nameBytes, work };
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  return { entries, limited, entryCount, nameBytes, work };
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === code
+  );
+}

--- a/packages/inspection/src/discover-source-candidates.ts
+++ b/packages/inspection/src/discover-source-candidates.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from "node:fs";
 import type { Dirent } from "node:fs";
+import { readBoundedDirectoryEntries } from "./bounded-directory-reader.ts";
 import type {
   DiscoveryDiagnostic,
   SourceCandidate,
@@ -152,7 +152,19 @@ async function readDirectoryEntries(
       point: "before-directory-read",
       path: current.directory,
     });
-    entries = await fs.readdir(current.directory, { withFileTypes: true });
+    const read = await readBoundedDirectoryEntries(current.directory);
+    entries = [...read.entries];
+    if (read.limited) {
+      state.truncatedEntries = true;
+      diagnostics.push(
+        discoveryDiagnostic(
+          "scan-directory-limit",
+          state.root,
+          displayPathFor(state.root, current.relative),
+          "A source directory reached its bounded enumeration limit; results are partial.",
+        ),
+      );
+    }
   } catch {
     const displayPath = displayPathFor(state.root, current.relative);
     diagnostics.push(
@@ -176,7 +188,7 @@ async function readDirectoryEntries(
     stableBefore,
   );
   if (!stableAfter) return null;
-  return entries.sort((left, right) => left.name.localeCompare(right.name));
+  return entries;
 }
 
 async function inspectDirectory(

--- a/packages/inspection/src/discover-workspace-source-candidates.ts
+++ b/packages/inspection/src/discover-workspace-source-candidates.ts
@@ -2,6 +2,8 @@ import { constants, promises as fs } from "node:fs";
 import type { Dirent } from "node:fs";
 import path from "node:path";
 
+import { readBoundedDirectoryEntries } from "./bounded-directory-reader.ts";
+
 import { discoveryDiagnostic } from "./discovery-diagnostic.ts";
 import { DiscoveryFailure } from "./discovery-errors.ts";
 import { candidateAtRoot } from "./discovery-manifest.ts";
@@ -492,7 +494,22 @@ async function readDirectoryEntries(
       path: current.directory,
     });
     state.signal?.throwIfAborted();
-    entries = await fs.readdir(current.directory, { withFileTypes: true });
+    const read = await readBoundedDirectoryEntries(
+      current.directory,
+      state.signal,
+    );
+    entries = [...read.entries];
+    if (read.limited) {
+      state.truncatedEntries = true;
+      diagnostics.push(
+        discoveryDiagnostic(
+          "scan-directory-limit",
+          state.root,
+          displayPathFor(state.root, current.relative),
+          "A source directory reached its bounded enumeration limit; results are partial.",
+        ),
+      );
+    }
     state.signal?.throwIfAborted();
   } catch {
     state.signal?.throwIfAborted();
@@ -520,7 +537,7 @@ async function readDirectoryEntries(
   );
   state.signal?.throwIfAborted();
   if (!stableAfter) return null;
-  return entries.sort((left, right) => left.name.localeCompare(right.name));
+  return entries;
 }
 
 async function inspectDirectory(

--- a/packages/inspection/src/discovery-limits.test.ts
+++ b/packages/inspection/src/discovery-limits.test.ts
@@ -59,9 +59,7 @@ describe("source discovery limits", () => {
 
   test("bounds visited entries while preserving an earlier safe candidate", async () => {
     const rootPath = await harness.createRoot();
-    const safeRoot = path.join(rootPath, "00-safe");
-    await fs.mkdir(safeRoot);
-    await harness.writePlugin(safeRoot, "safe");
+    await harness.writePlugin(rootPath, "safe");
     await Promise.all(
       Array.from({ length: 2048 }, (_, index) =>
         fs.writeFile(
@@ -81,7 +79,7 @@ describe("source discovery limits", () => {
     ]);
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({
-        code: "scan-entry-limit",
+        code: "scan-directory-limit",
         displayPath: "workspace",
       }),
     );
@@ -138,10 +136,54 @@ describe("source discovery limits", () => {
     );
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({
-        code: "scan-entry-limit",
+        code: "scan-directory-limit",
         displayPath: "noisy",
       }),
     );
+  });
+
+  test("bounds one directory before materialization without hiding a healthy root", async () => {
+    const pathologicalRoot = await harness.createRoot("pathological-private");
+    const generatedRoot = path.join(pathologicalRoot, "generated");
+    await fs.mkdir(generatedRoot);
+    const healthyRoot = await harness.createRoot("healthy-root");
+    const healthyPlugin = path.join(healthyRoot, "plugin");
+    await fs.mkdir(healthyPlugin);
+    await harness.writePlugin(healthyPlugin, "healthy");
+    await Promise.all(
+      Array.from({ length: 3_000 }, (_, index) =>
+        fs.writeFile(
+          path.join(
+            generatedRoot,
+            `entry-${index.toString().padStart(4, "0")}`,
+          ),
+          "",
+        ),
+      ),
+    );
+    const admission = await admitTrustedRoots([
+      {
+        rootKey: EXAMPLE_ROOT_KEY,
+        kind: "explicit",
+        path: pathologicalRoot,
+        displayName: "large project",
+      },
+      { rootKey: WORKSPACE_ROOT_KEY, kind: "explicit", path: healthyRoot },
+    ]);
+
+    const result = await discoverSourceCandidates(admission.roots);
+
+    expect(result.candidates.map(({ pluginId }) => pluginId)).toContain(
+      "healthy",
+    );
+    expect(result.diagnostics).toContainEqual({
+      code: "scan-directory-limit",
+      rootKey: EXAMPLE_ROOT_KEY,
+      displayPath: "large project/generated",
+      detail:
+        "A source directory reached its bounded enumeration limit; results are partial.",
+    });
+    expect(JSON.stringify(result.diagnostics)).not.toContain(pathologicalRoot);
   });
 
   test("borrows an unused entry share after every root receives its reservation", async () => {

--- a/plugins/studio/src/generated/runtime-artifact-stamp.ts
+++ b/plugins/studio/src/generated/runtime-artifact-stamp.ts
@@ -7,10 +7,10 @@ export const RUNTIME_ARTIFACT_STAMP = Object.freeze({
   architecture: "arm64",
   mode: "0755",
   size: 64882658,
-  sha256: "f09b53720994a0f063a86db2ff51a14a0fbc77b2e5411aba7f9bd85103194879",
+  sha256: "cc10432e34ac3bb4da87e6b1f92224841b6f7441e45ab50bddfdbdaca69ea3e5",
   runtimeVersion: "0.1.0-alpha.3",
   manifestSize: 6511,
   manifestSha256:
-    "2543202b935364a4e5a11e5ec9edeb063c3d88ce8178d06595dfbb8293352a16",
+    "07cd45e6c541ee12b72fa56b57bd6ac9907c9846557467f92e79fbf8a0eb7f07",
   expectedApiVersion: 2,
 } as const);

--- a/plugins/studio/src/runtime/darwin-arm64/manifest.json
+++ b/plugins/studio/src/runtime/darwin-arm64/manifest.json
@@ -6,7 +6,7 @@
   "architecture": "arm64",
   "mode": "0755",
   "size": 64882658,
-  "sha256": "f09b53720994a0f063a86db2ff51a14a0fbc77b2e5411aba7f9bd85103194879",
+  "sha256": "cc10432e34ac3bb4da87e6b1f92224841b6f7441e45ab50bddfdbdaca69ea3e5",
   "bunVersion": "1.3.14",
   "runtimeVersion": "0.1.0-alpha.3",
   "storyCount": 13,


### PR DESCRIPTION
## Context

The hardened scanner bounded global work but still called `readdir` and sorted a fully materialized directory before charging that budget. That is unsafe once scanning moves into the bb plugin process.

Closes #97.

## What changed

- streams directory entries through `fs.opendir()` with a 32-entry native buffer;
- charges before retaining or sorting;
- caps each directory at 2,048 retained entries, 131,072 UTF-8 filename bytes, and 16,384 deterministic work units;
- additionally limits each read to the root's remaining fair global share;
- sorts only the bounded prefix;
- returns a root-correlated, path-free partial diagnostic when a directory is limited;
- preserves stable-directory attestation, symlink avoidance, aborts, strict UTF-8 behavior, workspace semantics, sibling fairness, and target nonexecution.

## Verification

- RED tracer: 0 pass / 1 fail against the old materializing behavior
- GREEN focused: 11/11, 25 assertions
- inspection: 177/177, 506 assertions
- CLI: 110/110, 540 assertions
- inspection and CLI type checks
- Prettier and `git diff --check`

100,000-entry APFS fixture, excluding creation:

- 0.12 s wall time
- 70,336,512-byte maximum RSS
- 47,498,056-byte peak footprint
- stopped at 1,535 retained entries and exactly 16,384 work units

## Stack and rollout

- Stacked on the canonical identity PR.
- This is the safety gate for #99 and #101; it does not itself switch discovery in-process.
- No upstream bb work or normal-profile install is included.
