### PR TITLE
fix: disable enrolled-host discovery

### DIFF
--- a/.agents/plans/2026-08-13-disable-enrolled-host-discovery.md
+++ b/.agents/plans/2026-08-13-disable-enrolled-host-discovery.md
@@ -1,0 +1,44 @@
+# Disable enrolled-host discovery
+
+Date: 2026-08-13
+Status: Implemented; review PR pending
+
+## Outcome
+
+Keep Plugin Studio focused on primary-host projects. Enrolled-host discovery is
+an explicit Studio feature flag that ships disabled. Remote-only projects stay
+outside the active Studio inventory and never enter filesystem discovery.
+
+## Behavior
+
+- `enrolledHostDiscovery` defaults to `false` in one backend feature-flag
+  module.
+- A project with exactly one valid source on an enrolled, non-primary host is
+  omitted while the flag is disabled. It does not make healthy primary-host
+  inventory partial.
+- Mixed, multiple, malformed, or otherwise ambiguous source declarations still
+  make inventory partial and never enter discovery.
+- Enabling the future feature still requires the bounded public bb capability;
+  this change does not add a remote scanner or an unsafe fallback.
+
+## Verification
+
+- Add a public adapter regression for the disabled remote-only behavior.
+- Retain plugin-level proof that enrolled paths never reach the controller or
+  public response.
+- Run focused backend tests, Studio typecheck/build, repository formatting, and
+  diff checks.
+- Reconcile #102 and the runtime ADR as deferred, default-off future scope.
+
+## Boundary
+
+Do not change browser behavior, upstream bb, package publication, or the
+primary-host scanner.
+
+## Completion evidence
+
+- Focused Studio backend: 15 tests, 81 assertions.
+- Full workspace unit suite and script suite: green.
+- Full check, bb 0.37 compatibility, Studio build, format, and diff checks:
+  green.
+- Browser code and issue #70: unchanged.

--- a/.agents/plans/2026-08-13-plugin-studio-convergence.md
+++ b/.agents/plans/2026-08-13-plugin-studio-convergence.md
@@ -1,7 +1,7 @@
 # Plugin Studio identity, runtime, and compatibility convergence
 
 Date: 2026-08-13
-Status: Ready-PR horizon complete; implementation stack remains unmerged
+Status: Native convergence landed on `main`; enrolled-host discovery deferred
 Parent: [#21](https://github.com/galligan/bb-plugin-studio/issues/21)
 
 ## Outcome
@@ -14,8 +14,8 @@ Plugin Studio:
   followed by one clean canonical `studio` installation;
 - primary-host discovery no longer requires a packaged child runtime or private
   loopback API;
-- enrolled-host discovery waits for a bounded public bb capability rather than
-  using hidden terminals or unrestricted execution; and
+- enrolled-host discovery is explicitly feature-gated off and outside the
+  current product scope; and
 - compatibility promises a minimum bb version while newer releases remain
   usable and auditable.
 
@@ -39,18 +39,18 @@ Plugin Studio:
   result truncation.
 - Compatibility separately enforces minimum bb 0.36.0 and verified-through bb
   0.37.0, while newer compatible releases produce a nonfatal audit notice.
-- PRs #108, #109, #110, #113, and #114 are exact-head reviewed, hosted-green,
-  mergeable, and ready for review. They have not been merged or published.
+- PRs #108, #109, #110, #113, and #114 landed bottom-to-top on `main`; exact
+  post-merge CI and compatibility checks are green. Nothing has been published.
 
 ## Work graph
 
 ### Technical identity migration
 
-- [ ] [#86](https://github.com/galligan/bb-plugin-studio/issues/86) — parent
+- [x] [#86](https://github.com/galligan/bb-plugin-studio/issues/86) — completed
 - [x] [#94](https://github.com/galligan/bb-plugin-studio/issues/94) — superseded
       by the owner-approved legacy removal and clean canonical install
-- [ ] [#95](https://github.com/galligan/bb-plugin-studio/issues/95) — ready in
-      PR #108; closes after the stack lands
+- [x] [#95](https://github.com/galligan/bb-plugin-studio/issues/95) — landed in
+      PR #108
 
 Historical release evidence and Git history retain truthful old names. Current
 old-name exceptions must be isolated to a compatibility manifest/module and
@@ -58,28 +58,28 @@ retired under a versioned policy.
 
 ### Native-runtime convergence
 
-- [ ] [#96](https://github.com/galligan/bb-plugin-studio/issues/96) — parent
+- [x] [#96](https://github.com/galligan/bb-plugin-studio/issues/96) — completed
 - [x] [#98](https://github.com/galligan/bb-plugin-studio/issues/98) — runtime
       boundary ADR and live schema inventory
-- [ ] [#99](https://github.com/galligan/bb-plugin-studio/issues/99) — ready in
+- [x] [#99](https://github.com/galligan/bb-plugin-studio/issues/99) — landed in
       PR #113 with one shared controller and no production child path
-- [ ] [#100](https://github.com/galligan/bb-plugin-studio/issues/100) — ready in
-      PR #110 with bb-owned catalog storage
-- [ ] [#101](https://github.com/galligan/bb-plugin-studio/issues/101) — ready in
-      PR #114; removes supervision, private HTTP/auth, and packaged runtime
-- [ ] [#102](https://github.com/galligan/bb-plugin-studio/issues/102) — add
-      bounded host-routed discovery to public bb
+- [x] [#100](https://github.com/galligan/bb-plugin-studio/issues/100) — landed
+      in PR #110 with bb-owned catalog storage
+- [x] [#101](https://github.com/galligan/bb-plugin-studio/issues/101) — landed
+      in PR #114; removed supervision, private HTTP/auth, and packaged runtime
+- [ ] [#102](https://github.com/galligan/bb-plugin-studio/issues/102) — deferred
+      future proposal; `enrolledHostDiscovery` ships off
 
-Critical path: #98 → (#99 and #100) → #101. #102 can proceed in parallel and
-blocks full enrolled-machine parity, but it does not block removing the child
-runtime for primary-host Studio use.
+The native critical path #98 → (#99 and #100) → #101 is complete. #102 is not
+scheduled for the current Plugin Studio scope and does not block primary-host
+use or sharing.
 
 ### Compatibility and scanner hardening
 
 - [x] [#93](https://github.com/galligan/bb-plugin-studio/issues/93) — minimum
       `0.36.0`, separately tracked verified-through `0.37.0`, and a nonfatal
       newer-than-verified result
-- [ ] [#97](https://github.com/galligan/bb-plugin-studio/issues/97) — ready in
+- [x] [#97](https://github.com/galligan/bb-plugin-studio/issues/97) — landed in
       PR #109 with bounded enumeration and measured pathological-tree proof
 
 Required PR CI uses immutable exact minimum and exact verified-through lanes.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Today bb Plugin Studio can:
 - delegate compatible build and development commands to the native `bb` CLI;
 - explain what is available in Fixture, official SDK Harness, and Live bb modes.
 
+> [!NOTE]
+> Remote projects on enrolled bb machines are not currently supported. Plugin
+> Studio discovers projects only on bb's primary machine.
+
 ## bb, the plugin SDK, and bb Plugin Studio
 
 | Layer                              | What it owns                                                                                                                                            |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,8 +3,9 @@
 The runtime direction is governed by
 [`docs/architecture/runtime-convergence.md`](architecture/runtime-convergence.md):
 Plugin Studio converges onto bb-owned plugin lifecycle and storage, retains the
-native in-process path for primary-host discovery, and requires a new bounded
-public bb capability before enrolled remote-host discovery is enabled.
+native in-process path for primary-host discovery, and ships enrolled remote-host
+discovery behind the default-off `enrolledHostDiscovery` Studio feature flag.
+Remote-only projects are outside the active Studio inventory while it is off.
 
 ## Repository boundary
 

--- a/docs/architecture/runtime-convergence.md
+++ b/docs/architecture/runtime-convergence.md
@@ -21,11 +21,13 @@ The in-process path is authoritative for primary-host discovery after
 [#100](https://github.com/galligan/bb-plugin-studio/issues/100). The child
 runtime source and package were removed under
 [#101](https://github.com/galligan/bb-plugin-studio/issues/101). Enrolled
-remote-host discovery remains
-explicitly unavailable until bb exposes the bounded, host-routed public
-capability tracked in
-[#102](https://github.com/galligan/bb-plugin-studio/issues/102). It does not
-block removing the child runtime for primary-host use.
+remote-host discovery is deferred future scope behind the default-off
+`STUDIO_FEATURE_FLAGS.enrolledHostDiscovery` flag. While disabled, remote-only
+projects are omitted from Studio's active inventory and never make healthy
+primary-host inventory partial. Mixed or ambiguous declarations still fail
+closed. [#102](https://github.com/galligan/bb-plugin-studio/issues/102)
+preserves the bounded public-contract proposal but is not part of the current
+Plugin Studio scope.
 
 While this ADR is active, do not add another private runtime route, capability,
 principal, object kind, packaging obligation, or protocol version. A new
@@ -105,21 +107,21 @@ justify them through public bb contracts.
 
 ## Ownership decision
 
-| Responsibility                                 | Current owner                                                           | Target owner                                                                                                  | Disposition and public contract                                                                                                                |
-| ---------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Project inventory and primary source selection | Studio backend through `project-adapter.ts`                             | Studio backend                                                                                                | `bb.sdk.system.config()` plus `bb.sdk.projects.list/get()` provide the primary host and authorized `local_path` sources.                       |
-| Manifest-only discovery                        | Studio backend using bounded `packages/inspection`                      | Studio backend using `packages/inspection`                                                                    | Moved in-process under #99 after #97 closed the per-directory materialization gap. No plugin entrypoint or build tool is imported or executed. |
-| Enrolled remote-host discovery                 | No safe complete path                                                   | bb host/SDK capability consumed by Studio                                                                     | Blocked on #102. Do not use server-local paths, hidden terminals, unrestricted commands, or `files.listPaths` as a fallback.                   |
-| Development-target catalog                     | `bb.storage.database()` and `bb.storage.migrate()`                      | `bb.storage.database()` and `bb.storage.migrate()`                                                            | Migrated under #100 with durable identity and event semantics. bb owns the plugin database handle, WAL mode, busy timeout, and disposal.       |
-| Generic objects and events                     | None; development-target history lives in the native bb-owned catalog   | None by default                                                                                               | Removed as future-only. Reintroduce product objects behind native bb RPC/storage only as their surfaces ship.                                  |
-| Child supervision and handshake                | None                                                                    | bb plugin loader and `bb.background.service` only where continuous work is real                               | Removed under #101. Refresh work is request-scoped; abort in-flight work from `bb.onDispose`.                                                  |
-| Private HTTP and bearer auth                   | None                                                                    | `bb.rpc` for app calls; `bb.http` only for a real external HTTP use case                                      | Removed. bb's local RPC auth and output validation replace the private target routes. Do not publish an unauthenticated replacement.           |
-| Realtime progress                              | Not currently a live runtime capability                                 | `bb.realtime.publish` if progress becomes necessary                                                           | Delegate to bb; do not add private streaming first.                                                                                            |
-| CLI                                            | Source `bb-plugin-studio` inspection and Fixture commands               | bb native `bb.cli.register` for installed-plugin operations; retain independently useful source commands only | The private `serve` path was removed under #101; source inspection and Fixture commands remain.                                                |
-| Agent tools and skills                         | Capability probes and plugin manifest                                   | `bb.agents.registerTool/configure` plus manifest skills                                                       | Delegate to bb. Do not add an MCP server to compensate for a native tool surface already available.                                            |
-| Browser bootstrap and app communication        | Future capability plus current `bb.rpc` status/refresh                  | bb-hosted plugin app and `bb.rpc`; browser-only Fixture workbench stays independent                           | Remove the private bootstrap concept. Native bb is the Live visual authority; the ordinary browser remains a deterministic Fixture surface.    |
-| Packaging                                      | Studio npm artifact contains the plugin, source CLI, and Fixture assets | Plugin server/app/assets plus independently useful source commands                                            | The executable child runtime, checksum stamp, supervision gates, and associated redistribution work were removed under #101.                   |
-| Lifecycle cleanup                              | Plugin-owned refresh abort/dispose plus bb-owned database handles       | Plugin-owned refresh abort/dispose plus bb-owned database handles                                             | Abort the shared scan controller from `bb.onDispose`; close only resources Plugin Studio itself owns. No child supervision remains.            |
+| Responsibility                                 | Current owner                                                           | Target owner                                                                                                  | Disposition and public contract                                                                                                                                                                                     |
+| ---------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Project inventory and primary source selection | Studio backend through `project-adapter.ts`                             | Studio backend                                                                                                | `bb.sdk.system.config()` plus `bb.sdk.projects.list/get()` provide the primary host and authorized `local_path` sources.                                                                                            |
+| Manifest-only discovery                        | Studio backend using bounded `packages/inspection`                      | Studio backend using `packages/inspection`                                                                    | Moved in-process under #99 after #97 closed the per-directory materialization gap. No plugin entrypoint or build tool is imported or executed.                                                                      |
+| Enrolled remote-host discovery                 | Disabled Studio feature flag                                            | Deferred bb host/SDK capability                                                                               | Default off and outside current scope. Remote-only projects are omitted; mixed declarations fail closed. Never use server-local paths, hidden terminals, unrestricted commands, or `files.listPaths` as a fallback. |
+| Development-target catalog                     | `bb.storage.database()` and `bb.storage.migrate()`                      | `bb.storage.database()` and `bb.storage.migrate()`                                                            | Migrated under #100 with durable identity and event semantics. bb owns the plugin database handle, WAL mode, busy timeout, and disposal.                                                                            |
+| Generic objects and events                     | None; development-target history lives in the native bb-owned catalog   | None by default                                                                                               | Removed as future-only. Reintroduce product objects behind native bb RPC/storage only as their surfaces ship.                                                                                                       |
+| Child supervision and handshake                | None                                                                    | bb plugin loader and `bb.background.service` only where continuous work is real                               | Removed under #101. Refresh work is request-scoped; abort in-flight work from `bb.onDispose`.                                                                                                                       |
+| Private HTTP and bearer auth                   | None                                                                    | `bb.rpc` for app calls; `bb.http` only for a real external HTTP use case                                      | Removed. bb's local RPC auth and output validation replace the private target routes. Do not publish an unauthenticated replacement.                                                                                |
+| Realtime progress                              | Not currently a live runtime capability                                 | `bb.realtime.publish` if progress becomes necessary                                                           | Delegate to bb; do not add private streaming first.                                                                                                                                                                 |
+| CLI                                            | Source `bb-plugin-studio` inspection and Fixture commands               | bb native `bb.cli.register` for installed-plugin operations; retain independently useful source commands only | The private `serve` path was removed under #101; source inspection and Fixture commands remain.                                                                                                                     |
+| Agent tools and skills                         | Capability probes and plugin manifest                                   | `bb.agents.registerTool/configure` plus manifest skills                                                       | Delegate to bb. Do not add an MCP server to compensate for a native tool surface already available.                                                                                                                 |
+| Browser bootstrap and app communication        | Future capability plus current `bb.rpc` status/refresh                  | bb-hosted plugin app and `bb.rpc`; browser-only Fixture workbench stays independent                           | Remove the private bootstrap concept. Native bb is the Live visual authority; the ordinary browser remains a deterministic Fixture surface.                                                                         |
+| Packaging                                      | Studio npm artifact contains the plugin, source CLI, and Fixture assets | Plugin server/app/assets plus independently useful source commands                                            | The executable child runtime, checksum stamp, supervision gates, and associated redistribution work were removed under #101.                                                                                        |
+| Lifecycle cleanup                              | Plugin-owned refresh abort/dispose plus bb-owned database handles       | Plugin-owned refresh abort/dispose plus bb-owned database handles                                             | Abort the shared scan controller from `bb.onDispose`; close only resources Plugin Studio itself owns. No child supervision remains.                                                                                 |
 
 ## Public bb capabilities to reuse
 
@@ -281,7 +283,7 @@ bb responsiveness.
 #98 boundary ADR
   |-- #99 in-process primary-host discovery + shadow parity --\
   |-- #100 bb-owned catalog import + rollback ---------------+--> #101 remove child runtime
-  `-- #102 bounded enrolled-host discovery (parallel; upstream public contract)
+  `-- #102 bounded enrolled-host discovery (deferred; feature flag off)
 
 #97 bounded per-directory enumeration -----> authoritative #99 cutover
 ```
@@ -327,12 +329,15 @@ bb responsiveness.
 - Retain independently useful Fixture/inspect commands only if they no longer
   imply the removed topology.
 
-### Parallel enrolled-host track (#102)
+### Deferred enrolled-host track (#102)
 
-- Agree on and implement the public bounded host operation upstream.
-- Capability-detect it on supported bb versions.
-- Show remote projects as unavailable/unsupported until it is present; never
-  substitute primary-host filesystem access.
+- Ship `STUDIO_FEATURE_FLAGS.enrolledHostDiscovery` as `false`.
+- Omit remote-only projects from the active inventory while the flag is off;
+  mixed or ambiguous declarations remain partial.
+- Do not schedule upstream work as part of the current Plugin Studio scope.
+- If the product later reopens this feature, agree on and implement the public
+  bounded host operation before enabling it. Never substitute primary-host
+  filesystem access.
 
 ## Historical rollback design and current compatibility
 
@@ -365,8 +370,9 @@ decision may remove legacy files; #101 does not silently delete them.
 
 The plugin declares a minimum bb version but accepts newer compatible releases.
 Implementation gates run against both the minimum lane and the current stable
-lane. Capability detection, not an exact version equality check, controls the
-optional #102 remote-host path. A newer bb version must not be rejected merely
+lane. The enrolled-host feature remains off regardless of bb version; a future
+implementation would capability-detect its bounded host contract rather than
+use exact version equality. A newer bb version must not be rejected merely
 because it is newer.
 
 ## Acceptance evidence
@@ -412,7 +418,8 @@ state without waiting for an upstream remote filesystem contract.
 
 The tradeoff is that discovery work now shares bb's process, so bounded work
 and cancellation become hard safety requirements rather than defense in depth.
-Remote enrolled-host parity remains incomplete until #102 lands. Future
-sessions, annotations, captures, comparisons, briefs, reviews, or MCP work must
-choose native bb surfaces when those product slices are actually implemented;
-the dormant generic runtime schema is not carried forward automatically.
+Remote enrolled-host parity is deliberately outside the current product scope
+and its feature flag remains off. Future sessions, annotations, captures,
+comparisons, briefs, reviews, or MCP work must choose native bb surfaces when
+those product slices are actually implemented; the dormant generic runtime
+schema is not carried forward automatically.

--- a/plugins/studio/src/backend/plugin.test.ts
+++ b/plugins/studio/src/backend/plugin.test.ts
@@ -248,10 +248,13 @@ describe("Plugin Studio in-process backend v4", () => {
   });
 
   test("never sends enrolled, mixed, or ambiguous paths to discovery", async () => {
-    for (const sources of [
-      [source({ hostId: "enrolled-host" })],
-      [source(), source({ id: "source-2", hostId: "enrolled-host" })],
-      [source(), source({ id: "source-2" })],
+    for (const [sources, expectedState] of [
+      [[source({ hostId: "enrolled-host" })], "ready"],
+      [
+        [source(), source({ id: "source-2", hostId: "enrolled-host" })],
+        "partial",
+      ],
+      [[source(), source({ id: "source-2" })], "partial"],
     ]) {
       let called = false;
       let scannedPaths: string[] = [];
@@ -266,6 +269,7 @@ describe("Plugin Studio in-process backend v4", () => {
       const result = await host.handlers().refresh();
       expect(called).toBe(true);
       expect(scannedPaths).toEqual([]);
+      expect(result).toMatchObject({ projects: { state: expectedState } });
       expect(JSON.stringify(result)).not.toContain("enrolled-host");
     }
   });

--- a/plugins/studio/src/backend/project-adapter.test.ts
+++ b/plugins/studio/src/backend/project-adapter.test.ts
@@ -9,6 +9,7 @@ import {
   listProjectOptions,
   resolveProjectSource,
 } from "./project-adapter.ts";
+import { STUDIO_FEATURE_FLAGS } from "./studio-feature-flags.ts";
 
 const source = (overrides: Record<string, unknown> = {}) => ({
   id: "source-1",
@@ -54,6 +55,32 @@ function sdk(projects = [project()], primaryHostId: string | null = "host-1") {
 }
 
 describe("released bb project adapter", () => {
+  test("ships enrolled-host discovery disabled and omits remote-only projects", async () => {
+    expect(STUDIO_FEATURE_FLAGS.enrolledHostDiscovery).toBe(false);
+
+    const inventory = await loadProjectInventory(
+      sdk([
+        project({
+          sources: [source({ hostId: "enrolled-host" })],
+        }),
+      ]),
+    );
+
+    expect(inventory).toMatchObject({
+      state: "ready",
+      inventoryState: "complete",
+      catalog: { state: "ready", truncated: false, items: [] },
+      sources: [],
+    });
+    expect(JSON.stringify(inventory)).not.toContain("enrolled-host");
+    await expect(
+      resolveProjectSource(
+        sdk([project({ sources: [source({ hostId: "enrolled-host" })] })]),
+        "project-1",
+      ),
+    ).rejects.toThrow("Project source unavailable");
+  });
+
   test("returns path-free rows beside server-private source identities", async () => {
     const inventory = await loadProjectInventory(sdk());
     expect(inventory.catalog.items).toEqual([
@@ -155,11 +182,10 @@ describe("released bb project adapter", () => {
     });
   });
 
-  test("fails closed for zero, foreign-project, foreign-host, or multiple matching sources", async () => {
+  test("fails closed for zero, foreign-project, malformed, or ambiguous sources", async () => {
     const variants = [
       [],
       [source({ projectId: "other" })],
-      [source({ hostId: "host-2" })],
       [source(), source({ id: "source-2" })],
       [source(), source({ id: "source-2", hostId: "host-2" })],
       [source({ path: "../relative" })],

--- a/plugins/studio/src/backend/project-adapter.ts
+++ b/plugins/studio/src/backend/project-adapter.ts
@@ -11,6 +11,10 @@ import {
   projectOptionSchema,
   type ProjectCatalog,
 } from "./workbench-contract.ts";
+import {
+  STUDIO_FEATURE_FLAGS,
+  type StudioFeatureFlags,
+} from "./studio-feature-flags.ts";
 
 interface ProjectSourceLike {
   readonly id?: unknown;
@@ -117,6 +121,23 @@ function sourceFor(project: ProjectLike, primaryHostId: string | null) {
     : null;
 }
 
+function isDisabledEnrolledHostProject(
+  project: ProjectLike,
+  primaryHostId: string,
+  featureFlags: StudioFeatureFlags,
+) {
+  if (featureFlags.enrolledHostDiscovery || project.sources.length !== 1) {
+    return false;
+  }
+  const source = project.sources[0]!;
+  return (
+    source.type === "local_path" &&
+    source.projectId === project.id &&
+    typeof source.hostId === "string" &&
+    source.hostId !== primaryHostId
+  );
+}
+
 export async function listProjectOptions(
   sdk: ReleasedProjectSdk,
 ): Promise<ProjectCatalog> {
@@ -125,6 +146,7 @@ export async function listProjectOptions(
 
 export async function loadProjectInventory(
   sdk: ReleasedProjectSdk,
+  featureFlags: StudioFeatureFlags = STUDIO_FEATURE_FLAGS,
 ): Promise<ProjectInventory> {
   try {
     const [{ primaryHostId, dataDir }, projects] = await Promise.all([
@@ -135,6 +157,7 @@ export async function loadProjectInventory(
     const hasUnscannableProjects = projects.some(
       (project) =>
         projectIdSchema.safeParse(project.id).success &&
+        !isDisabledEnrolledHostProject(project, primaryHostId, featureFlags) &&
         sourceFor(project, primaryHostId) === null,
     );
     const eligible = projects

--- a/plugins/studio/src/backend/studio-feature-flags.ts
+++ b/plugins/studio/src/backend/studio-feature-flags.ts
@@ -1,0 +1,15 @@
+export interface StudioFeatureFlags {
+  readonly enrolledHostDiscovery: boolean;
+}
+
+/**
+ * Product-scope switches owned by Plugin Studio.
+ *
+ * Enrolled-host discovery stays off until Studio can consume a bounded public
+ * bb host API. Turning the flag on only brings remote projects into the
+ * inventory contract; it must never make their paths eligible for the local
+ * filesystem scanner.
+ */
+export const STUDIO_FEATURE_FLAGS: StudioFeatureFlags = Object.freeze({
+  enrolledHostDiscovery: false,
+});

--- a/scripts/source-preview-docs.test.ts
+++ b/scripts/source-preview-docs.test.ts
@@ -32,6 +32,9 @@ describe("bb Plugin Studio source preview documentation", () => {
     expect(readme).not.toContain("img.shields.io/npm/v/bb-plugin-studio");
     expect(readme).toContain("## Try the source preview");
     expect(readme).toContain("[Source preview guide](docs/source-preview.md)");
+    expect(readme).toContain(
+      "Remote projects on enrolled bb machines are not currently supported.",
+    );
 
     expect(preview).toContain(
       "git clone https://github.com/galligan/bb-plugin-studio.git\ncd bb-plugin-studio",


### PR DESCRIPTION
## Context

Enrolled-host discovery is outside the current Plugin Studio scope. The existing primary-host scanner must remain authoritative without treating remote-only projects as an incomplete local inventory.

## What changed

- adds one explicit `enrolledHostDiscovery` Studio feature flag, defaulting to `false`
- omits remote-only projects while disabled so healthy primary-host inventory remains ready
- keeps mixed, multiple, malformed, and ambiguous source declarations fail-closed and partial
- retains the hard boundary that enrolled paths never enter filesystem discovery or public responses
- reconciles the runtime ADR and convergence plan with the landed native stack and deferred #102 scope

## Verification

- focused Studio backend: 15 tests / 81 assertions
- full workspace and scripts unit suites green
- full check and bb 0.37 compatibility green
- Studio build, Prettier, and diff checks green

## Boundary

No upstream bb work, browser behavior, package publication, or primary-host scanner changes. Refs #102.